### PR TITLE
File transfer: Make sure the filename is being converted to a QUrl correctly

### DIFF
--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -1331,7 +1331,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, const QStri
 
     // create job
     QXmppTransferJob *job = sendFile(jid, device, fileInfo);
-    job->setLocalFileUrl(filePath);
+    job->setLocalFileUrl(QUrl::fromLocalFile(filePath));
     return job;
 }
 

--- a/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
+++ b/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
@@ -148,6 +148,7 @@ void tst_QXmppTransferManager::testSendFile()
     QEventLoop loop;
     QXmppTransferJob *senderJob = senderManager->sendFile("receiver@localhost/QXmpp", ":/test.svg");
     QVERIFY(senderJob);
+    QCOMPARE(senderJob->localFileUrl().toLocalFile(), QString(":/test.svg"));
     connect(senderJob, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
 

--- a/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
+++ b/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
@@ -148,7 +148,7 @@ void tst_QXmppTransferManager::testSendFile()
     QEventLoop loop;
     QXmppTransferJob *senderJob = senderManager->sendFile("receiver@localhost/QXmpp", ":/test.svg");
     QVERIFY(senderJob);
-    QCOMPARE(senderJob->localFileUrl().toLocalFile(), QString(":/test.svg"));
+    QCOMPARE(senderJob->localFileUrl(), QUrl::fromLocalFile(":/test.svg"));
     connect(senderJob, SIGNAL(finished()), &loop, SLOT(quit()));
     loop.exec();
 


### PR DESCRIPTION
As it is already done in the QXmppTransferJob::accept method, QXmppTransferManager::sendFile should also convert the local file path to a QUrl using the QUrl::fromLocalFile method.