### PR TITLE
allow to compile with a namespaced installation of Qt

### DIFF
--- a/examples/example_3_transferHandling/example_3_transferHandling.h
+++ b/examples/example_3_transferHandling/example_3_transferHandling.h
@@ -28,8 +28,6 @@
 #include "QXmppClient.h"
 #include "QXmppTransferManager.h"
 
-class QBuffer;
-
 class xmppClient : public QXmppClient
 {
     Q_OBJECT

--- a/src/base/QXmppElement.h
+++ b/src/base/QXmppElement.h
@@ -30,7 +30,7 @@
 
 #include "QXmppGlobal.h"
 
-class QDomElement;
+QT_FORWARD_DECLARE_CLASS(QDomElement)
 class QXmppElement;
 class QXmppElementPrivate;
 

--- a/src/base/QXmppSocks.h
+++ b/src/base/QXmppSocks.h
@@ -29,7 +29,7 @@
 
 #include "QXmppGlobal.h"
 
-class QTcpServer;
+QT_FORWARD_DECLARE_CLASS(QTcpServer)
 
 class QXMPP_EXPORT QXmppSocksClient : public QTcpSocket
 {

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -30,8 +30,8 @@
 #include <QObject>
 #include "QXmppLogger.h"
 
-class QDomElement;
-class QSslSocket;
+QT_FORWARD_DECLARE_CLASS(QDomElement)
+QT_FORWARD_DECLARE_CLASS(QSslSocket)
 class QXmppStanza;
 class QXmppStreamPrivate;
 

--- a/src/base/QXmppStun.h
+++ b/src/base/QXmppStun.h
@@ -30,9 +30,9 @@
 #include "QXmppJingleIq.h"
 
 class CandidatePair;
-class QDataStream;
-class QUdpSocket;
-class QTimer;
+QT_FORWARD_DECLARE_CLASS(QDataStream)
+QT_FORWARD_DECLARE_CLASS(QUdpSocket)
+QT_FORWARD_DECLARE_CLASS(QTimer)
 class QXmppIceComponentPrivate;
 class QXmppIceConnectionPrivate;
 class QXmppIcePrivate;

--- a/src/base/QXmppStun_p.h
+++ b/src/base/QXmppStun_p.h
@@ -26,8 +26,8 @@
 
 #include "QXmppStun.h"
 
-class QUdpSocket;
-class QTimer;
+QT_FORWARD_DECLARE_CLASS(QUdpSocket)
+QT_FORWARD_DECLARE_CLASS(QTimer)
 
 //
 //  W A R N I N G

--- a/src/base/QXmppUtils.h
+++ b/src/base/QXmppUtils.h
@@ -34,11 +34,11 @@
 
 #include "QXmppGlobal.h"
 
-class QByteArray;
-class QDateTime;
-class QDomElement;
-class QString;
-class QStringList;
+QT_FORWARD_DECLARE_CLASS(QByteArray)
+QT_FORWARD_DECLARE_CLASS(QDateTime)
+QT_FORWARD_DECLARE_CLASS(QDomElement)
+QT_FORWARD_DECLARE_CLASS(QString)
+QT_FORWARD_DECLARE_CLASS(QStringList)
 
 /// \brief The QXmppUtils class contains static utility functions.
 ///

--- a/src/base/qdnslookup.h
+++ b/src/base/qdnslookup.h
@@ -56,13 +56,13 @@ QT_BEGIN_NAMESPACE
 
 QT_MODULE(Network)
 
-class QHostAddress;
-class QDnsLookupPrivate;
-class QDnsDomainNameRecordPrivate;
-class QDnsHostAddressRecordPrivate;
-class QDnsMailExchangeRecordPrivate;
-class QDnsServiceRecordPrivate;
-class QDnsTextRecordPrivate;
+QT_FORWARD_DECLARE_CLASS(QHostAddress)
+QT_FORWARD_DECLARE_CLASS(QDnsLookupPrivate)
+QT_FORWARD_DECLARE_CLASS(QDnsDomainNameRecordPrivate)
+QT_FORWARD_DECLARE_CLASS(QDnsHostAddressRecordPrivate)
+QT_FORWARD_DECLARE_CLASS(QDnsMailExchangeRecordPrivate)
+QT_FORWARD_DECLARE_CLASS(QDnsServiceRecordPrivate)
+QT_FORWARD_DECLARE_CLASS(QDnsTextRecordPrivate)
 
 class QXMPP_EXPORT QDnsDomainNameRecord
 {

--- a/src/base/qdnslookup_p.h
+++ b/src/base/qdnslookup_p.h
@@ -66,7 +66,7 @@ QT_BEGIN_NAMESPACE
 
 //#define QDNSLOOKUP_DEBUG
 
-class QDnsLookupRunnable;
+QT_FORWARD_DECLARE_CLASS(QDnsLookupRunnable)
 
 class QDnsLookupReply
 {

--- a/src/client/QXmppCallManager.h
+++ b/src/client/QXmppCallManager.h
@@ -31,7 +31,7 @@
 #include "QXmppClientExtension.h"
 #include "QXmppLogger.h"
 
-class QHostAddress;
+QT_FORWARD_DECLARE_CLASS(QHostAddress)
 class QXmppCallPrivate;
 class QXmppCallManager;
 class QXmppCallManagerPrivate;

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -31,7 +31,7 @@
 #include "QXmppLogger.h"
 #include "QXmppPresence.h"
 
-class QSslError;
+QT_FORWARD_DECLARE_CLASS(QSslError)
 
 class QXmppClientExtension;
 class QXmppClientPrivate;

--- a/src/client/QXmppClientExtension.h
+++ b/src/client/QXmppClientExtension.h
@@ -27,8 +27,8 @@
 #include "QXmppDiscoveryIq.h"
 #include "QXmppLogger.h"
 
-class QDomElement;
-class QStringList;
+QT_FORWARD_DECLARE_CLASS(QDomElement)
+QT_FORWARD_DECLARE_CLASS(QStringList)
 
 class QXmppClient;
 class QXmppClientExtensionPrivate;

--- a/src/client/QXmppConfiguration.h
+++ b/src/client/QXmppConfiguration.h
@@ -30,8 +30,8 @@
 
 #include "QXmppGlobal.h"
 
-class QNetworkProxy;
-class QSslCertificate;
+QT_FORWARD_DECLARE_CLASS(QNetworkProxy)
+QT_FORWARD_DECLARE_CLASS(QSslCertificate)
 class QXmppConfigurationPrivate;
 
 /// \brief The QXmppConfiguration class holds configuration options.

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -30,8 +30,8 @@
 #include "QXmppStanza.h"
 #include "QXmppStream.h"
 
-class QDomElement;
-class QSslError;
+QT_FORWARD_DECLARE_CLASS(QDomElement)
+QT_FORWARD_DECLARE_CLASS(QSslError)
 
 class QXmppConfiguration;
 class QXmppPresence;

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -31,7 +31,7 @@
 
 #include "QXmppClientExtension.h"
 
-class QTcpSocket;
+QT_FORWARD_DECLARE_CLASS(QTcpSocket)
 class QXmppByteStreamIq;
 class QXmppIbbCloseIq;
 class QXmppIbbDataIq;

--- a/src/client/QXmppTransferManager_p.h
+++ b/src/client/QXmppTransferManager_p.h
@@ -38,7 +38,7 @@
 // We mean it.
 //
 
-class QTimer;
+QT_FORWARD_DECLARE_CLASS(QTimer)
 class QXmppSocksClient;
 
 class QXmppTransferIncomingJob : public QXmppTransferJob

--- a/src/server/QXmppOutgoingServer.h
+++ b/src/server/QXmppOutgoingServer.h
@@ -28,7 +28,7 @@
 
 #include "QXmppStream.h"
 
-class QSslError;
+QT_FORWARD_DECLARE_CLASS(QSslError)
 class QXmppDialback;
 class QXmppOutgoingServer;
 class QXmppOutgoingServerPrivate;

--- a/src/server/QXmppServer.h
+++ b/src/server/QXmppServer.h
@@ -29,10 +29,10 @@
 
 #include "QXmppLogger.h"
 
-class QDomElement;
-class QSslCertificate;
-class QSslKey;
-class QSslSocket;
+QT_FORWARD_DECLARE_CLASS(QDomElement)
+QT_FORWARD_DECLARE_CLASS(QSslCertificate)
+QT_FORWARD_DECLARE_CLASS(QSslKey)
+QT_FORWARD_DECLARE_CLASS(QSslSocket)
 
 class QXmppDialback;
 class QXmppIncomingClient;

--- a/src/server/QXmppServerExtension.h
+++ b/src/server/QXmppServerExtension.h
@@ -28,8 +28,8 @@
 
 #include "QXmppLogger.h"
 
-class QDomElement;
-class QStringList;
+QT_FORWARD_DECLARE_CLASS(QDomElement)
+QT_FORWARD_DECLARE_CLASS(QStringList)
 
 class QXmppServer;
 class QXmppServerExtensionPrivate;

--- a/src/server/QXmppServerPlugin.h
+++ b/src/server/QXmppServerPlugin.h
@@ -41,7 +41,9 @@ public:
     virtual QStringList keys() const = 0;
 };
 
+QT_BEGIN_NAMESPACE
 Q_DECLARE_INTERFACE(QXmppServerPluginInterface, "com.googlecode.qxmpp.ServerPlugin/1.0")
+QT_END_NAMESPACE
 
 /// \brief The QXmppServerPlugin class is the base class for QXmppServer plugins.
 ///


### PR DESCRIPTION
This patch allows to compile the code with a Qt installation, which has been compiled with a namespace (Qt configure called with -qtnamespace XXX -qtlibinfix XXX),
which is needed when an application itself delivers the qt libs so that they do not conflict with the system installed ones (as our commercial product does).

By using the Qt macro QT_FORWARD_DECLARE_CLASS one can compile the same code with or without Qt being namespaced.
