### PR TITLE
QT_NO_KEYWORDS patch

### DIFF
--- a/examples/GuiClient/capabilitiesCache.h
+++ b/examples/GuiClient/capabilitiesCache.h
@@ -47,9 +47,9 @@ public:
     QStringList getFeatures(const QString& nodeVer);
     QStringList getIdentities(const QString& nodeVer);
 
-signals:
+Q_SIGNALS:
 
-private slots:
+private Q_SLOTS:
     void infoReceived(const QXmppDiscoveryIq&);
 
 private:

--- a/examples/GuiClient/chatDialog.h
+++ b/examples/GuiClient/chatDialog.h
@@ -53,7 +53,7 @@ public:
     void setQXmppClient(QXmppClient* client);
     void messageReceived(const QString& msg);
 
-private slots:
+private Q_SLOTS:
     void sendMessage();
 
 protected:

--- a/examples/GuiClient/mainDialog.h
+++ b/examples/GuiClient/mainDialog.h
@@ -60,7 +60,7 @@ protected:
     void keyPressEvent(QKeyEvent*);
     void closeEvent(QCloseEvent* event);
 
-private slots:
+private Q_SLOTS:
     void rosterChanged(const QString& bareJid);
     void rosterReceived();
     void presenceChanged(const QString&, const QString&);

--- a/examples/GuiClient/profileDialog.h
+++ b/examples/GuiClient/profileDialog.h
@@ -51,7 +51,7 @@ public:
     void setFullName(const QString&);
     void setStatusText(const QString&);
 
-private slots:
+private Q_SLOTS:
     void versionReceived(const QXmppVersionIq&);
     void timeReceived(const QXmppEntityTimeIq&);
 

--- a/examples/GuiClient/rosterItemSortFilterProxyModel.h
+++ b/examples/GuiClient/rosterItemSortFilterProxyModel.h
@@ -34,7 +34,7 @@ class rosterItemSortFilterProxyModel : public QSortFilterProxyModel
 public:
     rosterItemSortFilterProxyModel(QObject* parent = 0);
 
-public slots:
+public Q_SLOTS:
     void setShowOfflineContacts(bool);
     void sortByName(bool);
 

--- a/examples/GuiClient/rosterListView.cpp
+++ b/examples/GuiClient/rosterListView.cpp
@@ -101,14 +101,14 @@ void rosterListView::showChatDialog_helper()
 {
     QString bareJid = selectedBareJid();
     if(!bareJid.isEmpty())
-        emit showChatDialog(bareJid);
+        Q_EMIT showChatDialog(bareJid);
 }
 
 void rosterListView::showProfile_helper()
 {
     QString bareJid = selectedBareJid();
     if(!bareJid.isEmpty())
-        emit showProfile(bareJid);
+        Q_EMIT showProfile(bareJid);
 }
 
 void rosterListView::keyPressEvent(QKeyEvent* event1)
@@ -124,5 +124,5 @@ void rosterListView::removeContact_helper()
 {
     QString bareJid = selectedBareJid();
     if(!bareJid.isEmpty())
-        emit removeContact(bareJid);
+        Q_EMIT removeContact(bareJid);
 }

--- a/examples/GuiClient/rosterListView.h
+++ b/examples/GuiClient/rosterListView.h
@@ -36,12 +36,12 @@ public:
     rosterListView(QWidget* parent = 0);
     bool event(QEvent* e);
 
-public slots:
+public Q_SLOTS:
     void mousePressed(const QModelIndex& index);
     void doubleClicked(const QModelIndex& index);
     void clicked(const QModelIndex& index);
 
-private slots:
+private Q_SLOTS:
     void showChatDialog_helper();
     void showProfile_helper();
     void removeContact_helper();
@@ -49,7 +49,7 @@ private slots:
 protected:
     void keyPressEvent(QKeyEvent*);
 
-signals:
+Q_SIGNALS:
     void showChatDialog(const QString& bareJid);
     void showProfile(const QString& bareJid);
     void removeContact(const QString& bareJid);

--- a/examples/GuiClient/signInStatusLabel.h
+++ b/examples/GuiClient/signInStatusLabel.h
@@ -46,7 +46,7 @@ public:
 
 //    QSize sizeHint() const;
 
-private slots:
+private Q_SLOTS:
     void timeout();
 
 private:

--- a/examples/GuiClient/statusTextWidget.cpp
+++ b/examples/GuiClient/statusTextWidget.cpp
@@ -122,7 +122,7 @@ void statusTextWidget::textChanged()
 void statusTextWidget::statusTextChanged_helper()
 {
     addStatusTextToList(m_statusLineEdit->text());
-    emit statusTextChanged(m_statusLineEdit->text());
+    Q_EMIT statusTextChanged(m_statusLineEdit->text());
     parentWidget()->setFocus();
 }
 
@@ -168,11 +168,11 @@ void statusTextWidget::statusTextChanged_menuClick()
             m_statusTextActionList.append(action);
         }
         m_statusLineEdit->setText(action->data().toString());
-        emit statusTextChanged(action->data().toString());
+        Q_EMIT statusTextChanged(action->data().toString());
     }
 }
 
 void statusTextWidget::clearStatusTextHistory()
 {
-    emit statusTextChanged("");
+    Q_EMIT statusTextChanged("");
 }

--- a/examples/GuiClient/statusTextWidget.h
+++ b/examples/GuiClient/statusTextWidget.h
@@ -111,16 +111,16 @@ public:
     statusTextWidget(QWidget* parent = 0);
     void setStatusText(const QString& statusText);
 
-public slots:
+public Q_SLOTS:
     void showMenu();
     void textChanged();
 
-private slots:
+private Q_SLOTS:
     void statusTextChanged_helper();
     void statusTextChanged_menuClick();
     void clearStatusTextHistory();
 
-signals:
+Q_SIGNALS:
     void statusTextChanged(const QString&);
 
 private:

--- a/examples/GuiClient/statusWidget.cpp
+++ b/examples/GuiClient/statusWidget.cpp
@@ -78,29 +78,29 @@ void statusWidget::presenceMenuTriggered()
     QAction* action = qobject_cast<QAction*>(sender());
     if(action == actionAvailable)
     {
-        emit presenceTypeChanged(QXmppPresence::Available);
+        Q_EMIT presenceTypeChanged(QXmppPresence::Available);
         icon = "green";
     }
     else if(action == actionBusy)
     {
-        emit presenceStatusTypeChanged(QXmppPresence::DND);
+        Q_EMIT presenceStatusTypeChanged(QXmppPresence::DND);
         icon = "red";
     }
     else if(action == actionAway)
     {
-        emit presenceStatusTypeChanged(QXmppPresence::Away);
+        Q_EMIT presenceStatusTypeChanged(QXmppPresence::Away);
         icon = "orange";
     }
 #if 0
     else if(action == actionInvisible)
     {
-        emit presenceStatusTypeChanged(QXmppPresence::Invisible);
+        Q_EMIT presenceStatusTypeChanged(QXmppPresence::Invisible);
         icon = "gray";
     }
 #endif
     else if(action == actionSign_out)
     {
-        emit presenceTypeChanged(QXmppPresence::Unavailable);
+        Q_EMIT presenceTypeChanged(QXmppPresence::Unavailable);
         icon = "gray";
     }
     label->setPixmap(QPixmap(":/icons/resource/"+icon+".png"));
@@ -150,7 +150,7 @@ void statusWidget::avatarSelection()
     {
         QImage scaled = image.scaled(QSize(96, 96), Qt::KeepAspectRatio,
                                      Qt::SmoothTransformation);
-        emit avatarChanged(scaled);
+        Q_EMIT avatarChanged(scaled);
     }
     else
         QMessageBox::information(this, "Avatar selection", "Invalid image file");

--- a/examples/GuiClient/statusWidget.h
+++ b/examples/GuiClient/statusWidget.h
@@ -44,11 +44,11 @@ public:
                                   QXmppPresence::AvailableStatusType statusType);
     void setAvatar(const QImage&);
 
-private slots:
+private Q_SLOTS:
     void presenceMenuTriggered();
     void avatarSelection();
 
-signals:
+Q_SIGNALS:
     void statusTextChanged(const QString&);
     void presenceTypeChanged(QXmppPresence::Type);
     void presenceStatusTypeChanged(QXmppPresence::AvailableStatusType);

--- a/examples/GuiClient/vCardCache.cpp
+++ b/examples/GuiClient/vCardCache.cpp
@@ -49,7 +49,7 @@ void vCardCache::vCardReceived(const QXmppVCardIq& vcard)
 
     saveToFile(from);
 
-    emit vCardReadyToUse(from);
+    Q_EMIT vCardReadyToUse(from);
 }
 
 bool vCardCache::isVCardAvailable(const QString& bareJid) const

--- a/examples/GuiClient/vCardCache.h
+++ b/examples/GuiClient/vCardCache.h
@@ -48,10 +48,10 @@ public:
 
     QByteArray getPhotoHash(const QString& bareJid) const;
 
-signals:
+Q_SIGNALS:
     void vCardReadyToUse(const QString& bareJid);
 
-public slots:
+public Q_SLOTS:
     void vCardReceived(const QXmppVCardIq&);
 
 private:

--- a/examples/GuiClient/xmlConsoleDialog.h
+++ b/examples/GuiClient/xmlConsoleDialog.h
@@ -40,7 +40,7 @@ public:
     explicit xmlConsoleDialog(QWidget *parent = 0);
     ~xmlConsoleDialog();
 
-public slots:
+public Q_SLOTS:
     void message(QXmppLogger::MessageType, const QString &);
 
 private:

--- a/examples/example_1_echoClient/example_1_echoClient.h
+++ b/examples/example_1_echoClient/example_1_echoClient.h
@@ -35,7 +35,7 @@ public:
     echoClient(QObject *parent = 0);
     ~echoClient();
 
-public slots:
+public Q_SLOTS:
     void messageReceived(const QXmppMessage&);
 };
 

--- a/examples/example_2_rosterHandling/example_2_rosterHandling.h
+++ b/examples/example_2_rosterHandling/example_2_rosterHandling.h
@@ -35,7 +35,7 @@ public:
     xmppClient(QObject *parent = 0);
     ~xmppClient();
 
-public slots:
+public Q_SLOTS:
     void clientConnected();
     void rosterReceived();
     void presenceChanged(const QString& bareJid, const QString& resource);

