### PR TITLE
Use QSysInfo for client OS in VersionManager

### DIFF
--- a/src/client/QXmppDiscoveryManager.cpp
+++ b/src/client/QXmppDiscoveryManager.cpp
@@ -48,7 +48,11 @@ QXmppDiscoveryManager::QXmppDiscoveryManager()
 {
     d->clientCapabilitiesNode = "https://github.com/qxmpp-project/qxmpp";
     d->clientCategory = "client";
+#if defined Q_OS_ANDROID || defined Q_OS_BLACKBERRY || defined Q_OS_IOS || defined Q_OS_WP
+    d->clientType = "phone";
+#else
     d->clientType = "pc";
+#endif
     if (qApp->applicationName().isEmpty() && qApp->applicationVersion().isEmpty())
         d->clientName = QString("%1 %2").arg("Based on QXmpp", QXmppVersion());
     else
@@ -212,7 +216,8 @@ QString QXmppDiscoveryManager::clientCategory() const
 
 /// Returns the type of the local XMPP client.
 ///
-/// By default this is "pc".
+/// With Qt builds for Android, Blackberry, iOS or Windows Phone this is set to
+/// "phone", otherwise it defaults to "pc".
 
 QString QXmppDiscoveryManager::clientType() const
 {

--- a/src/client/QXmppVersionManager.cpp
+++ b/src/client/QXmppVersionManager.cpp
@@ -23,6 +23,9 @@
 
 #include <QCoreApplication>
 #include <QDomElement>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+#include <QSysInfo>
+#endif
 
 #include "QXmppClient.h"
 #include "QXmppConstants_p.h"
@@ -45,7 +48,9 @@ QXmppVersionManager::QXmppVersionManager()
     if (d->clientName.isEmpty())
         d->clientName = "Based on QXmpp";
 
-#if defined(Q_OS_LINUX)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    d->clientOs = QSysInfo::prettyProductName();
+#elif defined(Q_OS_LINUX)
     d->clientOs = QString::fromLatin1("Linux");
 #elif defined(Q_OS_MAC)
     d->clientOs = QString::fromLatin1("Mac OS");
@@ -129,8 +134,8 @@ QString QXmppVersionManager::clientVersion() const
 
 /// Returns the local XMPP client's operating system.
 ///
-/// By default this is "Linux", "Mac OS", "Symbian" or "Windows" depending
-/// on the platform QXmpp was compiled for.
+/// By default this equals to QSysInfo::prettyProductName() which contains the
+/// OS name and version (e.g. "Windows 8.1" or "Debian GNU/Linux buster").
 
 QString QXmppVersionManager::clientOs() const
 {


### PR DESCRIPTION
The QXmppVersionManager will use QSysInfo in Qt 5.4 or later to
determine the client's OS, so it will also contain the OS version or
some codenames.