### PR TITLE
CMake: Use CMakePackageConfigHelpers to generate the package config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,23 @@ if(BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    QXmppConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/QXmppConfig.cmake
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/qxmpp"
+)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/QXmppConfigVersion.cmake
+    VERSION ${VERSION_STRING}
+    COMPATIBILITY SameMajorVersion
+)
+
 install(
-    FILES QXmppConfig.cmake
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/QXmppConfig.cmake
+          ${CMAKE_CURRENT_BINARY_DIR}/QXmppConfigVersion.cmake
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/qxmpp"
     COMPONENT Devel
 )

--- a/QXmppConfig.cmake
+++ b/QXmppConfig.cmake
@@ -1,3 +1,0 @@
-find_package(Qt5 REQUIRED COMPONENTS Core Network Xml)
-
-include("${CMAKE_CURRENT_LIST_DIR}/QXmpp.cmake")

--- a/QXmppConfig.cmake.in
+++ b/QXmppConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/QXmpp.cmake")
+check_required_components(QXmpp)
+


### PR DESCRIPTION
Now we also generate a QXmppConfigVersion.cmake file.

This allows other applications to depend on a specific (or minimum) version of QXmpp.