### PR TITLE
In Stanza error make to/from string methods public

### DIFF
--- a/src/base/QXmppStanza.h
+++ b/src/base/QXmppStanza.h
@@ -149,13 +149,13 @@ public:
         void toXml(QXmlStreamWriter *writer) const;
         /// \endcond
 
-    private:
         QString getConditionStr() const;
         void setConditionFromStr(const QString& cond);
 
         QString getTypeStr() const;
         void setTypeFromStr(const QString& type);
 
+    private:
         int m_code;
         Type m_type;
         Condition m_condition;

--- a/src/client/QXmppMucManager.cpp
+++ b/src/client/QXmppMucManager.cpp
@@ -136,8 +136,10 @@ bool QXmppMucManager::handleStanza(const QDomElement &element)
 
             QXmppMucRoom *room = d->rooms.value(iq.from());
             if (room && iq.type() == QXmppIq::Result && !iq.form().isNull())
+            {
                 emit room->configurationReceived(iq.form());
-            return true;
+                return true;
+            }
         }
     }
     return false;


### PR DESCRIPTION
I'm integrating XMPP into a scripting language. In this context it is useful to have the stanza error type and condition as strings, therefore this patch makes the existing methods public.