### PR TITLE
Fix : MUC Room joined signal can not be emitted

### DIFF
--- a/src/client/QXmppMucManager.cpp
+++ b/src/client/QXmppMucManager.cpp
@@ -75,10 +75,10 @@ QXmppMucManager::~QXmppMucManager()
 
 QXmppMucRoom *QXmppMucManager::addRoom(const QString &roomJid)
 {
-    QXmppMucRoom *room = d->rooms.value(roomJid);
+    QXmppMucRoom *room = d->rooms.value(roomJid.toLower());
     if (!room) {
-        room = new QXmppMucRoom(client(), roomJid, this);
-        d->rooms.insert(roomJid, room);
+        room = new QXmppMucRoom(client(), roomJid.toLower(), this);
+        d->rooms.insert(roomJid.toLower(), room);
         connect(room, SIGNAL(destroyed(QObject*)),
             this, SLOT(_q_roomDestroyed(QObject*)));
 


### PR DESCRIPTION
All names in qmpp are received in lower cases and hence MUC room names should also be converted to lower case while they are being created. If user creates a room having any capital letter and requests to join the room, joined signal is not emitted because of the mismatch between cases, This code fixes the bug where joined() signal is not emitted even after room->join API is invoked.