--- a/examples/example_3_transferHandling/example_3_transferHandling.h
+++ b/examples/example_3_transferHandling/example_3_transferHandling.h
@@ -36,7 +36,7 @@ public:
     xmppClient(QObject *parent = 0);
     void setRecipient(const QString &recipient);
 
-private slots:
+private Q_SLOTS:
     void slotError(QXmppTransferJob::Error error);
     void slotFileReceived(QXmppTransferJob *job);
     void slotFinished();

--- a/examples/example_4_callHandling/example_4_callHandling.h
+++ b/examples/example_4_callHandling/example_4_callHandling.h
@@ -39,7 +39,7 @@ public:
     xmppClient(QObject *parent = 0);
     void setRecipient(const QString &recipient);
 
-private slots:
+private Q_SLOTS:
     void slotAudioModeChanged(QIODevice::OpenMode mode);
     void slotCallReceived(QXmppCall *call);
     void slotCallStateChanged(QXmppCall::State state);

--- a/examples/example_5_rpcInterface/remoteinterface.h
+++ b/examples/example_5_rpcInterface/remoteinterface.h
@@ -12,7 +12,7 @@ public:
     bool isAuthorized( const QString &jid ) const;
 
 // RPC Interface
-public slots:
+public Q_SLOTS:
     QString echoString( const QString &message );
 
 };

--- a/examples/example_6_rpcClient/rpcClient.h
+++ b/examples/example_6_rpcClient/rpcClient.h
@@ -38,7 +38,7 @@ public:
     rpcClient(QObject *parent = 0);
     ~rpcClient();
 
-private slots:
+private Q_SLOTS:
     void slotInvokeRemoteMethod();
     void slotPresenceReceived(const QXmppPresence &presence);
 

--- a/examples/example_7_archiveHandling/example_7_archiveHandling.h
+++ b/examples/example_7_archiveHandling/example_7_archiveHandling.h
@@ -49,7 +49,7 @@ public:
     void setPageDirection(PageDirection direction);
     void setPageSize(int size);
 
-public slots:
+public Q_SLOTS:
     void clientConnected();
     void archiveListReceived(const QList<QXmppArchiveChat> &chats, const QXmppResultSetReply &rsmReply);
     void archiveChatReceived(const QXmppArchiveChat &chat, const QXmppResultSetReply &rsmReply);

--- a/examples/example_9_vCard/example_9_vCard.h
+++ b/examples/example_9_vCard/example_9_vCard.h
@@ -37,7 +37,7 @@ public:
     xmppClient(QObject *parent = 0);
     ~xmppClient();
 
-public slots:
+public Q_SLOTS:
     void clientConnected();
     void rosterReceived();
     void vCardReceived(const QXmppVCardIq&);

--- a/src/base/QXmppLogger.cpp
+++ b/src/base/QXmppLogger.cpp
@@ -211,7 +211,7 @@ void QXmppLogger::log(QXmppLogger::MessageType type, const QString& text)
         std::cout << qPrintable(formatted(type, text)) << std::endl;
         break;
     case QXmppLogger::SignalLogging:
-        emit message(type, text);
+        Q_EMIT message(type, text);
         break;
     default:
         break;

--- a/src/base/QXmppLogger.h
+++ b/src/base/QXmppLogger.h
@@ -88,14 +88,14 @@ public:
     QXmppLogger::MessageTypes messageTypes();
     void setMessageTypes(QXmppLogger::MessageTypes types);
 
-public slots:
+public Q_SLOTS:
     virtual void setGauge(const QString &gauge, double value);
     virtual void updateCounter(const QString &counter, qint64 amount);
 
     void log(QXmppLogger::MessageType type, const QString& text);
     void reopen();
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted whenever a log message is received.
     void message(QXmppLogger::MessageType type, const QString &text);
 
@@ -126,7 +126,7 @@ protected:
 
     void debug(const QString &message)
     {
-        emit logMessage(QXmppLogger::DebugMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::DebugMessage, qxmpp_loggable_trace(message));
     }
 
     /// Logs an informational message.
@@ -135,7 +135,7 @@ protected:
 
     void info(const QString &message)
     {
-        emit logMessage(QXmppLogger::InformationMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::InformationMessage, qxmpp_loggable_trace(message));
     }
 
     /// Logs a warning message.
@@ -144,7 +144,7 @@ protected:
 
     void warning(const QString &message)
     {
-        emit logMessage(QXmppLogger::WarningMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::WarningMessage, qxmpp_loggable_trace(message));
     }
 
     /// Logs a received packet.
@@ -153,7 +153,7 @@ protected:
 
     void logReceived(const QString &message)
     {
-        emit logMessage(QXmppLogger::ReceivedMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::ReceivedMessage, qxmpp_loggable_trace(message));
     }
 
     /// Logs a sent packet.
@@ -162,10 +162,10 @@ protected:
 
     void logSent(const QString &message)
     {
-        emit logMessage(QXmppLogger::SentMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::SentMessage, qxmpp_loggable_trace(message));
     }
 
-signals:
+Q_SIGNALS:
     /// Sets the given \a gauge to \a value.
     void setGauge(const QString &gauge, double value);
 

--- a/src/base/QXmppRtpChannel.cpp
+++ b/src/base/QXmppRtpChannel.cpp
@@ -413,12 +413,12 @@ void QXmppRtpAudioChannel::datagramReceived(const QByteArray &ba)
     if (d->incomingBuffer.size() >= d->incomingMinimum)
         d->incomingBuffering = false;
     if (!d->incomingBuffering)
-        emit readyRead();
+        Q_EMIT readyRead();
 }
 
 void QXmppRtpAudioChannel::emitSignals()
 {
-    emit bytesWritten(d->writtenSinceLastEmit);
+    Q_EMIT bytesWritten(d->writtenSinceLastEmit);
     d->writtenSinceLastEmit = 0;
     d->signalsEmitted = false;
 }
@@ -634,7 +634,7 @@ void QXmppRtpAudioChannel::writeDatagram()
 #ifdef QXMPP_DEBUG_RTP
             logSent(packet.toString());
 #endif
-            emit sendDatagram(packet.encode());
+            Q_EMIT sendDatagram(packet.encode());
             d->outgoingSequence++;
             d->outgoingStamp += packetTicks;
 
@@ -675,7 +675,7 @@ void QXmppRtpAudioChannel::writeDatagram()
 #ifdef QXMPP_DEBUG_RTP
         logSent(packet.toString());
 #endif
-        emit sendDatagram(packet.encode());
+        Q_EMIT sendDatagram(packet.encode());
         d->outgoingSequence++;
         d->outgoingStamp += packetTicks;
     }
@@ -999,7 +999,7 @@ void QXmppRtpVideoChannel::writeFrame(const QXmppVideoFrame &frame)
 #ifdef QXMPP_DEBUG_RTP
         logSent(packet.toString());
 #endif
-        emit sendDatagram(packet.encode());
+        Q_EMIT sendDatagram(packet.encode());
     }
     d->outgoingStamp += 1;
 }

--- a/src/base/QXmppRtpChannel.h
+++ b/src/base/QXmppRtpChannel.h
@@ -109,14 +109,14 @@ public:
     qint64 pos() const;
     bool seek(qint64 pos);
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a datagram needs to be sent.
     void sendDatagram(const QByteArray &ba);
 
     /// \brief This signal is emitted to send logging messages.
     void logMessage(QXmppLogger::MessageType type, const QString &msg);
 
-public slots:
+public Q_SLOTS:
     void datagramReceived(const QByteArray &ba);
     void startTone(QXmppRtpAudioChannel::Tone tone);
     void stopTone(QXmppRtpAudioChannel::Tone tone);
@@ -125,22 +125,22 @@ protected:
     /// \cond
     void debug(const QString &message)
     {
-        emit logMessage(QXmppLogger::DebugMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::DebugMessage, qxmpp_loggable_trace(message));
     }
 
     void warning(const QString &message)
     {
-        emit logMessage(QXmppLogger::WarningMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::WarningMessage, qxmpp_loggable_trace(message));
     }
 
     void logReceived(const QString &message)
     {
-        emit logMessage(QXmppLogger::ReceivedMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::ReceivedMessage, qxmpp_loggable_trace(message));
     }
 
     void logSent(const QString &message)
     {
-        emit logMessage(QXmppLogger::SentMessage, qxmpp_loggable_trace(message));
+        Q_EMIT logMessage(QXmppLogger::SentMessage, qxmpp_loggable_trace(message));
     }
 
     void payloadTypesChanged();
@@ -148,7 +148,7 @@ protected:
     qint64 writeData(const char * data, qint64 maxSize);
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void emitSignals();
     void writeDatagram();
 
@@ -272,11 +272,11 @@ public:
     void setEncoderFormat(const QXmppVideoFormat &format);
     void writeFrame(const QXmppVideoFrame &frame);
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a datagram needs to be sent.
     void sendDatagram(const QByteArray &ba);
 
-public slots:
+public Q_SLOTS:
     void datagramReceived(const QByteArray &ba);
 
 protected:

--- a/src/base/QXmppSocks.cpp
+++ b/src/base/QXmppSocks.cpp
@@ -189,7 +189,7 @@ void QXmppSocksClient::slotReadyRead()
 
         // notify of connection
         m_step = ReadyState;
-        emit ready();
+        Q_EMIT ready();
     }
 }
 
@@ -320,7 +320,7 @@ void QXmppSocksServer::slotReadyRead()
 
         // notify of connection
         m_states.insert(socket, ReadyState);
-        emit newConnection(socket, hostName, hostPort);
+        Q_EMIT newConnection(socket, hostName, hostPort);
 
         // send response
         buffer.resize(3);

--- a/src/base/QXmppSocks.h
+++ b/src/base/QXmppSocks.h
@@ -39,10 +39,10 @@ public:
     QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, QObject *parent=0);
     void connectToHost(const QString &hostName, quint16 hostPort);
 
-signals:
+Q_SIGNALS:
     void ready();
 
-private slots:
+private Q_SLOTS:
     void slotConnected();
     void slotReadyRead();
 
@@ -65,10 +65,10 @@ public:
 
     quint16 serverPort() const;
 
-signals:
+Q_SIGNALS:
     void newConnection(QTcpSocket *socket, QString hostName, quint16 port);
 
-private slots:
+private Q_SLOTS:
     void slotNewConnection();
     void slotReadyRead();
 

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -49,7 +49,7 @@ public:
     virtual bool isConnected() const;
     bool sendPacket(const QXmppStanza&);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the stream is connected.
     void connected();
 
