### PR TITLE
travis: Only use system binaries

### DIFF
--- a/tests/travis/build-and-test
+++ b/tests/travis/build-and-test
@@ -15,9 +15,13 @@ case "$CONFIG" in
     ;;
 esac
 
-# pick up cmake files from homebrew
 if [ "$(uname -s)" = "Darwin" ]; then
+    # pick up cmake files from homebrew
     CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5"
+else
+    # This hides all the paths that contain custom travis binaries like the
+    # updated version of cmake.
+    export PATH=/usr/sbin:/usr/bin:/sbin:/bin
 fi
 
 # build with code coverage

--- a/tests/travis/install-build-depends
+++ b/tests/travis/install-build-depends
@@ -12,7 +12,7 @@ if [ "$(uname -s)" = "Darwin" ]; then
     esac
 else
     sudo apt-get update -qq
-    sudo apt-get install -qq cmake qtbase5-dev
+    sudo apt-get install -qq clang cmake qtbase5-dev
 
     case "$CONFIG" in
     full*)


### PR DESCRIPTION
With this change we will use the CMake version provided by Ubuntu Xenial and not the updated one from Travis.