### PR TITLE
Implement XEP-0392: Consistent Color Generation

### DIFF
--- a/doc/xep.doc
+++ b/doc/xep.doc
@@ -41,6 +41,7 @@ Complete:
 - XEP-0313: Message Archive Management
 - XEP-0319: Last User Interaction in Presence
 - XEP-0352: Client State Indication
+- XEP-0392: Consistent Color Generation (v0.6.0)
 
 Ongoing:
 - XEP-0009: Jabber-RPC (API is not finalized yet)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,10 +11,12 @@ set(INSTALL_HEADER_FILES
     ${CMAKE_CURRENT_BINARY_DIR}/base/QXmppGlobal.h
 
     # Base
+    base/hsluv.h
     base/QXmppArchiveIq.h
     base/QXmppBindIq.h
     base/QXmppBookmarkSet.h
     base/QXmppByteStreamIq.h
+    base/QXmppColorGenerator.h
     base/QXmppDataForm.h
     base/QXmppDiscoveryIq.h
     base/QXmppElement.h
@@ -84,11 +86,13 @@ set(INSTALL_HEADER_FILES
 
 set(SOURCE_FILES
     # Base
+    base/hsluv.c
     base/QXmppArchiveIq.cpp
     base/QXmppBindIq.cpp
     base/QXmppBookmarkSet.cpp
     base/QXmppByteStreamIq.cpp
     base/QXmppCodec.cpp
+    base/QXmppColorGenerator.cpp
     base/QXmppConstants.cpp
     base/QXmppDataForm.cpp
     base/QXmppDiscoveryIq.cpp

--- a/src/base/QXmppColorGenerator.cpp
+++ b/src/base/QXmppColorGenerator.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2008-2019 The QXmpp developers
+ *
+ * Author:
+ *  Linus Jahn <lnj@kaidan.im>
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#include "QXmppColorGenerator.h"
+#include "hsluv.h"
+#include <ctgmath>
+#include <QCryptographicHash>
+
+/// \brief Generates a color from the input value. This is intended for
+/// generating colors for contacts. The generated colors are "consistent", so
+/// they are shared between all clients with support for XEP-0392: Consistent
+/// Color Generation.
+///
+/// \param name This should be the (user-specified) nickname of the
+/// participant. If there is no nickname set, the bare JID shall be used.
+/// \param deficiency Color correction to be done, defaults to
+/// ColorVisionDeficiency::NoDeficiency.
+
+QXmppColorGenerator::RGBColor QXmppColorGenerator::generateColor(
+        const QString &name, ColorVisionDeficiency deficiency)
+{
+    QByteArray input = name.toUtf8();
+
+    // hash input through SHA-1
+    QCryptographicHash hash(QCryptographicHash::Sha1);
+    hash.addData(input);
+
+    // the first two bytes are used to calculate the angle/hue
+    int angle = hash.result().at(0) + hash.result().at(1) * 256;
+
+    double hue = double(angle) / 65536.0 * 360.0;
+    double saturation = 100.0;
+    double lightness = 50.0;
+
+    // Corrections for Color Vision Deficiencies
+    // this uses floating point modulo (fmod)
+    if (deficiency == RedGreenBlindness) {
+        hue += 90.0;
+        hue = fmod(hue, 180);
+        hue -= 90.0;
+        hue = fmod(hue, 360);
+    } else if (deficiency == BlueBlindness) {
+        hue = fmod(hue, 180);
+    }
+
+    // convert to rgb values (values are between 0.0 and 1.0)
+    double red, green, blue = 0.0;
+    hsluv2rgb(hue, saturation, lightness, &red, &green, &blue);
+
+    RGBColor color;
+    color.red = quint8(red * 255.0);
+    color.green = quint8(green * 255.0);
+    color.blue = quint8(blue * 255.0);
+    return color;
+}

--- a/src/base/QXmppColorGenerator.h
+++ b/src/base/QXmppColorGenerator.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2008-2019 The QXmpp developers
+ *
+ * Author:
+ *  Linus Jahn <lnj@kaidan.im>
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#ifndef QXMPPCOLORGENERATOR_H
+#define QXMPPCOLORGENERATOR_H
+
+#include <QByteArray>
+#include <QString>
+
+class QXmppColorGenerator
+{
+public:
+    struct RGBColor {
+        quint8 red = 0;
+        quint8 green = 0;
+        quint8 blue = 0;
+    };
+
+    enum ColorVisionDeficiency {
+        NoDeficiency,
+        RedGreenBlindness,
+        BlueBlindness
+    };
+
+    static RGBColor generateColor(const QString&,
+                                  ColorVisionDeficiency = NoDeficiency);
+};
+
+#endif // QXMPPCOLORGENERATOR_H

--- a/src/base/hsluv.c
+++ b/src/base/hsluv.c
@@ -1,0 +1,453 @@
+/*
+ * HSLuv-C: Human-friendly HSL
+ * <http://github.com/hsluv/hsluv-c>
+ * <http://www.hsluv.org/>
+ *
+ * Copyright (c) 2015 Alexei Boronine (original idea, JavaScript implementation)
+ * Copyright (c) 2015 Roger Tallada (Obj-C implementation)
+ * Copyright (c) 2017 Martin Mitas (C implementation, based on Obj-C implementation)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "hsluv.h"
+
+#include <float.h>
+#include <math.h>
+
+
+typedef struct Triplet_tag Triplet;
+struct Triplet_tag {
+    double a;
+    double b;
+    double c;
+};
+
+/* for RGB */
+static const Triplet m[3] = {
+    {  3.24096994190452134377, -1.53738317757009345794, -0.49861076029300328366 },
+    { -0.96924363628087982613,  1.87596750150772066772,  0.04155505740717561247 },
+    {  0.05563007969699360846, -0.20397695888897656435,  1.05697151424287856072 }
+};
+
+/* for XYZ */
+static const Triplet m_inv[3] = {
+    {  0.41239079926595948129,  0.35758433938387796373,  0.18048078840183428751 },
+    {  0.21263900587151035754,  0.71516867876775592746,  0.07219231536073371500 },
+    {  0.01933081871559185069,  0.11919477979462598791,  0.95053215224966058086 }
+};
+
+static const double ref_u = 0.19783000664283680764;
+static const double ref_v = 0.46831999493879100370;
+
+static const double kappa = 903.29629629629629629630;
+static const double epsilon = 0.00885645167903563082;
+
+
+typedef struct Bounds_tag Bounds;
+struct Bounds_tag {
+    double a;
+    double b;
+};
+
+
+static void
+get_bounds(double l, Bounds bounds[6])
+{
+    double tl = l + 16.0;
+    double sub1 = (tl * tl * tl) / 1560896.0;
+    double sub2 = (sub1 > epsilon ? sub1 : (l / kappa));
+    int channel;
+    int t;
+
+    for(channel = 0; channel < 3; channel++) {
+        double m1 = m[channel].a;
+        double m2 = m[channel].b;
+        double m3 = m[channel].c;
+
+        for (t = 0; t < 2; t++) {
+            double top1 = (284517.0 * m1 - 94839.0 * m3) * sub2;
+            double top2 = (838422.0 * m3 + 769860.0 * m2 + 731718.0 * m1) * l * sub2 -  769860.0 * t * l;
+            double bottom = (632260.0 * m3 - 126452.0 * m2) * sub2 + 126452.0 * t;
+
+            bounds[channel * 2 + t].a = top1 / bottom;
+            bounds[channel * 2 + t].b = top2 / bottom;
+        }
+    }
+}
+
+static double
+intersect_line_line(const Bounds* line1, const Bounds* line2)
+{
+    return (line1->b - line2->b) / (line2->a - line1->a);
+}
+
+static double
+dist_from_pole_squared(double x, double y)
+{
+    return x * x + y * y;
+}
+
+static double
+ray_length_until_intersect(double theta, const Bounds* line)
+{
+    return line->b / (sin(theta) - line->a * cos(theta));
+}
+
+static double
+max_safe_chroma_for_l(double l)
+{
+    double min_len_squared = DBL_MAX;
+    Bounds bounds[6];
+    int i;
+
+    get_bounds(l, bounds);
+    for(i = 0; i < 6; i++) {
+        double m1 = bounds[i].a;
+        double b1 = bounds[i].b;
+        /* x where line intersects with perpendicular running though (0, 0) */
+        Bounds line2 = { -1.0 / m1, 0.0 };
+        double x = intersect_line_line(&bounds[i], &line2);
+        double distance = dist_from_pole_squared(x, b1 + x * m1);
+
+        if(distance < min_len_squared)
+            min_len_squared = distance;
+    }
+
+    return sqrt(min_len_squared);
+}
+
+static double
+max_chroma_for_lh(double l, double h)
+{
+    double min_len = DBL_MAX;
+    double hrad = h * 0.01745329251994329577; /* (2 * pi / 360) */
+    Bounds bounds[6];
+    int i;
+
+    get_bounds(l, bounds);
+    for(i = 0; i < 6; i++) {
+        double len = ray_length_until_intersect(hrad, &bounds[i]);
+
+        if(len >= 0  &&  len < min_len)
+            min_len = len;
+    }
+    return min_len;
+}
+
+static double
+dot_product(const Triplet* t1, const Triplet* t2)
+{
+    return (t1->a * t2->a + t1->b * t2->b + t1->c * t2->c);
+}
+
+/* Used for rgb conversions */
+static double
+from_linear(double c)
+{
+    if(c <= 0.0031308)
+        return 12.92 * c;
+    else
+        return 1.055 * pow(c, 1.0 / 2.4) - 0.055;
+}
+
+static double
+to_linear(double c)
+{
+    if (c > 0.04045)
+        return pow((c + 0.055) / 1.055, 2.4);
+    else
+        return c / 12.92;
+}
+
+static void
+xyz2rgb(Triplet* in_out)
+{
+    double r = from_linear(dot_product(&m[0], in_out));
+    double g = from_linear(dot_product(&m[1], in_out));
+    double b = from_linear(dot_product(&m[2], in_out));
+    in_out->a = r;
+    in_out->b = g;
+    in_out->c = b;
+}
+
+static void
+rgb2xyz(Triplet* in_out)
+{
+    Triplet rgbl = { to_linear(in_out->a), to_linear(in_out->b), to_linear(in_out->c) };
+    double x = dot_product(&m_inv[0], &rgbl);
+    double y = dot_product(&m_inv[1], &rgbl);
+    double z = dot_product(&m_inv[2], &rgbl);
+    in_out->a = x;
+    in_out->b = y;
+    in_out->c = z;
+}
+
+/* http://en.wikipedia.org/wiki/CIELUV
+ * In these formulas, Yn refers to the reference white point. We are using
+ * illuminant D65, so Yn (see refY in Maxima file) equals 1. The formula is
+ * simplified accordingly.
+ */
+static double
+y2l(double y)
+{
+    if(y <= epsilon)
+        return y * kappa;
+    else
+        return 116.0 * cbrt(y) - 16.0;
+}
+
+static double
+l2y(double l)
+{
+    if(l <= 8.0) {
+        return l / kappa;
+    } else {
+        double x = (l + 16.0) / 116.0;
+        return (x * x * x);
+    }
+}
+
+static void
+xyz2luv(Triplet* in_out)
+{
+    double var_u = (4.0 * in_out->a) / (in_out->a + (15.0 * in_out->b) + (3.0 * in_out->c));
+    double var_v = (9.0 * in_out->b) / (in_out->a + (15.0 * in_out->b) + (3.0 * in_out->c));
+    double l = y2l(in_out->b);
+    double u = 13.0 * l * (var_u - ref_u);
+    double v = 13.0 * l * (var_v - ref_v);
+
+    in_out->a = l;
+    if(l < 0.00000001) {
+        in_out->b = 0.0;
+        in_out->c = 0.0;
+    } else {
+        in_out->b = u;
+        in_out->c = v;
+    }
+}
+
+static void
+luv2xyz(Triplet* in_out)
+{
+    if(in_out->a <= 0.00000001) {
+        /* Black will create a divide-by-zero error. */
+        in_out->a = 0.0;
+        in_out->b = 0.0;
+        in_out->c = 0.0;
+        return;
+    }
+
+    double var_u = in_out->b / (13.0 * in_out->a) + ref_u;
+    double var_v = in_out->c / (13.0 * in_out->a) + ref_v;
+    double y = l2y(in_out->a);
+    double x = -(9.0 * y * var_u) / ((var_u - 4.0) * var_v - var_u * var_v);
+    double z = (9.0 * y - (15.0 * var_v * y) - (var_v * x)) / (3.0 * var_v);
+    in_out->a = x;
+    in_out->b = y;
+    in_out->c = z;
+}
+
+static void
+luv2lch(Triplet* in_out)
+{
+    double l = in_out->a;
+    double u = in_out->b;
+    double v = in_out->c;
+    double h;
+    double c = sqrt(u * u + v * v);
+
+    /* Grays: disambiguate hue */
+    if(c < 0.00000001) {
+        h = 0;
+    } else {
+        h = atan2(v, u) * 57.29577951308232087680;  /* (180 / pi) */
+        if(h < 0.0)
+            h += 360.0;
+    }
+
+    in_out->a = l;
+    in_out->b = c;
+    in_out->c = h;
+}
+
+static void
+lch2luv(Triplet* in_out)
+{
+    double hrad = in_out->c * 0.01745329251994329577;  /* (pi / 180.0) */
+    double u = cos(hrad) * in_out->b;
+    double v = sin(hrad) * in_out->b;
+
+    in_out->b = u;
+    in_out->c = v;
+}
+
+static void
+hsluv2lch(Triplet* in_out)
+{
+    double h = in_out->a;
+    double s = in_out->b;
+    double l = in_out->c;
+    double c;
+
+    /* White and black: disambiguate chroma */
+    if(l > 99.9999999 || l < 0.00000001)
+        c = 0.0;
+    else
+        c = max_chroma_for_lh(l, h) / 100.0 * s;
+
+    /* Grays: disambiguate hue */
+    if (s < 0.00000001)
+        h = 0.0;
+
+    in_out->a = l;
+    in_out->b = c;
+    in_out->c = h;
+}
+
+static void
+lch2hsluv(Triplet* in_out)
+{
+    double l = in_out->a;
+    double c = in_out->b;
+    double h = in_out->c;
+    double s;
+
+    /* White and black: disambiguate saturation */
+    if(l > 99.9999999 || l < 0.00000001)
+        s = 0.0;
+    else
+        s = c / max_chroma_for_lh(l, h) * 100.0;
+
+    /* Grays: disambiguate hue */
+    if (c < 0.00000001)
+        h = 0.0;
+
+    in_out->a = h;
+    in_out->b = s;
+    in_out->c = l;
+}
+
+static void
+hpluv2lch(Triplet* in_out)
+{
+    double h = in_out->a;
+    double s = in_out->b;
+    double l = in_out->c;
+    double c;
+
+    /* White and black: disambiguate chroma */
+    if(l > 99.9999999 || l < 0.00000001)
+        c = 0.0;
+    else
+        c = max_safe_chroma_for_l(l) / 100.0 * s;
+
+    /* Grays: disambiguate hue */
+    if (s < 0.00000001)
+        h = 0.0;
+
+    in_out->a = l;
+    in_out->b = c;
+    in_out->c = h;
+}
+
+static void
+lch2hpluv(Triplet* in_out)
+{
+    double l = in_out->a;
+    double c = in_out->b;
+    double h = in_out->c;
+    double s;
+
+    /* White and black: disambiguate saturation */
+    if (l > 99.9999999 || l < 0.00000001)
+        s = 0.0;
+    else
+        s = c / max_safe_chroma_for_l(l) * 100.0;
+
+    /* Grays: disambiguate hue */
+    if (c < 0.00000001)
+        h = 0.0;
+
+    in_out->a = h;
+    in_out->b = s;
+    in_out->c = l;
+}
+
+
+
+void
+hsluv2rgb(double h, double s, double l, double* pr, double* pg, double* pb)
+{
+    Triplet tmp = { h, s, l };
+
+    hsluv2lch(&tmp);
+    lch2luv(&tmp);
+    luv2xyz(&tmp);
+    xyz2rgb(&tmp);
+
+    *pr = tmp.a;
+    *pg = tmp.b;
+    *pb = tmp.c;
+}
+
+void
+hpluv2rgb(double h, double s, double l, double* pr, double* pg, double* pb)
+{
+    Triplet tmp = { h, s, l };
+
+    hpluv2lch(&tmp);
+    lch2luv(&tmp);
+    luv2xyz(&tmp);
+    xyz2rgb(&tmp);
+
+    *pr = tmp.a;
+    *pg = tmp.b;
+    *pb = tmp.c;
+}
+
+void
+rgb2hsluv(double r, double g, double b, double* ph, double* ps, double* pl)
+{
+    Triplet tmp = { r, g, b };
+
+    rgb2xyz(&tmp);
+    xyz2luv(&tmp);
+    luv2lch(&tmp);
+    lch2hsluv(&tmp);
+
+    *ph = tmp.a;
+    *ps = tmp.b;
+    *pl = tmp.c;
+}
+
+void
+rgb2hpluv(double r, double g, double b, double* ph, double* ps, double* pl)
+{
+    Triplet tmp = { r, g, b };
+
+    rgb2xyz(&tmp);
+    xyz2luv(&tmp);
+    luv2lch(&tmp);
+    lch2hpluv(&tmp);
+
+    *ph = tmp.a;
+    *ps = tmp.b;
+    *pl = tmp.c;
+}

--- a/src/base/hsluv.h
+++ b/src/base/hsluv.h
@@ -1,0 +1,90 @@
+/*
+ * HSLuv-C: Human-friendly HSL
+ * <http://github.com/hsluv/hsluv-c>
+ * <http://www.hsluv.org/>
+ *
+ * Copyright (c) 2015 Alexei Boronine (original idea, JavaScript implementation)
+ * Copyright (c) 2015 Roger Tallada (Obj-C implementation)
+ * Copyright (c) 2017 Martin Mitas (C implementation, based on Obj-C implementation)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef HSLUV_H
+#define HSLUV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * Convert HSLuv to RGB.
+ *
+ * @param h Hue. Between 0.0 and 360.0.
+ * @param s Saturation. Between 0.0 and 100.0.
+ * @param l Lightness. Between 0.0 and 100.0.
+ * @param[out] pr Red component. Between 0.0 and 1.0.
+ * @param[out] pr Green component. Between 0.0 and 1.0.
+ * @param[out] pr Blue component. Between 0.0 and 1.0.
+ */
+void hsluv2rgb(double h, double s, double l, double* pr, double* pg, double* pb);
+
+/**
+ * Convert RGB to HSLuv.
+ *
+ * @param r Red component. Between 0.0 and 1.0.
+ * @param g Green component. Between 0.0 and 1.0.
+ * @param b Blue component. Between 0.0 and 1.0.
+ * @param[out] ph Hue. Between 0.0 and 360.0.
+ * @param[out] ps Saturation. Between 0.0 and 100.0.
+ * @param[out] pl Lightness. Between 0.0 and 100.0.
+ */
+void rgb2hsluv(double r, double g, double b, double* ph, double* ps, double* pl);
+
+/**
+ * Convert HPLuv to RGB.
+ *
+ * @param h Hue. Between 0.0 and 360.0.
+ * @param s Saturation. Between 0.0 and 100.0.
+ * @param l Lightness. Between 0.0 and 100.0.
+ * @param[out] pr Red component. Between 0.0 and 1.0.
+ * @param[out] pg Green component. Between 0.0 and 1.0.
+ * @param[out] pb Blue component. Between 0.0 and 1.0.
+ */
+void hpluv2rgb(double h, double s, double l, double* pr, double* pg, double* pb);
+
+/**
+ * Convert RGB to HPLuv.
+ *
+ * @param r Red component. Between 0.0 and 1.0.
+ * @param g Green component. Between 0.0 and 1.0.
+ * @param b Blue component. Between 0.0 and 1.0.
+ * @param[out] ph Hue. Between 0.0 and 360.0.
+ * @param[out] ps Saturation. Between 0.0 and 100.0.
+ * @param[out] pl Lightness. Between 0.0 and 100.0.
+ */
+void rgb2hpluv(double r, double g, double b, double* ph, double* ps, double* pl);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* HSLUV_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_simple_test(qxmpparchiveiq)
 add_simple_test(qxmppbindiq)
 add_simple_test(qxmppcallmanager)
 add_simple_test(qxmppcarbonmanager)
+add_simple_test(qxmppcolorgenerator)
 add_simple_test(qxmppdataform)
 add_simple_test(qxmppdiscoveryiq)
 add_simple_test(qxmppentitytimeiq)
@@ -53,4 +54,3 @@ endif()
 
 add_subdirectory(qxmpptransfermanager)
 add_subdirectory(qxmpputils)
-

--- a/tests/qxmppcolorgenerator/tst_qxmppcolorgenerator.cpp
+++ b/tests/qxmppcolorgenerator/tst_qxmppcolorgenerator.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2008-2019 The QXmpp developers
+ *
+ * Author:
+ *  Linus Jahn <lnj@kaidan.im>
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#include <QObject>
+#include "util.h"
+
+#include "QXmppColorGenerator.h"
+
+Q_DECLARE_METATYPE(QXmppColorGenerator::ColorVisionDeficiency)
+
+class tst_QXmppColorGenerator : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void testBase_data();
+    void testBase();
+};
+
+void tst_QXmppColorGenerator::testBase_data()
+{
+    QTest::addColumn<QString>("name");
+    QTest::addColumn<QXmppColorGenerator::ColorVisionDeficiency>("deficiency");
+    QTest::addColumn<QString>("result");
+
+    QTest::newRow("normal")
+        << "4223@localhost"
+        << QXmppColorGenerator::NoDeficiency
+        << "124,122,0";
+    QTest::newRow("red-green-blindness-not-corrected")
+        << "somebody-zz@localhost"
+        << QXmppColorGenerator::NoDeficiency
+        << "0,137,74";
+    QTest::newRow("red-green-blindness-corrected")
+        << "somebody-zz@localhost"
+        << QXmppColorGenerator::RedGreenBlindness
+        << "217,0,187";
+    QTest::newRow("blue-blindness-not-corrected")
+        << "357@localhost"
+        << QXmppColorGenerator::NoDeficiency
+        << "0,133,123";
+    QTest::newRow("blue-blindness-corrected")
+        << "357@localhost"
+        << QXmppColorGenerator::BlueBlindness
+        << "233,0,102";
+}
+
+void tst_QXmppColorGenerator::testBase()
+{
+    QFETCH(QString, name);
+    QFETCH(QXmppColorGenerator::ColorVisionDeficiency, deficiency);
+    QFETCH(QString, result);
+
+    QXmppColorGenerator::RGBColor color = QXmppColorGenerator::generateColor(name, deficiency);
+    // check color
+    QCOMPARE(result, QString("%1,%2,%3").arg(color.red).arg(color.green).arg(color.blue));
+}
+
+QTEST_MAIN(tst_QXmppColorGenerator)
+#include "tst_qxmppcolorgenerator.moc"
+


### PR DESCRIPTION
This adds methods to generate a color for a JID (or nickname or whatever).
It also supports the color corrections for color vision deficiencies.
Only background color correction is not covered by this, but may be
added later.

It uses the hsluv-c library to convert the hue/saturation/lightness
values to RGB colors. hsluv-c is licensed under MIT and is included now.