@@ -98,11 +98,11 @@ private:
     /// Sends an acknowledgement request as defined in XEP-0198.
     void sendAcknowledgementRequest();
 
-public slots:
+public Q_SLOTS:
     virtual void disconnectFromHost();
     virtual bool sendData(const QByteArray&);
 
-private slots:
+private Q_SLOTS:
     void _q_socketConnected();
     void _q_socketEncrypted();
     void _q_socketError(QAbstractSocket::SocketError error);

--- a/src/base/QXmppStun.cpp
+++ b/src/base/QXmppStun.cpp
@@ -1137,7 +1137,7 @@ void QXmppStunTransaction::readStun(const QXmppStunMessage &response)
         response.messageClass() == QXmppStunMessage::Response) {
         m_response = response;
         m_retryTimer->stop();
-        emit finished();
+        Q_EMIT finished();
     }
 }
 
@@ -1160,12 +1160,12 @@ void QXmppStunTransaction::retry()
     if (m_tries >= STUN_RTO_MAX) {
         m_response.setType(QXmppStunMessage::Error);
         m_response.errorPhrase = QLatin1String("Request timed out");
-        emit finished();
+        Q_EMIT finished();
         return;
     }
 
     // resend request
-    emit writeStun(m_request);
+    Q_EMIT writeStun(m_request);
     m_retryTimer->start(m_tries ? 2 * m_retryTimer->interval() : STUN_RTO_INTERVAL);
     m_tries++;
 }
@@ -1308,7 +1308,7 @@ void QXmppTurnAllocation::handleDatagram(const QByteArray &buffer, const QHostAd
         stream >> channel;
         stream >> length;
         if (m_state == ConnectedState && m_channels.contains(channel) && length <= buffer.size() - 4) {
-            emit datagramReceived(buffer.mid(4, length), m_channels[channel].first,
+            Q_EMIT datagramReceived(buffer.mid(4, length), m_channels[channel].first,
                 m_channels[channel].second);
         }
         return;
@@ -1430,10 +1430,10 @@ void QXmppTurnAllocation::setState(AllocationState state)
         return;
     m_state = state;
     if (m_state == ConnectedState) {
-        emit connected();
+        Q_EMIT connected();
     } else if (m_state == UnconnectedState) {
         m_timer->stop();
-        emit disconnected();
+        Q_EMIT disconnected();
     }
 }
 
@@ -1633,7 +1633,7 @@ void QXmppUdpTransport::readyRead()
         const qint64 size = m_socket->pendingDatagramSize();
         buffer.resize(size);
         m_socket->readDatagram(buffer.data(), buffer.size(), &remoteHost, &remotePort);
-        emit datagramReceived(buffer, remoteHost, remotePort);
+        Q_EMIT datagramReceived(buffer, remoteHost, remotePort);
     }
 }
 
@@ -2063,7 +2063,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
     if (!transport)
         return;
 
-    // if this is not a STUN message, emit it
+    // if this is not a STUN message, Q_EMIT it
     quint32 messageCookie;
     QByteArray messageId;
     quint16 messageType = QXmppStunMessage::peekType(buffer, messageCookie, messageId);
@@ -2077,7 +2077,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
                 break;
             }
         }
-        emit datagramReceived(buffer);
+        Q_EMIT datagramReceived(buffer);
         return;
     }
 
@@ -2241,7 +2241,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
             const bool wasConnected = (d->activePair != 0);
             d->activePair = pair;
             if (!wasConnected)
-                emit connected();
+                Q_EMIT connected();
         }
     }
 }
@@ -2321,7 +2321,7 @@ void QXmppIceComponent::transactionFinished()
 
             d->localCandidates << candidate;
 
-            emit localCandidatesChanged();
+            Q_EMIT localCandidatesChanged();
         } else {
             debug(QString("STUN test failed (error %1)").arg(
                 transaction->response().errorPhrase));
@@ -2342,7 +2342,7 @@ void QXmppIceComponent::turnConnected()
         QString::number(candidate.port())));
     d->localCandidates << candidate;
 
-    emit localCandidatesChanged();
+    Q_EMIT localCandidatesChanged();
     updateGatheringState();
 }
 
@@ -2472,7 +2472,7 @@ void QXmppIceComponent::updateGatheringState()
 
     if (newGatheringState != d->gatheringState) {
         d->gatheringState = newGatheringState;
-        emit gatheringStateChanged();
+        Q_EMIT gatheringStateChanged();
     }
 }
 
@@ -2785,7 +2785,7 @@ void QXmppIceConnection::slotConnected()
             return;
     info(QString("ICE negotiation completed"));
     d->connectTimer->stop();
-    emit connected();
+    Q_EMIT connected();
 }
 
 void QXmppIceConnection::slotGatheringStateChanged()
@@ -2811,7 +2811,7 @@ void QXmppIceConnection::slotGatheringStateChanged()
             gathering_states[d->gatheringState],
             gathering_states[newGatheringState]));
         d->gatheringState = newGatheringState;
-        emit gatheringStateChanged();
+        Q_EMIT gatheringStateChanged();
     }
 }
 
@@ -2820,7 +2820,7 @@ void QXmppIceConnection::slotTimeout()
     warning(QString("ICE negotiation timed out"));
     foreach (QXmppIceComponent *socket, d->components.values())
         socket->close();
-    emit disconnected();
+    Q_EMIT disconnected();
 }
 
 QXmppIceTransport::QXmppIceTransport(QObject *parent)

--- a/src/base/QXmppStun.h
+++ b/src/base/QXmppStun.h
@@ -176,12 +176,12 @@ public:
     static QList<QHostAddress> discoverAddresses();
     static QList<QUdpSocket*> reservePorts(const QList<QHostAddress> &addresses, int count, QObject *parent = 0);
 
-public slots:
+public Q_SLOTS:
     void close();
     void connectToHost();
     qint64 sendDatagram(const QByteArray &datagram);
 
-private slots:
+private Q_SLOTS:
     void checkCandidates();
     void handleDatagram(const QByteArray &datagram, const QHostAddress &host, quint16 port);
     void turnConnected();
@@ -189,7 +189,7 @@ private slots:
     void updateGatheringState();
     void writeStun(const QXmppStunMessage &request);
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted once ICE negotiation succeeds.
     void connected();
 
@@ -277,7 +277,7 @@ public:
 
     GatheringState gatheringState() const;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted once ICE negotiation succeeds.
     void connected();
 
@@ -290,11 +290,11 @@ signals:
     /// \brief This signal is emitted when the list of local candidates changes.
     void localCandidatesChanged();
 
-public slots:
+public Q_SLOTS:
     void close();
     void connectToHost();
 
-private slots:
+private Q_SLOTS:
     void slotConnected();
     void slotGatheringStateChanged();
     void slotTimeout();

--- a/src/base/QXmppStun_p.h
+++ b/src/base/QXmppStun_p.h
@@ -55,14 +55,14 @@ public:
     QXmppStunMessage request() const;
     QXmppStunMessage response() const;
 
-signals:
+Q_SIGNALS:
     void finished();
     void writeStun(const QXmppStunMessage &request);
 
-public slots:
+public Q_SLOTS:
     void readStun(const QXmppStunMessage &response);
 
-private slots:
+private Q_SLOTS:
     void retry();
 
 private:
@@ -83,10 +83,10 @@ public:
     virtual QXmppJingleCandidate localCandidate(int component) const = 0;
     virtual qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port) = 0;
 
-public slots:
+public Q_SLOTS:
     virtual void disconnectFromHost() = 0;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a data packet is received.
     void datagramReceived(const QByteArray &data, const QHostAddress &host, quint16 port);
 };
@@ -124,18 +124,18 @@ public:
     QXmppJingleCandidate localCandidate(int component) const;
     qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port);
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted once TURN allocation succeeds.
     void connected();
 
     /// \brief This signal is emitted when TURN allocation fails.
     void disconnected();
 
-public slots:
+public Q_SLOTS:
     void connectToHost();
     void disconnectFromHost();
 
-private slots:
+private Q_SLOTS:
     void readyRead();
     void refresh();
     void refreshChannels();
@@ -186,10 +186,10 @@ public:
     QXmppJingleCandidate localCandidate(int component) const;
     qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port);
 
-public slots:
+public Q_SLOTS:
     void disconnectFromHost();
 
-private slots:
+private Q_SLOTS:
     void readyRead();
 
 private:

--- a/src/base/qdnslookup.cpp
+++ b/src/base/qdnslookup.cpp
@@ -340,7 +340,7 @@ void QDnsLookup::setName(const QString &name)
     Q_D(QDnsLookup);
     if (name != d->name) {
         d->name = name;
-        emit nameChanged(name);
+        Q_EMIT nameChanged(name);
     }
 }
 
@@ -359,7 +359,7 @@ void QDnsLookup::setType(Type type)
     Q_D(QDnsLookup);
     if (type != d->type) {
         d->type = type;
-        emit typeChanged(type);
+        Q_EMIT typeChanged(type);
     }
 }
 
@@ -449,7 +449,7 @@ void QDnsLookup::abort()
         d->reply.error = QDnsLookup::OperationCancelledError;
         d->reply.errorString = tr("Operation cancelled");
         d->isFinished = true;
-        emit finished();
+        Q_EMIT finished();
     }
 }
 
@@ -920,7 +920,7 @@ void QDnsLookupPrivate::_q_lookupFinished(const QDnsLookupReply &_reply)
         reply = _reply;
         runnable = 0;
         isFinished = true;
-        emit q->finished();
+        Q_EMIT q->finished();
     }
 }
 
@@ -932,7 +932,7 @@ void QDnsLookupRunnable::run()
     if (requestName.isEmpty()) {
         reply.error = QDnsLookup::InvalidRequestError;
         reply.errorString = tr("Invalid domain name");
-        emit finished(reply);
+        Q_EMIT finished(reply);
         return;
     }
 
@@ -947,7 +947,7 @@ void QDnsLookupRunnable::run()
     qt_qdnsmailexchangerecord_sort(reply.mailExchangeRecords);
     qt_qdnsservicerecord_sort(reply.serviceRecords);
 
-    emit finished(reply);
+    Q_EMIT finished(reply);
 }
 
 QDnsLookupThreadPool::QDnsLookupThreadPool()

--- a/src/base/qdnslookup_p.h
+++ b/src/base/qdnslookup_p.h
@@ -120,7 +120,7 @@ public:
     { }
     void run();
 
-signals:
+Q_SIGNALS:
     void finished(const QDnsLookupReply &reply);
 
 private:
