### PR TITLE
Add not authorized condition for stream error

### DIFF
--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -563,7 +563,7 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
         if (!nodeRecv.firstChildElement("conflict").isNull())
             d->xmppStreamError = QXmppStanza::Error::Conflict;
-        else if (!nodeRecv.firstChildElement("not-authorized").isNull() || !nodeRecv.firstChildElement("bad-auth").isNull())
+        else if (!nodeRecv.firstChildElement("not-authorized").isNull())
             d->xmppStreamError = QXmppStanza::Error::NotAuthorized;
         else
             d->xmppStreamError = QXmppStanza::Error::UndefinedCondition;

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -563,6 +563,8 @@ void QXmppOutgoingClient::handleStanza(const QDomElement &nodeRecv)
 
         if (!nodeRecv.firstChildElement("conflict").isNull())
             d->xmppStreamError = QXmppStanza::Error::Conflict;
+        else if (!nodeRecv.firstChildElement("not-authorized").isNull() || !nodeRecv.firstChildElement("bad-auth").isNull())
+            d->xmppStreamError = QXmppStanza::Error::NotAuthorized;
         else
             d->xmppStreamError = QXmppStanza::Error::UndefinedCondition;
         emit error(QXmppClient::XmppStreamError);


### PR DESCRIPTION
Support `not-authorized` condition for `stream:error`.

This allow us to distinguish `stream:error` conditions more specifically.

Please refer to https://xmpp.org/rfcs/rfc6120.html#streams-error-conditions-not-authorized.