### PR TITLE
Set local TLS certificate and private key as QSslCertificate and QSslKey

### DIFF
--- a/src/server/QXmppServer.cpp
+++ b/src/server/QXmppServer.cpp
@@ -482,6 +482,19 @@ void QXmppServer::setLocalCertificate(const QString &path)
         server->setLocalCertificate(d->localCertificate);
 }
 
+/// Sets the local SSL certificate
+///
+/// \param certificate
+
+void QXmppServer::setLocalCertificate(const QSslCertificate &certificate)
+{
+    d->localCertificate = certificate;
+
+    // reconfigure servers
+    foreach (QXmppSslServer *server, d->serversForClients + d->serversForServers)
+        server->setLocalCertificate(d->localCertificate);
+}
+
 /// Sets the path for the local SSL private key.
 ///
 /// \param path
@@ -499,6 +512,19 @@ void QXmppServer::setPrivateKey(const QString &path)
         d->warning(QString("SSL key is not readable %1").arg(path));
         d->privateKey = QSslKey();
     }
+
+    // reconfigure servers
+    foreach (QXmppSslServer *server, d->serversForClients + d->serversForServers)
+        server->setPrivateKey(d->privateKey);
+}
+
+/// Sets the local SSL private key.
+///
+/// \param key
+
+void QXmppServer::setPrivateKey(const QSslKey &key)
+{
+    d->privateKey = key;
 
     // reconfigure servers
     foreach (QXmppSslServer *server, d->serversForClients + d->serversForServers)

--- a/src/server/QXmppServer.h
+++ b/src/server/QXmppServer.h
@@ -81,7 +81,9 @@ public:
 
     void addCaCertificates(const QString &caCertificates);
     void setLocalCertificate(const QString &path);
+    void setLocalCertificate(const QSslCertificate &certificate);
     void setPrivateKey(const QString &path);
+    void setPrivateKey(const QSslKey &key);
 
     void close();
     bool listenForClients(const QHostAddress &address = QHostAddress::Any, quint16 port = 5222);


### PR DESCRIPTION
I've added the possibility to set the local TLS certificate and private key as QSslCertificate and QSslKey objects.
This makes it possible to use encryped private keys, DER encoded certificates and detect problems with the certificate.