@@ -137,7 +137,7 @@ public:
     QDnsLookupThreadPool();
     void start(QRunnable *runnable);
 
-private slots:
+private Q_SLOTS:
     void _q_applicationDestroyed();
 
 private:

--- a/src/client/QXmppArchiveManager.cpp
+++ b/src/client/QXmppArchiveManager.cpp
@@ -45,14 +45,14 @@ bool QXmppArchiveManager::handleStanza(const QDomElement &element)
     {
         QXmppArchiveChatIq archiveIq;
         archiveIq.parse(element);
-        emit archiveChatReceived(archiveIq.chat(), archiveIq.resultSetReply());
+        Q_EMIT archiveChatReceived(archiveIq.chat(), archiveIq.resultSetReply());
         return true;
     }
     else if(QXmppArchiveListIq::isArchiveListIq(element))
     {
         QXmppArchiveListIq archiveIq;
         archiveIq.parse(element);
-        emit archiveListReceived(archiveIq.chats(), archiveIq.resultSetReply());
+        Q_EMIT archiveListReceived(archiveIq.chats(), archiveIq.resultSetReply());
         return true;
     }
     else if(QXmppArchivePrefIq::isArchivePrefIq(element))

--- a/src/client/QXmppArchiveManager.h
+++ b/src/client/QXmppArchiveManager.h
@@ -67,7 +67,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when archive list is received
     /// after calling listCollections()
     void archiveListReceived(const QList<QXmppArchiveChat>&, const QXmppResultSetReply &rsm = QXmppResultSetReply());

--- a/src/client/QXmppBookmarkManager.cpp
+++ b/src/client/QXmppBookmarkManager.cpp
@@ -172,7 +172,7 @@ bool QXmppBookmarkManager::handleStanza(const QDomElement &stanza)
             {
                 d->bookmarks = iq.bookmarks();
                 d->bookmarksReceived = true;
-                emit bookmarksReceived(d->bookmarks);
+                Q_EMIT bookmarksReceived(d->bookmarks);
             }
             return true;
         }
@@ -183,7 +183,7 @@ bool QXmppBookmarkManager::handleStanza(const QDomElement &stanza)
             if (iq.type() == QXmppIq::Result)
             {
                 d->bookmarks = d->pendingBookmarks;
-                emit bookmarksReceived(d->bookmarks);
+                Q_EMIT bookmarksReceived(d->bookmarks);
             }
             d->pendingId = QString();
             return true;

--- a/src/client/QXmppBookmarkManager.h
+++ b/src/client/QXmppBookmarkManager.h
@@ -51,7 +51,7 @@ public:
     bool handleStanza(const QDomElement &stanza);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when bookmarks are received.
     void bookmarksReceived(const QXmppBookmarkSet &bookmarks);
 
@@ -60,7 +60,7 @@ protected:
     void setClient(QXmppClient* client);
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void slotConnected();
     void slotDisconnected();
 

--- a/src/client/QXmppCallManager.cpp
+++ b/src/client/QXmppCallManager.cpp
@@ -415,12 +415,12 @@ void QXmppCallPrivate::setState(QXmppCall::State newState)
     if (state != newState)
     {
         state = newState;
-        emit q->stateChanged(state);
+        Q_EMIT q->stateChanged(state);
 
         if (state == QXmppCall::ActiveState)
-            emit q->connected();
+            Q_EMIT q->connected();
         else if (state == QXmppCall::FinishedState)
-            emit q->finished();
+            Q_EMIT q->finished();
     }
 }
 
@@ -612,7 +612,7 @@ void QXmppCall::updateOpenMode()
         mode = stream->channel->openMode() & QIODevice::ReadWrite;
     if (mode != d->audioMode) {
         d->audioMode = mode;
-        emit audioModeChanged(mode);
+        Q_EMIT audioModeChanged(mode);
     }
 
     // determine video mode
@@ -625,7 +625,7 @@ void QXmppCall::updateOpenMode()
     }
     if (mode != d->videoMode) {
         d->videoMode = mode;
-        emit videoModeChanged(mode);
+        Q_EMIT videoModeChanged(mode);
     }
 }
 
@@ -806,7 +806,7 @@ QXmppCall *QXmppCallManager::call(const QString &jid)
     check = connect(call, SIGNAL(destroyed(QObject*)),
                     this, SLOT(_q_callDestroyed(QObject*)));
     Q_ASSERT(check);
-    emit callStarted(call);
+    Q_EMIT callStarted(call);
 
     call->d->sendInvite();
 
@@ -936,7 +936,7 @@ void QXmppCallManager::_q_jingleIqReceived(const QXmppJingleIq &iq)
         call->d->sendRequest(ringing);
 
         // notify user
-        emit callReceived(call);
+        Q_EMIT callReceived(call);
         return;
 
     } else {

--- a/src/client/QXmppCallManager.h
+++ b/src/client/QXmppCallManager.h
@@ -90,7 +90,7 @@ public:
     QXmppRtpVideoChannel *videoChannel() const;
     QIODevice::OpenMode videoMode() const;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a call is connected.
     ///
     /// Once this signal is emitted, you can connect a QAudioOutput and
@@ -116,13 +116,13 @@ signals:
     /// \brief This signal is emitted when the video channel changes.
     void videoModeChanged(QIODevice::OpenMode mode);
 
-public slots:
+public Q_SLOTS:
     void accept();
     void hangup();
     void startVideo();
     void stopVideo();
 
-private slots:
+private Q_SLOTS:
     void localCandidatesChanged();
     void terminated();
     void updateOpenMode();
@@ -174,7 +174,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a new incoming call is received.
     ///
     /// To accept the call, invoke the call's QXmppCall::accept() method.
@@ -184,7 +184,7 @@ signals:
     /// This signal is emitted when a call (incoming or outgoing) is started.
     void callStarted(QXmppCall *call);
 
-public slots:
+public Q_SLOTS:
     QXmppCall *call(const QString &jid);
 
 protected:
@@ -192,7 +192,7 @@ protected:
     void setClient(QXmppClient* client);
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void _q_callDestroyed(QObject *object);
     void _q_disconnected();
     void _q_iqReceived(const QXmppIq &iq);

--- a/src/client/QXmppCarbonManager.cpp
+++ b/src/client/QXmppCarbonManager.cpp
@@ -107,9 +107,9 @@ bool QXmppCarbonManager::handleStanza(const QDomElement &element)
     message.parse(messageelement);
 
     if(sent)
-        emit messageSent(message);
+        Q_EMIT messageSent(message);
     else
-        emit messageReceived(message);
+        Q_EMIT messageReceived(message);
 
     return true;
 }

--- a/src/client/QXmppCarbonManager.h
+++ b/src/client/QXmppCarbonManager.h
@@ -53,7 +53,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \brief Emitted when a message was received from someone else
     /// and directed to another resource.
     /// If you connect this signal to the \s QXmppClient::messageReceived

--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -481,7 +481,7 @@ void QXmppClient::_q_reconnect()
 void QXmppClient::_q_socketStateChanged(QAbstractSocket::SocketState socketState)
 {
     Q_UNUSED(socketState);
-    emit stateChanged(state());
+    Q_EMIT stateChanged(state());
 }
 
 /// At connection establishment, send initial presence.
@@ -492,8 +492,8 @@ void QXmppClient::_q_streamConnected()
     d->reconnectionTries = 0;
 
     // notify managers
-    emit connected();
-    emit stateChanged(QXmppClient::ConnectedState);
+    Q_EMIT connected();
+    Q_EMIT stateChanged(QXmppClient::ConnectedState);
 
     // send initial presence
     if (d->stream->isAuthenticated())
@@ -503,8 +503,8 @@ void QXmppClient::_q_streamConnected()
 void QXmppClient::_q_streamDisconnected()
 {
     // notify managers
-    emit disconnected();
-    emit stateChanged(QXmppClient::DisconnectedState);
+    Q_EMIT disconnected();
+    Q_EMIT stateChanged(QXmppClient::DisconnectedState);
 }
 
 void QXmppClient::_q_streamError(QXmppClient::Error err)
@@ -524,7 +524,7 @@ void QXmppClient::_q_streamError(QXmppClient::Error err)
     }
 
     // notify managers
-    emit error(err);
+    Q_EMIT error(err);
 }
 
 /// Returns the QXmppLogger associated with the current QXmppClient.
@@ -558,7 +558,7 @@ void QXmppClient::setLogger(QXmppLogger *logger)
                     d->logger, SLOT(updateCounter(QString,qint64)));
         }
 
-        emit loggerChanged(d->logger);
+        Q_EMIT loggerChanged(d->logger);
     }
 }
 

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -156,7 +156,7 @@ public:
     QXmppVCardManager& vCardManager();
     QXmppVersionManager& versionManager();
 
-signals:
+Q_SIGNALS:
 
     /// This signal is emitted when the client connects successfully to the XMPP
     /// server i.e. when a successful XMPP connection is established.
@@ -218,7 +218,7 @@ signals:
     /// This signal is emitted when the client state changes.
     void stateChanged(QXmppClient::State state);
 
-public slots:
+public Q_SLOTS:
     void connectToServer(const QXmppConfiguration&,
                          const QXmppPresence& initialPresence =
                          QXmppPresence());
@@ -228,7 +228,7 @@ public slots:
     bool sendPacket(const QXmppStanza&);
     void sendMessage(const QString& bareJid, const QString& message);
 
-private slots:
+private Q_SLOTS:
     void _q_elementReceived(const QDomElement &element, bool &handled);
     void _q_reconnect();
     void _q_socketStateChanged(QAbstractSocket::SocketState state);

--- a/src/client/QXmppDiscoveryManager.cpp
+++ b/src/client/QXmppDiscoveryManager.cpp
@@ -279,9 +279,9 @@ bool QXmppDiscoveryManager::handleStanza(const QDomElement &element)
         case QXmppIq::Error:
             // handle all replies
             if (receivedIq.queryType() == QXmppDiscoveryIq::InfoQuery) {
-                emit infoReceived(receivedIq);
+                Q_EMIT infoReceived(receivedIq);
             } else if (receivedIq.queryType() == QXmppDiscoveryIq::ItemsQuery) {
-                emit itemsReceived(receivedIq);
+                Q_EMIT itemsReceived(receivedIq);
             }
             return true;
 

--- a/src/client/QXmppDiscoveryManager.h
+++ b/src/client/QXmppDiscoveryManager.h
@@ -69,7 +69,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an information response is received.
     void infoReceived(const QXmppDiscoveryIq&);
 

