### PR TITLE
Check TLS-certs against connection host instead of JID domain

### DIFF
--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -148,7 +148,7 @@ void QXmppOutgoingClientPrivate::connectToHost(const QString &host, quint16 port
     q->socket()->setProxy(config.networkProxy());
 
     // set the name the SSL certificate should match
-    q->socket()->setPeerVerifyName(config.domain());
+    q->socket()->setPeerVerifyName(host);
 
     // connect to host
     const QXmppConfiguration::StreamSecurityMode localSecurity = q->configuration().streamSecurityMode();


### PR DESCRIPTION
Some server setups don't have a certificate for the actual JID domain
(e.g. myserver.org) and only for their local host (e.g. xmpp.myserver.org).