### PR TITLE
Set Stream Management to disabled when the socket becomes ready

### DIFF
--- a/src/base/QXmppStream.cpp
+++ b/src/base/QXmppStream.cpp
@@ -112,6 +112,7 @@ void QXmppStream::disconnectFromHost()
 
 void QXmppStream::handleStart()
 {
+    d->streamManagementEnabled = false;
     d->dataBuffer.clear();
     d->streamStart.clear();
 }


### PR DESCRIPTION
This is important for reconnects.

It fixes the latest discussion in https://github.com/qxmpp-project/qxmpp/issues/66