### PR TITLE
CMake: Add binary paths for tests to the include paths

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src/base)
 include_directories(${PROJECT_SOURCE_DIR}/src/client)
 include_directories(${PROJECT_SOURCE_DIR}/src/server)
 include_directories(${PROJECT_BINARY_DIR}/src/base)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_simple_test(qxmpparchiveiq)
 add_simple_test(qxmppbindiq)

--- a/tests/qxmpptransfermanager/CMakeLists.txt
+++ b/tests/qxmpptransfermanager/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_executable(tst_qxmpptransfermanager tst_qxmpptransfermanager.cpp tst_qxmpptransfermanager.qrc)
 add_test(tst_qxmpptransfermanager tst_qxmpptransfermanager)
 target_link_libraries(tst_qxmpptransfermanager Qt5::Test qxmpp)

--- a/tests/qxmpputils/CMakeLists.txt
+++ b/tests/qxmpputils/CMakeLists.txt
@@ -1,3 +1,4 @@
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 add_executable(tst_qxmpputils tst_qxmpputils.cpp tst_qxmpputils.qrc)
 add_test(tst_qxmpputils tst_qxmpputils)
 target_link_libraries(tst_qxmpputils Qt5::Test qxmpp)


### PR DESCRIPTION
This PR contains three small fixes for the CMake build system.