### PR TITLE
[sasl] order mechanisms to prefer the most secure

### DIFF
--- a/src/base/QXmppSasl.cpp
+++ b/src/base/QXmppSasl.cpp
@@ -272,8 +272,8 @@ QXmppSaslClient::~QXmppSaslClient()
 
 QStringList QXmppSaslClient::availableMechanisms()
 {
-    return QStringList() << "PLAIN" << "DIGEST-MD5" << "ANONYMOUS"
-                         << "SCRAM-SHA-1" << "SCRAM-SHA-256"
+    return QStringList() << "SCRAM-SHA-256" << "SCRAM-SHA-1" << "DIGEST-MD5"
+                         << "PLAIN" << "ANONYMOUS"
                          << "X-FACEBOOK-PLATFORM" << "X-MESSENGER-OAUTH2" << "X-OAUTH2";
 }
 

--- a/src/client/QXmppConfiguration.cpp
+++ b/src/client/QXmppConfiguration.cpp
@@ -90,7 +90,6 @@ QXmppConfigurationPrivate::QXmppConfigurationPrivate()
     , ignoreSslErrors(false)
     , streamSecurityMode(QXmppConfiguration::TLSEnabled)
     , nonSASLAuthMechanism(QXmppConfiguration::NonSASLDigest)
-    , saslAuthMechanism("DIGEST-MD5")
 {
 }
 
@@ -501,8 +500,6 @@ void QXmppConfiguration::setNonSASLAuthMechanism(
 }
 
 /// Returns the preferred SASL authentication mechanism.
-///
-/// Default value: "DIGEST-MD5"
 
 QString QXmppConfiguration::saslAuthMechanism() const
 {
@@ -511,7 +508,8 @@ QString QXmppConfiguration::saslAuthMechanism() const
 
 /// Sets the preferred SASL authentication \a mechanism.
 ///
-/// Valid values: "PLAIN", "DIGEST-MD5", "ANONYMOUS", "X-FACEBOOK-PLATFORM"
+/// Valid values: "SCRAM-SHA-256", "SCRAM-SHA-1", "DIGEST-MD5", "PLAIN", "ANONYMOUS",
+//                "X-FACEBOOK-PLATFORM", "X-MESSENGER-OAUTH2", "X-OAUTH2"
 
 void QXmppConfiguration::setSaslAuthMechanism(const QString &mechanism)
 {

--- a/tests/qxmppsasl/tst_qxmppsasl.cpp
+++ b/tests/qxmppsasl/tst_qxmppsasl.cpp
@@ -189,7 +189,7 @@ void tst_QXmppSasl::testSuccess()
 
 void tst_QXmppSasl::testClientAvailableMechanisms()
 {
-    QCOMPARE(QXmppSaslClient::availableMechanisms(), QStringList() << "PLAIN" << "DIGEST-MD5" << "ANONYMOUS" << "SCRAM-SHA-1" << "SCRAM-SHA-256" << "X-FACEBOOK-PLATFORM" << "X-MESSENGER-OAUTH2" << "X-OAUTH2");
+    QCOMPARE(QXmppSaslClient::availableMechanisms(), QStringList() << "SCRAM-SHA-256" << "SCRAM-SHA-1" << "DIGEST-MD5" << "PLAIN" << "ANONYMOUS" << "X-FACEBOOK-PLATFORM" << "X-MESSENGER-OAUTH2" << "X-OAUTH2");
 }
 
 void tst_QXmppSasl::testClientBadMechanism()


### PR DESCRIPTION
The previous logic was:

- use the preferred SASL mechanism if available
- otherwise use the first supported mechanism offered by the server

However RFC 6120, section 6.3.3 states:

"The initiating entity MUST maintain its own preference order independent
of the preference order of the receiving entity."

The new logic is:

- order our supported mechanisms from most secure to least secure
- if the user sets QXmppConfiguration::saslMechanism, put it first
- use the best mechanism supported by the server