### PR TITLE
Clang warnings fixed

### DIFF
--- a/src/base/QXmppCodec.cpp
+++ b/src/base/QXmppCodec.cpp
@@ -397,7 +397,6 @@ qint64 QXmppSpeexCodec::decode(QDataStream &input, QDataStream &output)
 
 #ifdef QXMPP_USE_OPUS
 QXmppOpusCodec::QXmppOpusCodec(int clockrate, int channels):
-    sampleRate(clockrate),
     nChannels(channels)
 {
     int error;
@@ -415,7 +414,7 @@ QXmppOpusCodec::QXmppOpusCodec(int clockrate, int channels):
     else
         qCritical() << "Opus encoder initialization error:" << opus_strerror(error);
 
-    // Here, clockrate is synonym of sampleRate.
+    // Here, clockrate is synonym of sample rate.
     decoder = opus_decoder_create(clockrate, channels, &error);
 
     if (!encoder || error != OPUS_OK)
@@ -429,7 +428,7 @@ QXmppOpusCodec::QXmppOpusCodec(int clockrate, int channels):
     // so now, calculate the equivalent number of samples to process in each
     // frame.
     //
-    // nSamples = t * sampleRate
+    // nSamples = t * clockrate
     for (int i = 0; i < validFrameSize.size(); i++)
         validFrameSize[i] *= clockrate;
 

--- a/src/base/QXmppCodec_p.h
+++ b/src/base/QXmppCodec_p.h
@@ -128,7 +128,6 @@ public:
 private:
     OpusEncoder *encoder;
     OpusDecoder *decoder;
-    int sampleRate;
     int nChannels;
     QList<float> validFrameSize;
     int nSamples;

--- a/src/base/QXmppSocks.cpp
+++ b/src/base/QXmppSocks.cpp
@@ -108,7 +108,7 @@ QXmppSocksClient::QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, 
     connect(this, SIGNAL(readyRead()), this, SLOT(slotReadyRead()));
 }
 
-void QXmppSocksClient::connectToHost(const QString &hostName, quint16 hostPort)
+void QXmppSocksClient::establishConnection(const QString &hostName, quint16 hostPort)
 {
     m_hostName = hostName;
     m_hostPort = hostPort;

--- a/src/base/QXmppSocks.h
+++ b/src/base/QXmppSocks.h
@@ -37,7 +37,7 @@ class QXMPP_EXPORT QXmppSocksClient : public QTcpSocket
 
 public:
     QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, QObject *parent=0);
-    void connectToHost(const QString &hostName, quint16 hostPort);
+    void establishConnection(const QString &hostName, quint16 hostPort);
 
 signals:
     void ready();

--- a/src/client/QXmppCallManager.cpp
+++ b/src/client/QXmppCallManager.cpp
@@ -87,7 +87,7 @@ private:
 class QXmppCallManagerPrivate
 {
 public:
-    QXmppCallManagerPrivate(QXmppCallManager *qq);
+    QXmppCallManagerPrivate();
     QXmppCall *findCall(const QString &sid) const;
     QXmppCall *findCall(const QString &sid, QXmppCall::Direction direction) const;
 
@@ -98,9 +98,6 @@ public:
     quint16 turnPort;
     QString turnUser;
     QString turnPassword;
-
-private:
-    QXmppCallManager *q;
 };
 
 QXmppCallPrivate::QXmppCallPrivate(QXmppCall *qq)
@@ -691,10 +688,9 @@ void QXmppCall::stopVideo()
         updateOpenMode();
 }
 
-QXmppCallManagerPrivate::QXmppCallManagerPrivate(QXmppCallManager *qq)
+QXmppCallManagerPrivate::QXmppCallManagerPrivate()
     : stunPort(0),
-    turnPort(0),
-    q(qq)
+    turnPort(0)
 {
 }
 
