### PR TITLE
QXmppTransferManager: Fixed device management

### DIFF
--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -1307,7 +1307,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, const QStri
     fileInfo.setDescription(description);
 
     // open file
-    QIODevice *device = new QFile(filePath);
+    QIODevice *device = new QFile(filePath, this);
     if (!device->open(QIODevice::ReadOnly))
     {
         warning(QString("Could not read from %1").arg(filePath));
@@ -1342,6 +1342,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, const QStri
 /// Returns 0 if the \a jid is not valid.
 ///
 /// \note The recipient's \a jid must be a full JID with a resource, for instance "user@host/resource".
+/// \note The ownership of the \a device should be managed by the caller.
 ///
 
 QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, QIODevice *device, const QXmppTransferFileInfo &fileInfo, const QString &sid)
@@ -1361,8 +1362,6 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, QIODevice *
         job->d->sid = sid;
     job->d->fileInfo = fileInfo;
     job->d->iodevice = device;
-    if (device)
-        device->setParent(job);
 
     // check file is open
     if (!device || !device->isReadable())

--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -204,6 +204,7 @@ public:
     QString requestId;
     QXmppTransferJob::State state;
     QTime transferStart;
+    bool deviceIsOwn;
 
     // file meta-data
     QXmppTransferFileInfo fileInfo;
@@ -225,6 +226,7 @@ QXmppTransferJobPrivate::QXmppTransferJobPrivate()
     iodevice(0),
     method(QXmppTransferJob::NoMethod),
     state(QXmppTransferJob::OfferState),
+    deviceIsOwn(false),
     ibbSequence(0),
     socksSocket(0)
 {
@@ -426,7 +428,7 @@ void QXmppTransferJob::terminate(QXmppTransferJob::Error cause)
     d->state = FinishedState;
 
     // close IO device
-    if (d->iodevice)
+    if (d->iodevice && d->deviceIsOwn)
         d->iodevice->close();
 
     // close socket
@@ -1332,6 +1334,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, const QStri
     // create job
     QXmppTransferJob *job = sendFile(jid, device, fileInfo);
     job->setLocalFileUrl(QUrl::fromLocalFile(filePath));
+    job->d->deviceIsOwn = true;
     return job;
 }
 


### PR DESCRIPTION
Prevent device reparenting and close the dev only if we opened it.

sendFile() method expects the device to be opened, but
QXmppTransferJob::terminate() closes the dev unconditionaly, which
breaks reusable QIODevice workflow.

E.g. current code closes an input-output buffer after transfer,
before the data from buffer read.

Device parent setup also cause the device deletion, which is not
expected in some cases.

This issue affects https://github.com/TelepathyQt/telepathy-nonsense project, which uses the same device to read/write file content from/to xmpp and to write/read the content to/from TelepathyQt FileTransfer interface.

I understand that this can lead to memory-leak, if a device, passed to QXmpp is allocated on heap, have no parent and not deleted manually, but I'm sure that this is the right thing to do. (Better, than to close and delete passed device)
We should close and delete only device, which we constructed and opened.