--- a/src/client/QXmppEntityTimeManager.cpp
+++ b/src/client/QXmppEntityTimeManager.cpp
@@ -78,7 +78,7 @@ bool QXmppEntityTimeManager::handleStanza(const QDomElement &element)
             client()->sendPacket(responseIq);
         }
 
-        emit timeReceived(entityTime);
+        Q_EMIT timeReceived(entityTime);
         return true;
     }
 

--- a/src/client/QXmppEntityTimeManager.h
+++ b/src/client/QXmppEntityTimeManager.h
@@ -46,7 +46,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a time response is received.
     void timeReceived(const QXmppEntityTimeIq&);
 };

--- a/src/client/QXmppInvokable.h
+++ b/src/client/QXmppInvokable.h
@@ -63,7 +63,7 @@ public:
           */
         virtual bool isAuthorized( const QString &jid ) const = 0;
 
-public slots:
+public Q_SLOTS:
         /**
           * This provides a list of interfaces for introspection of the presented interface.
           */

--- a/src/client/QXmppMamManager.cpp
+++ b/src/client/QXmppMamManager.cpp
@@ -55,7 +55,7 @@ bool QXmppMamManager::handleStanza(const QDomElement &element)
                         const QString stamp = delayElement.attribute("stamp");
                         message.setStamp(QXmppUtils::datetimeFromString(stamp));
                     }
-                    emit archivedMessageReceived(queryId, message);
+                    Q_EMIT archivedMessageReceived(queryId, message);
                 }
             }
             return true;
@@ -63,7 +63,7 @@ bool QXmppMamManager::handleStanza(const QDomElement &element)
     } else if (QXmppMamResultIq::isMamResultIq(element)) {
         QXmppMamResultIq result;
         result.parse(element);
-        emit resultsRecieved(result.id(), result.resultSetReply(), result.complete());
+        Q_EMIT resultsRecieved(result.id(), result.resultSetReply(), result.complete());
         return true;
     }
 

--- a/src/client/QXmppMamManager.h
+++ b/src/client/QXmppMamManager.h
@@ -61,7 +61,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an archived message is received
     void archivedMessageReceived(const QString &queryId,
                                  const QXmppMessage &message);

--- a/src/client/QXmppMessageReceiptManager.cpp
+++ b/src/client/QXmppMessageReceiptManager.cpp
@@ -54,7 +54,7 @@ bool QXmppMessageReceiptManager::handleStanza(const QDomElement &stanza)
 
     // Handle receipts and cancel any further processing.
     if (!message.receiptId().isEmpty()) {
-        emit messageDelivered(message.from(), message.receiptId());
+        Q_EMIT messageDelivered(message.from(), message.receiptId());
         return true;
     }
 

--- a/src/client/QXmppMessageReceiptManager.h
+++ b/src/client/QXmppMessageReceiptManager.h
@@ -44,7 +44,7 @@ public:
     virtual bool handleStanza(const QDomElement &stanza);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when receipt for the message with the
     /// given id is received. The id could be previously obtained by
     /// calling QXmppMessage::id().

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -73,7 +73,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an invitation to a chat room is received.
     void invitationReceived(const QString &roomJid, const QString &inviter, const QString &reason);
 
@@ -85,7 +85,7 @@ protected:
     void setClient(QXmppClient* client);
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void _q_messageReceived(const QXmppMessage &message);
     void _q_roomDestroyed(QObject *object);
 
@@ -143,7 +143,7 @@ public:
     QString subject() const;
     void setSubject(const QString &subject);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the allowed actions change.
     void allowedActionsChanged(QXmppMucRoom::Actions actions) const;
 
@@ -194,7 +194,7 @@ signals:
     /// This signal is emitted when the room's subject changes.
     void subjectChanged(const QString &subject);
 
-public slots:
+public Q_SLOTS:
     bool ban(const QString &jid, const QString &reason);
     bool join();
     bool kick(const QString &jid, const QString &reason);
@@ -206,7 +206,7 @@ public slots:
     bool sendInvitation(const QString &jid, const QString &reason);
     bool sendMessage(const QString &text);
 
-private slots:
+private Q_SLOTS:
     void _q_disconnected();
     void _q_discoveryInfoReceived(const QXmppDiscoveryIq &iq);
     void _q_messageReceived(const QXmppMessage &message);

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -298,7 +298,7 @@ void QXmppOutgoingClient::_q_socketDisconnected()
         d->redirectHost = QString();
         d->redirectPort = 0;
     } else {
-        emit disconnected();
+        Q_EMIT disconnected();
     }
 }
 
@@ -310,7 +310,7 @@ void QXmppOutgoingClient::socketSslErrors(const QList<QSslError> &errors)
         warning(errors.at(i).errorString());
 
     // relay signal
-    emit sslErrors(errors);
+    Q_EMIT sslErrors(errors);
 
     // if configured, ignore the errors
     if (configuration().ignoreSslErrors())
@@ -320,7 +320,7 @@ void QXmppOutgoingClient::socketSslErrors(const QList<QSslError> &errors)
 void QXmppOutgoingClient::socketError(QAbstractSocket::SocketError socketError)
 {
     Q_UNUSED(socketError);
-    emit error(QXmppClient::SocketError);
+    Q_EMIT error(QXmppClient::SocketError);
 }
 
 /// \cond
@@ -379,7 +379,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
     // give client opportunity to handle stanza
     bool handled = false;
-    emit elementReceived(nodeRecv, handled);
+    Q_EMIT elementReceived(nodeRecv, handled);
     if (handled)
         return;
 
@@ -518,7 +518,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
         // otherwise we are done
         d->sessionStarted = true;
-        emit connected();
+        Q_EMIT connected();
     }
     else if(ns == ns_stream && nodeRecv.tagName() == "error")
     {
@@ -538,7 +538,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
             d->xmppStreamError = QXmppStanza::Error::Conflict;
         else
             d->xmppStreamError = QXmppStanza::Error::UndefinedCondition;
-        emit error(QXmppClient::XmppStreamError);
+        Q_EMIT error(QXmppClient::XmppStreamError);
     }
     else if(ns == ns_tls)
     {
@@ -586,7 +586,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
                 d->xmppStreamError = QXmppStanza::Error::NotAuthorized;
             else
                 d->xmppStreamError = QXmppStanza::Error::UndefinedCondition;
-            emit error(QXmppClient::XmppStreamError);
+            Q_EMIT error(QXmppClient::XmppStreamError);
 
             warning("Authentication failure");
             disconnectFromHost();
@@ -616,7 +616,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
                 else
                 {
                     // we are connected now
-                    emit connected();
+                    Q_EMIT connected();
                 }
             }
             else if(QXmppBindIq::isBindIq(nodeRecv) && id == d->bindId)
@@ -649,7 +649,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
                             d->sendStreamManagementEnable();
                         } else {
                             // we are connected now
-                            emit connected();
+                            Q_EMIT connected();
                         }
                     }
                 }
@@ -665,7 +665,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
                 // xmpp connection made
                 d->sessionStarted = true;
-                emit connected();
+                Q_EMIT connected();
             }
             else if(QXmppNonSASLAuthIq::isNonSASLAuthIq(nodeRecv))
             {
@@ -726,7 +726,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
                     iq.setError(error);
                     sendPacket(iq);
                 } else {
-                    emit iqReceived(iqPacket);
+                    Q_EMIT iqReceived(iqPacket);
                 }
             }
         }
@@ -735,16 +735,16 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
             QXmppPresence presence;
             presence.parse(nodeRecv);
 
-            // emit presence
-            emit presenceReceived(presence);
+            // Q_EMIT presence
+            Q_EMIT presenceReceived(presence);
         }
         else if(nodeRecv.tagName() == "message")
         {
             QXmppMessage message;
             message.parse(nodeRecv);
 
-            // emit message
-            emit messageReceived(message);
+            // Q_EMIT message
+            Q_EMIT messageReceived(message);
         }
     }
     else if(QXmppStreamManagementEnabled::isStreamManagementEnabled(nodeRecv))
@@ -769,7 +769,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
         enableStreamManagement(true);
         // we are connected now
-        emit connected();
+        Q_EMIT connected();
     }
     else if(QXmppStreamManagementResumed::isStreamManagementResumed(nodeRecv))
     {
@@ -781,7 +781,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
         enableStreamManagement(false);
         // we are connected now
         // TODO: The stream was resumed. Therefore, we should not send presence information or request the roster.
-        emit connected();
+        Q_EMIT connected();
     }
     else if(QXmppStreamManagementFailed::isStreamManagementFailed(nodeRecv))
     {
@@ -803,10 +803,10 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
             // otherwise we are done
             d->sessionStarted = true;
-            emit connected();
+            Q_EMIT connected();
         } else {
             // we are connected now, but stream management is disabled
-            emit connected();
+            Q_EMIT connected();
         }
     }
 }
@@ -850,7 +850,7 @@ void QXmppOutgoingClient::pingTimeout()
 {
     warning("Ping timeout");
     QXmppStream::disconnectFromHost();
-    emit error(QXmppClient::KeepAliveError);
+    Q_EMIT error(QXmppClient::KeepAliveError);
 }
 
 void QXmppOutgoingClientPrivate::sendNonSASLAuth(bool plainText)

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -61,7 +61,7 @@ public:
 
     QXmppConfiguration& configuration();
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an error is encountered.
     void error(QXmppClient::Error);
 
@@ -88,10 +88,10 @@ protected:
     virtual void handleStream(const QDomElement &element);
     /// \endcond
 
-public slots:
+public Q_SLOTS:
     virtual void disconnectFromHost();
 
-private slots:
+private Q_SLOTS:
     void _q_dnsLookupFinished();
     void _q_socketDisconnected();
     void socketError(QAbstractSocket::SocketError);

--- a/src/client/QXmppRemoteMethod.cpp
+++ b/src/client/QXmppRemoteMethod.cpp
@@ -59,7 +59,7 @@ void QXmppRemoteMethod::gotError( const QXmppRpcErrorIq &iq )
         m_result.hasError = true;
         m_result.errorMessage = iq.error().text();
         m_result.code = iq.error().type();
-        emit callDone();
+        Q_EMIT callDone();
     }
 }
 
@@ -70,6 +70,6 @@ void QXmppRemoteMethod::gotResult( const QXmppRpcResponseIq &iq )
         m_result.hasError = false;
         // FIXME: we don't handle multiple responses
         m_result.result = iq.values().first();