@@ -719,8 +715,8 @@ QXmppCall *QXmppCallManagerPrivate::findCall(const QString &sid, QXmppCall::Dire
 ///
 
 QXmppCallManager::QXmppCallManager()
+    : d(new QXmppCallManagerPrivate())
 {
-    d = new QXmppCallManagerPrivate(this);
 }
 
 /// Destroys the QXmppCallManager object.

--- a/src/client/QXmppRosterManager.cpp
+++ b/src/client/QXmppRosterManager.cpp
@@ -33,7 +33,7 @@
 class QXmppRosterManagerPrivate
 {
 public:
-    QXmppRosterManagerPrivate(QXmppRosterManager *qq);
+    QXmppRosterManagerPrivate();
 
     // map of bareJid and its rosterEntry
     QMap<QString, QXmppRosterIq::Item> entries;
@@ -46,25 +46,20 @@ public:
 
     // id of the initial roster request
     QString rosterReqId;
-
-private:
-    QXmppRosterManager *q;
 };
 
-QXmppRosterManagerPrivate::QXmppRosterManagerPrivate(QXmppRosterManager *qq)
-    : isRosterReceived(false),
-    q(qq)
+QXmppRosterManagerPrivate::QXmppRosterManagerPrivate()
+    : isRosterReceived(false)
 {
 }
 
 /// Constructs a roster manager.
 
 QXmppRosterManager::QXmppRosterManager(QXmppClient* client)
+    : d(new QXmppRosterManagerPrivate())
 {
     bool check;
     Q_UNUSED(check);
-
-    d = new QXmppRosterManagerPrivate(this);
 
     check = connect(client, SIGNAL(connected()),
                     this, SLOT(_q_connected()));

--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -508,7 +508,7 @@ void QXmppTransferIncomingJob::connectToNextHost()
 
     m_candidateTimer->setSingleShot(true);
     m_candidateTimer->start(socksTimeout);
-    m_candidateClient->connectToHost(hostName, 0);
+    m_candidateClient->establishConnection(hostName, 0);
 }
 
 void QXmppTransferIncomingJob::connectToHosts(const QXmppByteStreamIq &iq)
@@ -644,7 +644,7 @@ void QXmppTransferOutgoingJob::connectToProxy()
     Q_ASSERT(check);
 
     d->socksSocket = socksClient;
-    socksClient->connectToHost(hostName, 0);
+    socksClient->establishConnection(hostName, 0);
 }
 
 void QXmppTransferOutgoingJob::startSending()
@@ -727,7 +727,7 @@ void QXmppTransferOutgoingJob::_q_sendData()
 class QXmppTransferManagerPrivate
 {
 public:
-    QXmppTransferManagerPrivate(QXmppTransferManager *qq);
+    QXmppTransferManagerPrivate();
 
     QXmppTransferIncomingJob *getIncomingJobByRequestId(const QString &jid, const QString &id);
     QXmppTransferIncomingJob *getIncomingJobBySid(const QString &jid, const QString &sid);
@@ -742,15 +742,13 @@ public:
 
 private:
     QXmppTransferJob *getJobByRequestId(QXmppTransferJob::Direction direction, const QString &jid, const QString &id);
-    QXmppTransferManager *q;
 };
 
-QXmppTransferManagerPrivate::QXmppTransferManagerPrivate(QXmppTransferManager *qq)
+QXmppTransferManagerPrivate::QXmppTransferManagerPrivate()
     : ibbBlockSize(4096)
     , proxyOnly(false)
     , socksServer(0)
     , supportedMethods(QXmppTransferJob::AnyMethod)
-    , q(qq)
 {
 }
 
@@ -788,11 +786,10 @@ QXmppTransferOutgoingJob *QXmppTransferManagerPrivate::getOutgoingJobByRequestId
 /// file transfers.
 
 QXmppTransferManager::QXmppTransferManager()
+    : d(new QXmppTransferManagerPrivate())
 {
     bool check;
     Q_UNUSED(check);
-
-    d = new QXmppTransferManagerPrivate(this);
 
     // start SOCKS server
     d->socksServer = new QXmppSocksServer(this);

--- a/tests/qxmppsocks/tst_qxmppsocks.cpp
+++ b/tests/qxmppsocks/tst_qxmppsocks.cpp
@@ -104,7 +104,7 @@ void tst_QXmppSocks::testClient()
     QEventLoop loop;
     connect(&server, SIGNAL(newConnection()), &loop, SLOT(quit()));
 
-    client.connectToHost("www.google.com", 80);
+    client.establishConnection("www.google.com", 80);
     loop.exec();
 
     // receive client handshake
@@ -163,7 +163,7 @@ void tst_QXmppSocks::testClientAndServer()
     QEventLoop loop;
     connect(&client, SIGNAL(ready()), &loop, SLOT(quit()));
   
-    client.connectToHost("www.google.com", 80);
+    client.establishConnection("www.google.com", 80);
     loop.exec();
 
     // check client


### PR DESCRIPTION
- Unused fields removed in private implementation classes.
- `connectToHost `method of `QXmppSocksClient `renamed, to avoid hiding simular methods of the base class.