### PR TITLE
Added a qmake CONFIG feature file

### DIFF
--- a/qxmpp.prf
+++ b/qxmpp.prf
@@ -1,0 +1,46 @@
+QXMPP_INCDIR = $$[QT_INSTALL_HEADERS]
+QXMPP_LIBDIR = $$[QT_INSTALL_LIBS]
+
+## Distributions can adjust this for Qt 4
+QXMPP_INCDIR ~= s!/qt5*!!
+QXMPP_LIBDIR ~= s!/qt5*!!
+
+CONFIG *= qt
+
+
+# if we are including qxmpp.prf from the qxmpp tree (and not utilizing it as
+# an installed qmake CONFIG feature), then point to the tree.  this allows our
+# qxmpp tree apps to build before qxmpp itself is installed.
+exists($$PWD/qxmpp.pro) {
+    ## Jan // I doubt this is needed for QXMPP
+    QXMPP_INCDIR = $$PWD/include
+    QXMPP_LIBDIR = $$PWD/lib
+}
+
+LINKAGE =
+
+# on mac, if qxmpp was built as a framework, link against it
+mac: {
+    ## Jan // No idea about any of this Mac stuff
+    framework_dir = $${QXMPP_LIBDIR}
+    exists($$framework_dir/qxmpp.framework) {
+        LIBS += -F$$framework_dir
+        exists($$PWD/qxmpp.pro): INCLUDEPATH += $$QXMPP_INCDIR
+        else: INCLUDEPATH += $$framework_dir/qxmpp.framework/Headers
+        LINKAGE = -framework qxmpp
+    }
+}
+
+# else, link normally
+isEmpty(LINKAGE) {
+    exists($$PWD/qxmpp.pro): INCLUDEPATH += $$QXMPP_INCDIR
+    else: INCLUDEPATH += $$QXMPP_INCDIR/qxmpp  ## Jan // This is probably the usual case
+    LIBS += -L$$QXMPP_LIBDIR
+    LINKAGE = -lqxmpp     ## Jan // Distributions might tune this with -lqxmpp_qt5, etc.
+    CONFIG(debug, debug|release) {
+        windows:LINKAGE = -lqxmppd
+        mac:LINKAGE = -lqxmpp_debug
+    }
+}
+
+LIBS += $$LINKAGE


### PR DESCRIPTION
.prf file provided as requested in https://github.com/qxmpp-project/qxmpp/issues/100

It's a rough adaptation of the feature file provided by the QtOAuth library. There are things I don't really understand, and conditionals for platforms I don't use, but it can be used as a starting point.

It will certainly make life easier (and safer) for people creating qmake-based projects which link to QXMPP, especially considering how some distributions might provide both Qt4 and Qt5 builds of QXMPP with different sonames and such.

I've tested it on my system, by copying the new file to /usr/lib/qt{4|5}/mkspecs/features/ and using "CONFIG += qxmpp" on my .pro file, and it works as expected.

Cheers!