-        emit callDone();
+        Q_EMIT callDone();
     }
 }

--- a/src/client/QXmppRemoteMethod.h
+++ b/src/client/QXmppRemoteMethod.h
@@ -46,11 +46,11 @@ public:
     QXmppRemoteMethod(const QString &jid, const QString &method, const QVariantList &args, QXmppClient *client);
     QXmppRemoteMethodResult call( );
 
-private slots:
+private Q_SLOTS:
     void gotError( const QXmppRpcErrorIq &iq );
     void gotResult( const QXmppRpcResponseIq &iq );
 
-signals:
+Q_SIGNALS:
     void callDone();
 
 private:

--- a/src/client/QXmppRosterManager.cpp
+++ b/src/client/QXmppRosterManager.cpp
@@ -148,17 +148,17 @@ bool QXmppRosterManager::handleStanza(const QDomElement &element)
                 if (item.subscriptionType() == QXmppRosterIq::Item::Remove) {
                     if (d->entries.remove(bareJid)) {
                         // notify the user that the item was removed
-                        emit itemRemoved(bareJid);
+                        Q_EMIT itemRemoved(bareJid);
                     }
                 } else {
                     const bool added = !d->entries.contains(bareJid);
                     d->entries.insert(bareJid, item);
                     if (added) {
                         // notify the user that the item was added
-                        emit itemAdded(bareJid);
+                        Q_EMIT itemAdded(bareJid);
                     } else {
                         // notify the user that the item changed
-                        emit itemChanged(bareJid);
+                        Q_EMIT itemChanged(bareJid);
                     }
                 }
             }
@@ -174,7 +174,7 @@ bool QXmppRosterManager::handleStanza(const QDomElement &element)
             if (isInitial)
             {
                 d->isRosterReceived = true;
-                emit rosterReceived();
+                Q_EMIT rosterReceived();
             }
             break;
         }
@@ -199,11 +199,11 @@ void QXmppRosterManager::_q_presenceReceived(const QXmppPresence& presence)
     {
     case QXmppPresence::Available:
         d->presences[bareJid][resource] = presence;
-        emit presenceChanged(bareJid, resource);
+        Q_EMIT presenceChanged(bareJid, resource);
         break;
     case QXmppPresence::Unavailable:
         d->presences[bareJid].remove(resource);
-        emit presenceChanged(bareJid, resource);
+        Q_EMIT presenceChanged(bareJid, resource);
         break;
     case QXmppPresence::Subscribe:
         if (client()->configuration().autoAcceptSubscriptions())
@@ -214,7 +214,7 @@ void QXmppRosterManager::_q_presenceReceived(const QXmppPresence& presence)
             // ask for reciprocal subscription
             subscribe(bareJid);
         } else {
-            emit subscriptionReceived(bareJid);
+            Q_EMIT subscriptionReceived(bareJid);
         }
         break;
     default:

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -83,7 +83,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-public slots:
+public Q_SLOTS:
     bool acceptSubscription(const QString &bareJid, const QString &reason = QString());
     bool refuseSubscription(const QString &bareJid, const QString &reason = QString());
     bool addItem(const QString &bareJid, const QString &name = QString(), const QSet<QString> &groups = QSet<QString>());
@@ -92,7 +92,7 @@ public slots:
     bool subscribe(const QString &bareJid, const QString &reason = QString());
     bool unsubscribe(const QString &bareJid, const QString &reason = QString());
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the Roster IQ is received after a successful
     /// connection. That is the roster entries are empty before this signal is emitted.
     /// One should use getRosterBareJids() and getRosterEntry() only after
@@ -123,7 +123,7 @@ signals:
     /// removed as a result of roster push.
     void itemRemoved(const QString& bareJid);
 
-private slots:
+private Q_SLOTS:
     void _q_connected();
     void _q_disconnected();
     void _q_presenceReceived(const QXmppPresence&);

--- a/src/client/QXmppRpcManager.cpp
+++ b/src/client/QXmppRpcManager.cpp
@@ -166,14 +166,14 @@ bool QXmppRpcManager::handleStanza(const QDomElement &element)
     {
         QXmppRpcResponseIq rpcResponseIq;
         rpcResponseIq.parse(element);
-        emit rpcCallResponse(rpcResponseIq);
+        Q_EMIT rpcCallResponse(rpcResponseIq);
         return true;
     }
     else if(QXmppRpcErrorIq::isRpcErrorIq(element))
     {
         QXmppRpcErrorIq rpcErrorIq;
         rpcErrorIq.parse(element);
-        emit rpcCallError(rpcErrorIq);
+        Q_EMIT rpcCallError(rpcErrorIq);
         return true;
     }
     return false;

--- a/src/client/QXmppRpcManager.h
+++ b/src/client/QXmppRpcManager.h
@@ -78,7 +78,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \cond
     void rpcCallResponse(const QXmppRpcResponseIq& result);
     void rpcCallError(const QXmppRpcErrorIq &err);

--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -328,7 +328,7 @@ void QXmppTransferJob::setLocalFileUrl(const QUrl &localFileUrl)
 {
     if (localFileUrl != d->localFileUrl) {
         d->localFileUrl = localFileUrl;
-        emit localFileUrlChanged(localFileUrl);
+        Q_EMIT localFileUrlChanged(localFileUrl);
     }
 }
 
@@ -406,16 +406,16 @@ void QXmppTransferJob::setState(QXmppTransferJob::State state)
         d->state = state;
         if (d->state == QXmppTransferJob::TransferState)
             d->transferStart.start();
-        emit stateChanged(d->state);
+        Q_EMIT stateChanged(d->state);
     }
 }
 
 void QXmppTransferJob::_q_terminated()
 {
-    emit stateChanged(d->state);
+    Q_EMIT stateChanged(d->state);
     if (d->error != NoError)
-        emit error(d->error);
-    emit finished();
+        Q_EMIT error(d->error);
+    Q_EMIT finished();
 }
 
 void QXmppTransferJob::terminate(QXmppTransferJob::Error cause)
@@ -438,7 +438,7 @@ void QXmppTransferJob::terminate(QXmppTransferJob::Error cause)
         d->socksSocket->close();
     }
 
-    // emit signals later
+    // Q_EMIT signals later
     QTimer::singleShot(0, this, SLOT(_q_terminated()));
 }
 
@@ -719,7 +719,7 @@ void QXmppTransferOutgoingJob::_q_sendData()
         d->socksSocket->write(buffer, length);
         delete [] buffer;
         d->done += length;
-        emit progress(d->done, fileSize());
+        Q_EMIT progress(d->done, fileSize());
     }
 }
 /// \endcond
@@ -1219,7 +1219,7 @@ void QXmppTransferManager::_q_jobFinished()
     if (!job || !d->jobs.contains(job))
         return;
 
-    emit jobFinished(job);
+    Q_EMIT jobFinished(job);
 }
 
 void QXmppTransferManager::_q_jobStateChanged(QXmppTransferJob::State state)
@@ -1281,7 +1281,7 @@ void QXmppTransferManager::_q_jobStateChanged(QXmppTransferJob::State state)
     client()->sendPacket(response);
 
     // notify user
-    emit jobStarted(job);
+    Q_EMIT jobStarted(job);
 }
 
 /// Sends the file at \a filePath to a remote party.
@@ -1417,7 +1417,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, QIODevice *
     client()->sendPacket(request);
 
     // notify user
-    emit jobStarted(job);
+    Q_EMIT jobStarted(job);
 
     return job;
 }
@@ -1626,7 +1626,7 @@ void QXmppTransferManager::streamInitiationSetReceived(const QXmppStreamInitiati
     Q_ASSERT(check);
 
     // allow user to accept or decline the job
-    emit fileReceived(job);
+    Q_EMIT fileReceived(job);
 }
 
 /// Return the JID of the bytestream proxy to use for

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -156,7 +156,7 @@ public:
     qint64 fileSize() const;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an error is encountered while
     /// processing the transfer job.
     void error(QXmppTransferJob::Error error);
@@ -179,12 +179,12 @@ signals:
     /// This signal is emitted when the transfer job changes state.
     void stateChanged(QXmppTransferJob::State state);
 
-public slots:
+public Q_SLOTS:
     void abort();
     void accept(const QString &filePath);
     void accept(QIODevice *output);
 
-private slots:
+private Q_SLOTS:
     void _q_terminated();
 
 private:
@@ -241,7 +241,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a new file transfer offer is received.
     ///
     /// To accept the transfer job, call the job's QXmppTransferJob::accept() method.
@@ -256,7 +256,7 @@ signals:
     /// \sa QXmppTransferJob::finished()
     void jobFinished(QXmppTransferJob *job);
 
-public slots:
+public Q_SLOTS:
     QXmppTransferJob *sendFile(const QString &jid, const QString &filePath, const QString &description = QString());
     QXmppTransferJob *sendFile(const QString &jid, QIODevice *device, const QXmppTransferFileInfo &fileInfo, const QString &sid = QString());
 
@@ -265,7 +265,7 @@ protected:
     void setClient(QXmppClient* client);
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void _q_iqReceived(const QXmppIq&);
     void _q_jobDestroyed(QObject *object);
     void _q_jobError(QXmppTransferJob::Error error);

--- a/src/client/QXmppTransferManager_p.h
+++ b/src/client/QXmppTransferManager_p.h
@@ -51,7 +51,7 @@ public:
     void connectToHosts(const QXmppByteStreamIq &iq);
     bool writeData(const QByteArray &data);
 
-private slots:
+private Q_SLOTS:
     void _q_candidateDisconnected();
     void _q_candidateReady();
     void _q_disconnected();
@@ -77,7 +77,7 @@ public:
     void connectToProxy();
     void startSending();
 
-private slots:
+private Q_SLOTS:
     void _q_disconnected();
     void _q_proxyReady();
     void _q_sendData();

--- a/src/client/QXmppVCardManager.cpp
+++ b/src/client/QXmppVCardManager.cpp
@@ -117,10 +117,10 @@ bool QXmppVCardManager::handleStanza(const QDomElement &element)
         if (vCardIq.from().isEmpty()) {
             d->clientVCard = vCardIq;
             d->isClientVCardReceived = true;
-            emit clientVCardReceived();
+            Q_EMIT clientVCardReceived();
         }
 
-        emit vCardReceived(vCardIq);
+        Q_EMIT vCardReceived(vCardIq);
 
         return true;
     }

