### PR TITLE
Allow connection encryption from start

### DIFF
--- a/src/client/QXmppConfiguration.cpp
+++ b/src/client/QXmppConfiguration.cpp
@@ -66,6 +66,8 @@ public:
     bool useNonSASLAuthentication;
     // default is true
     bool ignoreSslErrors;
+    // default is false
+    bool encryptOnConnect;
 
     QXmppConfiguration::StreamSecurityMode streamSecurityMode;
     QXmppConfiguration::NonSASLAuthMechanism nonSASLAuthMechanism;
@@ -88,6 +90,7 @@ QXmppConfigurationPrivate::QXmppConfigurationPrivate()
     , useSASLAuthentication(true)
     , useNonSASLAuthentication(true)
     , ignoreSslErrors(true)
+    , encryptOnConnect(false)
     , streamSecurityMode(QXmppConfiguration::TLSEnabled)
     , nonSASLAuthMechanism(QXmppConfiguration::NonSASLDigest)
     , saslAuthMechanism("DIGEST-MD5")
@@ -430,6 +433,29 @@ bool QXmppConfiguration::ignoreSslErrors() const
 void QXmppConfiguration::setIgnoreSslErrors(bool value)
 {
     d->ignoreSslErrors = value;
+}
+
+/// Returns whether the connection should be encrypted immediately after it
+/// is established.
+///
+/// \return boolean value
+/// true means use QSslSocket::startClientEncryption will be called right
+/// after connecting.
+
+bool QXmppConfiguration::startEncryptionOnConnect() const
+{
+    return d->encryptOnConnect;
+}
+
+/// Specifies whether the connection should be encrypted aimmediately after it
+/// is established.
+///
+/// When true, will call QSslSocket::startClientEncryption right after
+/// connecting.
+
+void QXmppConfiguration::setStartEncryptionOnConnect(bool value)
+{
+    d->encryptOnConnect = value;
 }
 
 /// Returns whether to make use of SASL authentication.

--- a/src/client/QXmppConfiguration.h
+++ b/src/client/QXmppConfiguration.h
@@ -128,6 +128,9 @@ public:
     bool ignoreSslErrors() const;
     void setIgnoreSslErrors(bool);
 
+    bool startEncryptionOnConnect() const;
+    void setStartEncryptionOnConnect(bool);
+
     QXmppConfiguration::StreamSecurityMode streamSecurityMode() const;
     void setStreamSecurityMode(QXmppConfiguration::StreamSecurityMode mode);
 

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -130,6 +130,9 @@ void QXmppOutgoingClientPrivate::connectToHost(const QString &host, quint16 port
 
     // connect to host
     q->socket()->connectToHost(host, port);
+    if (config.startEncryptionOnConnect()) {
+        q->socket()->startClientEncryption();
+    }
 }
 
 /// Constructs an outgoing client stream.


### PR DESCRIPTION
With a new client configuration parameter.

When trying to use the library to connect to Google Messaging Cloud service, I got all my connections dropped until I used `startClientEncryption` on the socket right after connecting.

I've added an option to the config object to make this happen.
