### PR TITLE
Add partial support of XEP-0066: Out of Band Data

### DIFF
--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -57,6 +57,8 @@ const char* ns_vcard = "vcard-temp";
 const char* ns_rsm = "http://jabber.org/protocol/rsm";
 // XEP-0065: SOCKS5 Bytestreams
 const char* ns_bytestreams = "http://jabber.org/protocol/bytestreams";
+// XEP-0066: Out of Band Data
+const char* ns_oob = "jabber:x:oob";
 // XEP-0071: XHTML-IM
 const char *ns_xhtml_im = "http://jabber.org/protocol/xhtml-im";
 // XEP-0077: In-Band Registration

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -69,6 +69,8 @@ extern const char* ns_vcard;
 extern const char* ns_rsm;
 // XEP-0065: SOCKS5 Bytestreams
 extern const char* ns_bytestreams;
+// XEP-0066: Out of Band Data
+extern const char* ns_oob;
 // XEP-0071: XHTML-IM
 extern const char *ns_xhtml_im;
 // XEP-0077: In-Band Registration

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -96,6 +96,9 @@ public:
 
     // XEP-0280: Message Carbons
     bool privatemsg;
+
+    // XEP-0066: Out of Band Data
+    QString outOfBandUrl;
 };
 
 /// Constructs a QXmppMessage.
@@ -475,6 +478,20 @@ bool QXmppMessage::isXmppStanza() const
     return true;
 }
 
+/// Returns a possibly attached URL from XEP-0066: Out of Band Data
+
+QString QXmppMessage::outOfBandUrl() const
+{
+    return d->outOfBandUrl;
+}
+
+/// Sets the attached URL for XEP-0066: Out of Band Data
+
+void QXmppMessage::setOutOfBandUrl(const QString &url)
+{
+    d->outOfBandUrl = url;
+}
+
 /// \cond
 void QXmppMessage::parse(const QDomElement &element)
 {
@@ -604,6 +621,9 @@ void QXmppMessage::parse(const QDomElement &element)
                 d->mucInvitationJid = xElement.attribute("jid");
                 d->mucInvitationPassword = xElement.attribute("password");
                 d->mucInvitationReason = xElement.attribute("reason");
+            } else if (xElement.namespaceURI() == ns_oob) {
+                // XEP-0066: Out of Band Data
+                d->outOfBandUrl = xElement.firstChildElement("url").text();
             }
             else {
                 extensions << QXmppElement(xElement);
@@ -726,6 +746,14 @@ void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
     if (d->privatemsg) {
         xmlWriter->writeStartElement("private");
         xmlWriter->writeAttribute("xmlns", ns_carbons);
+        xmlWriter->writeEndElement();
+    }
+
+    // XEP-0066: Out of Band Data
+    if (!d->outOfBandUrl.isEmpty()) {
+        xmlWriter->writeStartElement("x");
+        xmlWriter->writeAttribute("xmlns", ns_oob);
+        xmlWriter->writeTextElement("url", d->outOfBandUrl);
         xmlWriter->writeEndElement();
     }
 

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -135,6 +135,10 @@ public:
 
     bool isXmppStanza() const;
 
+    // XEP-0066: Out of Band Data
+    QString outOfBandUrl() const;
+    void setOutOfBandUrl(const QString&);
+
     /// \cond
     void parse(const QDomElement &element);
     void toXml(QXmlStreamWriter *writer) const;

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -46,6 +46,7 @@ private slots:
     void testSubextensions();
     void testChatMarkers();
     void testPrivateMessage();
+    void testOutOfBandUrl();
 };
 
 void tst_QXmppMessage::testBasic_data()
@@ -567,6 +568,33 @@ void tst_QXmppMessage::testPrivateMessage()
     QXmlStreamWriter writer(&buffer);
     privateMessage.toXml(&writer);
     QVERIFY(!buffer.data().contains("private"));
+}
+
+void tst_QXmppMessage::testOutOfBandUrl()
+{
+    const QByteArray oobXml(
+        "<message to=\"MaineBoy@jabber.org/home\" "
+                 "from=\"stpeter@jabber.org/work\" "
+                 "type=\"chat\">"
+            "<body>Yeah, but do you have a license to Jabber?</body>"
+            "<x xmlns=\"jabber:x:oob\">"
+                "<url>http://www.jabber.org/images/psa-license.jpg</url>"
+            "</x>"
+        "</message>"
+    );
+    const QString firstUrl = "http://www.jabber.org/images/psa-license.jpg";
+    const QString newUrl = "https://xmpp.org/theme/images/xmpp-logo.svg";
+
+    QXmppMessage oobMessage;
+    parsePacket(oobMessage, oobXml);
+    QCOMPARE(oobMessage.outOfBandUrl(), firstUrl);
+
+    oobMessage.setOutOfBandUrl(newUrl);
+    QCOMPARE(oobMessage.outOfBandUrl(), newUrl);
+
+    // set first url again
+    oobMessage.setOutOfBandUrl(firstUrl);
+    serializePacket(oobMessage, oobXml);
 }
 
 QTEST_MAIN(tst_QXmppMessage)


### PR DESCRIPTION
Today this is most important for attaching URLs generated by XEP-0363:
HTTP File Upload for a very basic form of media/file sharing.

The defined IQ protocol has not been implemented.