--- a/src/client/QXmppVCardManager.h
+++ b/src/client/QXmppVCardManager.h
@@ -74,7 +74,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the requested vCard is received
     /// after calling the requestVCard() function.
     void vCardReceived(const QXmppVCardIq&);

--- a/src/client/QXmppVersionManager.cpp
+++ b/src/client/QXmppVersionManager.cpp
@@ -164,8 +164,8 @@ bool QXmppVersionManager::handleStanza(const QDomElement &element)
 
             client()->sendPacket(responseIq);
         } else if (versionIq.type() == QXmppIq::Result) {
-            // emit response
-            emit versionReceived(versionIq);
+            // Q_EMIT response
+            Q_EMIT versionReceived(versionIq);
         }
 
         return true;

--- a/src/client/QXmppVersionManager.h
+++ b/src/client/QXmppVersionManager.h
@@ -57,7 +57,7 @@ public:
     bool handleStanza(const QDomElement &element);
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a version response is received.
     void versionReceived(const QXmppVersionIq&);
 

--- a/src/server/QXmppIncomingClient.cpp
+++ b/src/server/QXmppIncomingClient.cpp
@@ -337,7 +337,7 @@ void QXmppIncomingClient::handleStanza(const QDomElement &nodeRecv)
                 sendPacket(bindResult);
 
                 // bound
-                emit connected();
+                Q_EMIT connected();
                 return;
             }
             else if (QXmppSessionIq::isSessionIq(nodeRecv) && type == QLatin1String("set"))
@@ -384,8 +384,8 @@ void QXmppIncomingClient::handleStanza(const QDomElement &nodeRecv)
             if (nodeFull.attribute("to").isEmpty())
                 nodeFull.setAttribute("to", d->domain);
 
-            // emit stanza for processing by server
-            emit elementReceived(nodeFull);
+            // Q_EMIT stanza for processing by server
+            Q_EMIT elementReceived(nodeFull);
         }
     }
 }
@@ -456,7 +456,7 @@ void QXmppIncomingClient::onPasswordReply()
 void QXmppIncomingClient::onSocketDisconnected()
 {
     info(QString("Socket disconnected for '%1' from %2").arg(d->jid, d->origin()));
-    emit disconnected();
+    Q_EMIT disconnected();
 }
 
 void QXmppIncomingClient::onTimeout()

--- a/src/server/QXmppIncomingClient.h
+++ b/src/server/QXmppIncomingClient.h
@@ -50,7 +50,7 @@ public:
     void setInactivityTimeout(int secs);
     void setPasswordChecker(QXmppPasswordChecker *checker);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an element is received.
     void elementReceived(const QDomElement &element);
 
@@ -60,7 +60,7 @@ protected:
     void handleStanza(const QDomElement &element);
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void onDigestReply();
     void onPasswordReply();
     void onSocketDisconnected();

--- a/src/server/QXmppIncomingServer.cpp
+++ b/src/server/QXmppIncomingServer.cpp
@@ -170,14 +170,14 @@ void QXmppIncomingServer::handleStanza(const QDomElement &stanza)
         else if (request.command() == QXmppDialback::Verify)
         {
             debug(QString("Received a dialback verify from '%1' on %2").arg(domain, d->origin()));
-            emit dialbackRequestReceived(request);
+            Q_EMIT dialbackRequestReceived(request);
         }
 
     }
     else if (d->authenticated.contains(QXmppUtils::jidToDomain(stanza.attribute("from"))))
     {
         // relay stanza if the remote party is authenticated
-        emit elementReceived(stanza);
+        Q_EMIT elementReceived(stanza);
     } else {
         warning(QString("Received an element from unverified domain '%1' on %2").arg(QXmppUtils::jidToDomain(stanza.attribute("from")), d->origin()));
         disconnectFromHost();
@@ -223,7 +223,7 @@ void QXmppIncomingServer::slotDialbackResponseReceived(const QXmppDialback &dial
         const bool wasConnected = !d->authenticated.isEmpty();
         d->authenticated.insert(dialback.from());
         if (!wasConnected)
-            emit connected();
+            Q_EMIT connected();
     } else {
         warning(QString("Failed to verify incoming domain '%1' on %2").arg(dialback.from(), d->origin()));
         disconnectFromHost();
@@ -237,5 +237,5 @@ void QXmppIncomingServer::slotDialbackResponseReceived(const QXmppDialback &dial
 void QXmppIncomingServer::slotSocketDisconnected()
 {
     info(QString("Socket disconnected from %1").arg(d->origin()));
-    emit disconnected();
+    Q_EMIT disconnected();
 }

--- a/src/server/QXmppIncomingServer.h
+++ b/src/server/QXmppIncomingServer.h
@@ -45,7 +45,7 @@ public:
     bool isConnected() const;
     QString localStreamId() const;
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a dialback verify request is received.
     void dialbackRequestReceived(const QXmppDialback &result);
 
@@ -58,7 +58,7 @@ protected:
     void handleStream(const QDomElement &streamElement);
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void slotDialbackResponseReceived(const QXmppDialback &dialback);
     void slotSocketDisconnected();
 

--- a/src/server/QXmppOutgoingServer.cpp
+++ b/src/server/QXmppOutgoingServer.cpp
@@ -150,7 +150,7 @@ void QXmppOutgoingServer::_q_dnsLookupFinished()
 void QXmppOutgoingServer::_q_socketDisconnected()
 {
     debug("Socket disconnected");
-    emit disconnected();
+    Q_EMIT disconnected();
 }
 
 /// \cond
@@ -243,13 +243,13 @@ void QXmppOutgoingServer::handleStanza(const QDomElement &stanza)
                     sendData(data);
                 d->dataQueue.clear();
 
-                // emit signal
-                emit connected();
+                // Q_EMIT signal
+                Q_EMIT connected();
             }
         }
         else if (response.command() == QXmppDialback::Verify)
         {
-            emit dialbackResponseReceived(response);
+            Q_EMIT dialbackResponseReceived(response);
         }
 
     }
@@ -348,6 +348,6 @@ void QXmppOutgoingServer::slotSslErrors(const QList<QSslError> &errors)
 void QXmppOutgoingServer::socketError(QAbstractSocket::SocketError error)
 {
     Q_UNUSED(error);
-    emit disconnected();
+    Q_EMIT disconnected();
 }
 

--- a/src/server/QXmppOutgoingServer.h
+++ b/src/server/QXmppOutgoingServer.h
@@ -53,7 +53,7 @@ public:
 
     QString remoteDomain() const;
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a dialback verify response is received.
     void dialbackResponseReceived(const QXmppDialback &response);
 
@@ -64,11 +64,11 @@ protected:
     void handleStanza(const QDomElement &stanzaElement);
     /// \endcond
 
-public slots:
+public Q_SLOTS:
     void connectToHost(const QString &domain);
     void queueData(const QByteArray &data);
 
-private slots:
+private Q_SLOTS:
     void _q_dnsLookupFinished();
     void _q_socketDisconnected();
     void sendDialback();

--- a/src/server/QXmppPasswordChecker.cpp
+++ b/src/server/QXmppPasswordChecker.cpp
@@ -121,7 +121,7 @@ void QXmppPasswordReply::setError(QXmppPasswordReply::Error error)
 void QXmppPasswordReply::finish()
 {
     m_isFinished = true;
-    emit finished();
+    Q_EMIT finished();
 }
 
 /// Delay marking reply as finished.

--- a/src/server/QXmppPasswordChecker.h
+++ b/src/server/QXmppPasswordChecker.h
@@ -80,11 +80,11 @@ public:
 
     bool isFinished() const;
 
-public slots:
+public Q_SLOTS:
     void finish();
     void finishLater();
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the reply has finished.
     void finished();
 

--- a/src/server/QXmppServer.cpp
+++ b/src/server/QXmppServer.cpp
@@ -404,7 +404,7 @@ void QXmppServer::setLogger(QXmppLogger *logger)
                     d->logger, SLOT(updateCounter(QString,qint64)));
         }
 
-        emit loggerChanged(d->logger);
+        Q_EMIT loggerChanged(d->logger);
     }
 }
 
@@ -731,8 +731,8 @@ void QXmppServer::_q_clientConnected()
     d->incomingClientsByJid.insert(jid, client);
     d->incomingClientsByBareJid[QXmppUtils::jidToBareJid(jid)].insert(client);
 
-    // emit signal
-    emit clientConnected(jid);
+    // Q_EMIT signal
+    Q_EMIT clientConnected(jid);
 }
 
 /// Handle a stream disconnection for a client.
@@ -760,9 +760,9 @@ void QXmppServer::_q_clientDisconnected()
         // destroy client
         client->deleteLater();
 
-        // emit signal
+        // Q_EMIT signal
         if (!jid.isEmpty())
-            emit clientDisconnected(jid);
+            Q_EMIT clientDisconnected(jid);
 
         // update counter
         setGauge("incoming-client.count", d->incomingClients.size());
@@ -909,7 +909,7 @@ void QXmppSslServer::incomingConnection(qintptr socketDescriptor)
         socket->setLocalCertificate(d->localCertificate);
         socket->setPrivateKey(d->privateKey);
     }
-    emit newConnection(socket);
+    Q_EMIT newConnection(socket);
 }
 
 /// Adds the given certificates to the CA certificate database to be used

--- a/src/server/QXmppServer.h
+++ b/src/server/QXmppServer.h
@@ -94,7 +94,7 @@ public:
 
     void addIncomingClient(QXmppIncomingClient *stream);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a client has connected.
     void clientConnected(const QString &jid);
 
@@ -104,10 +104,10 @@ signals:
     /// This signal is emitted when the logger changes.
     void loggerChanged(QXmppLogger *logger);
 
-public slots:
+public Q_SLOTS:
     void handleElement(const QDomElement &element);
 
-private slots:
+private Q_SLOTS:
     void _q_clientConnection(QSslSocket *socket);
     void _q_clientConnected();
     void _q_clientDisconnected();
@@ -138,7 +138,7 @@ public:
     void setLocalCertificate(const QSslCertificate &certificate);
     void setPrivateKey(const QSslKey &key);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a new connection is established.
     void newConnection(QSslSocket *socket);
 

--- a/tests/qxmpparchiveiq/tst_qxmpparchiveiq.cpp
+++ b/tests/qxmpparchiveiq/tst_qxmpparchiveiq.cpp
@@ -29,7 +29,7 @@ class tst_QXmppArchiveIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testArchiveList_data();
     void testArchiveList();
     void testArchiveChat_data();

--- a/tests/qxmppbindiq/tst_qxmppbindiq.cpp
+++ b/tests/qxmppbindiq/tst_qxmppbindiq.cpp
@@ -30,7 +30,7 @@ class tst_QXmppBindIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testNoResource();
     void testResource();
     void testResult();

--- a/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
+++ b/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
@@ -35,7 +35,7 @@ class tst_QXmppCallManager : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void init();
     void testCall();
 

--- a/tests/qxmppcarbonmanager/tst_qxmppcarbonmanager.cpp
+++ b/tests/qxmppcarbonmanager/tst_qxmppcarbonmanager.cpp
@@ -31,7 +31,7 @@ class QXmppCarbonTestHelper  : public QObject
 {
     Q_OBJECT
 
-public slots:
+public Q_SLOTS:
     void messageSent(const QXmppMessage& msg);
     void messageReceived(const QXmppMessage& msg);
 
@@ -47,7 +47,7 @@ class tst_QXmppCarbonManager : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void initTestCase();
 
     void testHandleStanza_data();

--- a/tests/qxmppcodec/tst_qxmppcodec.cpp
+++ b/tests/qxmppcodec/tst_qxmppcodec.cpp
@@ -29,7 +29,7 @@ class tst_QXmppCodec : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testTheoraDecoder();
     void testTheoraEncoder();
 };

--- a/tests/qxmppdataform/tst_qxmppdataform.cpp
+++ b/tests/qxmppdataform/tst_qxmppdataform.cpp
@@ -30,7 +30,7 @@ class tst_QXmppDataForm : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testSimple();
     void testSubmit();
     void testMedia();

--- a/tests/qxmppdiscoveryiq/tst_qxmppdiscoveryiq.cpp
+++ b/tests/qxmppdiscoveryiq/tst_qxmppdiscoveryiq.cpp
@@ -30,7 +30,7 @@ class tst_QXmppDiscoveryIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testDiscovery();
     void testDiscoveryWithForm();
 };

--- a/tests/qxmppentitytimeiq/tst_qxmppentitytimeiq.cpp
+++ b/tests/qxmppentitytimeiq/tst_qxmppentitytimeiq.cpp
@@ -30,7 +30,7 @@ class tst_QXmppEntityTimeIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testEntityTimeGet();
     void testEntityTimeResult();
 };

--- a/tests/qxmppiceconnection/tst_qxmppiceconnection.cpp
+++ b/tests/qxmppiceconnection/tst_qxmppiceconnection.cpp
@@ -29,7 +29,7 @@ class tst_QXmppIceConnection : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testBind();
     void testBindStun();
     void testConnect();

--- a/tests/qxmppiq/tst_qxmppiq.cpp
+++ b/tests/qxmppiq/tst_qxmppiq.cpp
@@ -30,7 +30,7 @@ class tst_QXmppIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testBasic_data();
     void testBasic();
 };

--- a/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
+++ b/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
@@ -29,7 +29,7 @@ class tst_QXmppJingleIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testCandidate();
     void testContent();
     void testContentFingerprint();

--- a/tests/qxmppmammanager/tst_qxmppmammanager.cpp
+++ b/tests/qxmppmammanager/tst_qxmppmammanager.cpp
@@ -30,7 +30,7 @@ class QXmppMamTestHelper  : public QObject
 {
     Q_OBJECT
 
-public slots:
+public Q_SLOTS:
     void archivedMessageReceived(const QString &queryId, const QXmppMessage &message);
     void resultsRecieved(const QString &queryId, const QXmppResultSetReply &resultSetReply, bool complete);
 
@@ -49,7 +49,7 @@ class tst_QXmppMamManager : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void initTestCase();
 
     void testHandleStanza_data();

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -30,7 +30,7 @@ class tst_QXmppMessage : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testBasic_data();
     void testBasic();
     void testMessageAttention();

--- a/tests/qxmppnonsaslauthiq/tst_qxmppnonsaslauthiq.cpp
+++ b/tests/qxmppnonsaslauthiq/tst_qxmppnonsaslauthiq.cpp
@@ -29,7 +29,7 @@ class tst_QXmppNonSASLAuthIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testGet();
     void testSetPlain();
     void testSetDigest();

--- a/tests/qxmpppresence/tst_qxmpppresence.cpp
+++ b/tests/qxmpppresence/tst_qxmpppresence.cpp
@@ -32,7 +32,7 @@ class tst_QXmppPresence : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testPresence();
     void testPresence_data();
     void testPresenceWithCapability();

--- a/tests/qxmpppubsubiq/tst_qxmpppubsubiq.cpp
+++ b/tests/qxmpppubsubiq/tst_qxmpppubsubiq.cpp
@@ -29,7 +29,7 @@ class tst_QXmppPubSubIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testItems();
     void testItemsResponse();
     void testPublish();

--- a/tests/qxmppregisteriq/tst_qxmppregisteriq.cpp
+++ b/tests/qxmppregisteriq/tst_qxmppregisteriq.cpp
@@ -29,7 +29,7 @@ class tst_QXmppRegisterIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testGet();
     void testResult();
     void testResultWithForm();

--- a/tests/qxmppresultset/tst_qxmppresultset.cpp
+++ b/tests/qxmppresultset/tst_qxmppresultset.cpp
@@ -30,7 +30,7 @@ class tst_QXmppResultSet : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testQuery_data();
     void testQuery();
     void testReply_data();

--- a/tests/qxmpprosteriq/tst_qxmpprosteriq.cpp
+++ b/tests/qxmpprosteriq/tst_qxmpprosteriq.cpp
@@ -29,7 +29,7 @@ class tst_QXmppRosterIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testItem_data();
     void testItem();
 };

--- a/tests/qxmpprpciq/tst_qxmpprpciq.cpp
+++ b/tests/qxmpprpciq/tst_qxmpprpciq.cpp
@@ -52,7 +52,7 @@ class tst_QXmppRpcIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testBase64();
     void testBool();
     void testDateTime();

--- a/tests/qxmpprtcppacket/tst_qxmpprtcppacket.cpp
+++ b/tests/qxmpprtcppacket/tst_qxmpprtcppacket.cpp
@@ -29,7 +29,7 @@ class tst_QXmppRtcpPacket : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testBad();
     void testGoodbye();
     void testGoodbyeWithReason();

--- a/tests/qxmpprtppacket/tst_qxmpprtppacket.cpp
+++ b/tests/qxmpprtppacket/tst_qxmpprtppacket.cpp
@@ -29,7 +29,7 @@ class tst_QXmppRtpPacket : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testBad();
     void testSimple();
     void testWithCsrc();

--- a/tests/qxmppsasl/tst_qxmppsasl.cpp
+++ b/tests/qxmppsasl/tst_qxmppsasl.cpp
@@ -29,7 +29,7 @@ class tst_QXmppSasl : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testParsing();
     void testAuth_data();
     void testAuth();

--- a/tests/qxmppserver/tst_qxmppserver.cpp
+++ b/tests/qxmppserver/tst_qxmppserver.cpp
@@ -29,7 +29,7 @@ class tst_QXmppServer : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testConnect_data();
     void testConnect();
 };

--- a/tests/qxmppsessioniq/tst_qxmppsessioniq.cpp
+++ b/tests/qxmppsessioniq/tst_qxmppsessioniq.cpp
@@ -29,7 +29,7 @@ class TestPackets : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testSession();
 };
 

--- a/tests/qxmppsocks/tst_qxmppsocks.cpp
+++ b/tests/qxmppsocks/tst_qxmppsocks.cpp
@@ -30,7 +30,7 @@ class tst_QXmppSocks : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void init();
     void newConnectionSlot(QTcpSocket *socket, QString hostName, quint16 port);
 

--- a/tests/qxmppstanza/tst_qxmppstanza.cpp
+++ b/tests/qxmppstanza/tst_qxmppstanza.cpp
@@ -29,7 +29,7 @@ class tst_QXmppStanza : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testExtendedAddress_data();
     void testExtendedAddress();
 };

--- a/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
+++ b/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
@@ -28,7 +28,7 @@ class tst_QXmppStreamFeatures : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testEmpty();
     void testFull();
 };

--- a/tests/qxmppstreaminitiationiq/tst_qxmppstreaminitiationiq.cpp
+++ b/tests/qxmppstreaminitiationiq/tst_qxmppstreaminitiationiq.cpp
@@ -30,7 +30,7 @@ class tst_QXmppStreamInitiationIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testFileInfo_data();
     void testFileInfo();
     void testOffer();

--- a/tests/qxmppstunmessage/tst_qxmppstunmessage.cpp
+++ b/tests/qxmppstunmessage/tst_qxmppstunmessage.cpp
@@ -29,7 +29,7 @@ class tst_QXmppStunMessage : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testFingerprint();
     void testIntegrity();
     void testIPv4Address();

--- a/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
+++ b/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
@@ -35,7 +35,7 @@ class tst_QXmppTransferManager : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void init();
     void testSendFile_data();
     void testSendFile();

--- a/tests/qxmpputils/tst_qxmpputils.cpp
+++ b/tests/qxmpputils/tst_qxmpputils.cpp
@@ -30,7 +30,7 @@ class tst_QXmppUtils : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testCrc32();
     void testHmac();
     void testJid();

--- a/tests/qxmppvcardiq/tst_qxmppvcardiq.cpp
+++ b/tests/qxmppvcardiq/tst_qxmppvcardiq.cpp
@@ -29,7 +29,7 @@ class tst_QXmppVCardIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testAddress_data();
     void testAddress();
     void testEmail_data();

--- a/tests/qxmppversioniq/tst_qxmppversioniq.cpp
+++ b/tests/qxmppversioniq/tst_qxmppversioniq.cpp
@@ -30,7 +30,7 @@ class tst_QXmppVersionIq : public QObject
 {
     Q_OBJECT
 
-private slots:
+private Q_SLOTS:
     void testVersionGet();
     void testVersionResult();
 };


### PR DESCRIPTION
Dear QXMPP-ers,

I'm proposing a patch to switch to a QT_NO_KEYWORDS paradigm when using Qt in QXMPP. I had to use such a modified version in order to use QXMPP for enhancing LyX with chat capabilities:
http://www.lyx.org/trac/ticket/7964

Unfortunately, using the regular QXMPP header files clashes with boost libraries, whilst switching to the Q_\* variant (which is a Qt supported syntax anyway) makes it possible & smooth to use QXMPP along with boost libraries. This seems a good thing, in terms of usability of your library within other projects. Please, let me know what you think!

Thanks & keep up with the excellent work :-)!
