### PR TITLE
Modernize codebase using clang-tidy

### DIFF
--- a/examples/example_1_echoClient/example_1_echoClient.h
+++ b/examples/example_1_echoClient/example_1_echoClient.h
@@ -32,8 +32,8 @@ class echoClient : public QXmppClient
     Q_OBJECT
 
 public:
-    echoClient(QObject *parent = 0);
-    ~echoClient();
+    echoClient(QObject *parent = nullptr);
+    ~echoClient() override;
 
 public slots:
     void messageReceived(const QXmppMessage&);

--- a/examples/example_2_rosterHandling/example_2_rosterHandling.h
+++ b/examples/example_2_rosterHandling/example_2_rosterHandling.h
@@ -32,8 +32,8 @@ class xmppClient : public QXmppClient
     Q_OBJECT
 
 public:
-    xmppClient(QObject *parent = 0);
-    ~xmppClient();
+    xmppClient(QObject *parent = nullptr);
+    ~xmppClient() override;
 
 public slots:
     void clientConnected();

--- a/examples/example_3_transferHandling/example_3_transferHandling.cpp
+++ b/examples/example_3_transferHandling/example_3_transferHandling.cpp
@@ -35,7 +35,7 @@
 #include "example_3_transferHandling.h"
 
 xmppClient::xmppClient(QObject *parent)
-    : QXmppClient(parent), transferManager(0)
+    : QXmppClient(parent), transferManager(nullptr)
 {
     bool check;
     Q_UNUSED(check);

--- a/examples/example_3_transferHandling/example_3_transferHandling.h
+++ b/examples/example_3_transferHandling/example_3_transferHandling.h
@@ -33,7 +33,7 @@ class xmppClient : public QXmppClient
     Q_OBJECT
 
 public:
-    xmppClient(QObject *parent = 0);
+    xmppClient(QObject *parent = nullptr);
     void setRecipient(const QString &recipient);
 
 private slots:

--- a/examples/example_5_rpcInterface/remoteinterface.h
+++ b/examples/example_5_rpcInterface/remoteinterface.h
@@ -7,9 +7,9 @@ class RemoteInterface : public QXmppInvokable
 {
     Q_OBJECT
 public:
-    RemoteInterface(QObject *parent = 0);
+    RemoteInterface(QObject *parent = nullptr);
 
-    bool isAuthorized( const QString &jid ) const;
+    bool isAuthorized( const QString &jid ) const override;
 
 // RPC Interface
 public slots:

--- a/examples/example_6_rpcClient/rpcClient.h
+++ b/examples/example_6_rpcClient/rpcClient.h
@@ -35,8 +35,8 @@ class rpcClient : public QXmppClient
     Q_OBJECT
 
 public:
-    rpcClient(QObject *parent = 0);
-    ~rpcClient();
+    rpcClient(QObject *parent = nullptr);
+    ~rpcClient() override;
 
 private slots:
     void slotInvokeRemoteMethod();

--- a/examples/example_7_archiveHandling/example_7_archiveHandling.h
+++ b/examples/example_7_archiveHandling/example_7_archiveHandling.h
@@ -43,8 +43,8 @@ public:
         PageBackwards
     };
 
-    xmppClient(QObject *parent = 0);
-    ~xmppClient();
+    xmppClient(QObject *parent = nullptr);
+    ~xmppClient() override;
 
     void setPageDirection(PageDirection direction);
     void setPageSize(int size);

--- a/examples/example_8_server/example_8_server.cpp
+++ b/examples/example_8_server/example_8_server.cpp
@@ -33,7 +33,7 @@
 class passwordChecker : public QXmppPasswordChecker
 {
     /// Retrieves the password for the given username.
-    QXmppPasswordReply::Error getPassword(const QXmppPasswordRequest &request, QString &password)
+    QXmppPasswordReply::Error getPassword(const QXmppPasswordRequest &request, QString &password) override
     {
         if (request.username() == USERNAME)
         {
@@ -45,7 +45,7 @@ class passwordChecker : public QXmppPasswordChecker
     };
 
     /// Returns true as we implemented getPassword().
-    bool hasGetPassword() const
+    bool hasGetPassword() const override
     {
         return true;
     };

--- a/examples/example_9_vCard/example_9_vCard.h
+++ b/examples/example_9_vCard/example_9_vCard.h
@@ -34,8 +34,8 @@ class xmppClient : public QXmppClient
     Q_OBJECT
 
 public:
-    xmppClient(QObject *parent = 0);
-    ~xmppClient();
+    xmppClient(QObject *parent = nullptr);
+    ~xmppClient() override;
 
 public slots:
     void clientConnected();

--- a/src/base/QXmppArchiveIq.h
+++ b/src/base/QXmppArchiveIq.h
@@ -111,8 +111,8 @@ public:
     static bool isArchiveChatIq(const QDomElement &element);
 
 protected:
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -153,8 +153,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -186,8 +186,8 @@ public:
     static bool isArchiveRemoveIq(const QDomElement &element);
 
 protected:
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -218,8 +218,8 @@ public:
     static bool isArchiveRetrieveIq(const QDomElement &element);
 
 protected:
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -239,8 +239,8 @@ public:
     static bool isArchivePrefIq(const QDomElement &element);
 
 protected:
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 };
 

--- a/src/base/QXmppBindIq.h
+++ b/src/base/QXmppBindIq.h
@@ -48,8 +48,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppByteStreamIq.h
+++ b/src/base/QXmppByteStreamIq.h
@@ -78,8 +78,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppCodec_p.h
+++ b/src/base/QXmppCodec_p.h
@@ -60,8 +60,8 @@ class QXmppG711aCodec : public QXmppCodec
 public:
     QXmppG711aCodec(int clockrate);
 
-    qint64 encode(QDataStream &input, QDataStream &output);
-    qint64 decode(QDataStream &input, QDataStream &output);
+    qint64 encode(QDataStream &input, QDataStream &output) override;
+    qint64 decode(QDataStream &input, QDataStream &output) override;
 
 private:
     int m_frequency;
@@ -76,8 +76,8 @@ class QXmppG711uCodec : public QXmppCodec
 public:
     QXmppG711uCodec(int clockrate);
 
-    qint64 encode(QDataStream &input, QDataStream &output);
-    qint64 decode(QDataStream &input, QDataStream &output);
+    qint64 encode(QDataStream &input, QDataStream &output) override;
+    qint64 decode(QDataStream &input, QDataStream &output) override;
 
 private:
     int m_frequency;

--- a/src/base/QXmppDataForm.cpp
+++ b/src/base/QXmppDataForm.cpp
@@ -46,7 +46,7 @@ static field_type field_types[] = {
     {QXmppDataForm::Field::TextMultiField, "text-multi"},
     {QXmppDataForm::Field::TextPrivateField, "text-private"},
     {QXmppDataForm::Field::TextSingleField, "text-single"},
-    {static_cast<QXmppDataForm::Field::Type>(-1), NULL},
+    {static_cast<QXmppDataForm::Field::Type>(-1), nullptr},
 };
 
 class QXmppDataFormMediaPrivate : public QSharedData

--- a/src/base/QXmppDiscoveryIq.h
+++ b/src/base/QXmppDiscoveryIq.h
@@ -99,8 +99,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppElement.cpp
+++ b/src/base/QXmppElement.cpp
@@ -46,12 +46,12 @@ public:
 };
 
 QXmppElementPrivate::QXmppElementPrivate()
-    : counter(1), parent(NULL)
+    : counter(1), parent(nullptr)
 {
 }
 
 QXmppElementPrivate::QXmppElementPrivate(const QDomElement &element)
-    : counter(1), parent(NULL)
+    : counter(1), parent(nullptr)
 {
     if (element.isNull())
         return;
@@ -207,7 +207,7 @@ void QXmppElement::removeChild(const QXmppElement &child)
 
     d->children.removeAll(child.d);
     child.d->counter.deref();
-    child.d->parent = NULL;
+    child.d->parent = nullptr;
 }
 
 QString QXmppElement::tagName() const

--- a/src/base/QXmppElement.h
+++ b/src/base/QXmppElement.h
@@ -34,7 +34,7 @@ class QDomElement;
 class QXmppElement;
 class QXmppElementPrivate;
 
-typedef QList<QXmppElement> QXmppElementList;
+using QXmppElementList = QList<QXmppElement>;
 class QXMPP_EXPORT QXmppElement
 {
 public:

--- a/src/base/QXmppEntityTimeIq.h
+++ b/src/base/QXmppEntityTimeIq.h
@@ -44,8 +44,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppHttpUploadIq.h
+++ b/src/base/QXmppHttpUploadIq.h
@@ -42,7 +42,7 @@ class QXMPP_EXPORT QXmppHttpUploadRequestIq : public QXmppIq
 {
 public:
     QXmppHttpUploadRequestIq();
-    ~QXmppHttpUploadRequestIq();
+    ~QXmppHttpUploadRequestIq() override;
 
     QString fileName() const;
     void setFileName(const QString &filename);
@@ -57,8 +57,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -74,7 +74,7 @@ class QXMPP_EXPORT QXmppHttpUploadSlotIq : public QXmppIq
 {
 public:
     QXmppHttpUploadSlotIq();
-    ~QXmppHttpUploadSlotIq();
+    ~QXmppHttpUploadSlotIq() override;
 
     QUrl putUrl() const;
     void setPutUrl(const QUrl &putUrl);
@@ -89,8 +89,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppIbbIq.h
+++ b/src/base/QXmppIbbIq.h
@@ -42,8 +42,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -63,8 +63,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -89,8 +89,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppIq.h
+++ b/src/base/QXmppIq.h
@@ -53,18 +53,18 @@ public:
 
     QXmppIq(QXmppIq::Type type = QXmppIq::Get);
     QXmppIq(const QXmppIq &other);
-    ~QXmppIq();
+    ~QXmppIq() override;
 
     QXmppIq& operator=(const QXmppIq &other);
 
     QXmppIq::Type type() const;
     void setType(QXmppIq::Type);
 
-    bool isXmppStanza() const;
+    bool isXmppStanza() const override;
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
 
 protected:
     virtual void parseElementFromChild(const QDomElement &element);

--- a/src/base/QXmppJingleIq.h
+++ b/src/base/QXmppJingleIq.h
@@ -138,7 +138,7 @@ public:
     void parse(const QDomElement &element);
     void toXml(QXmlStreamWriter *writer) const;
 
-    static QXmppJingleCandidate::Type typeFromString(const QString &typeStr, bool *ok = 0);
+    static QXmppJingleCandidate::Type typeFromString(const QString &typeStr, bool *ok = nullptr);
     static QString typeToString(QXmppJingleCandidate::Type type);
     /// \endcond
 
@@ -289,7 +289,7 @@ public:
 
     QXmppJingleIq();
     QXmppJingleIq(const QXmppJingleIq &other);
-    ~QXmppJingleIq();
+    ~QXmppJingleIq() override;
 
     QXmppJingleIq& operator=(const QXmppJingleIq &other);
 
@@ -322,8 +322,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppLogger.cpp
+++ b/src/base/QXmppLogger.cpp
@@ -32,7 +32,7 @@
 
 #include "QXmppLogger.h"
 
-QXmppLogger* QXmppLogger::m_logger = 0;
+QXmppLogger* QXmppLogger::m_logger = nullptr;
 
 static const char *typeName(QXmppLogger::MessageType type)
 {
@@ -116,7 +116,7 @@ public:
 
 QXmppLoggerPrivate::QXmppLoggerPrivate()
     : loggingType(QXmppLogger::NoLogging)
-    , logFile(0)
+    , logFile(nullptr)
     , logFilePath("QXmppClientLog.log")
     , messageTypes(QXmppLogger::AnyMessage)
 {
@@ -268,7 +268,7 @@ void QXmppLogger::reopen()
 {
     if (d->logFile) {
         delete d->logFile;
-        d->logFile = 0;
+        d->logFile = nullptr;
     }
 }
 

--- a/src/base/QXmppLogger.h
+++ b/src/base/QXmppLogger.h
@@ -74,8 +74,8 @@ public:
     };
     Q_DECLARE_FLAGS(MessageTypes, MessageType)
 
-    QXmppLogger(QObject *parent = 0);
-    ~QXmppLogger();
+    QXmppLogger(QObject *parent = nullptr);
+    ~QXmppLogger() override;
 
     static QXmppLogger* getLogger();
 
@@ -113,11 +113,11 @@ class QXMPP_EXPORT QXmppLoggable : public QObject
     Q_OBJECT
 
 public:
-    QXmppLoggable(QObject *parent = 0);
+    QXmppLoggable(QObject *parent = nullptr);
 
 protected:
     /// \cond
-    virtual void childEvent(QChildEvent *event);
+    void childEvent(QChildEvent *event) override;
     /// \endcond
 
     /// Logs a debugging message.

--- a/src/base/QXmppMamIq.h
+++ b/src/base/QXmppMamIq.h
@@ -47,8 +47,8 @@ public:
     static bool isMamQueryIq(const QDomElement &element);
 
 protected:
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
 
 private:
     QXmppDataForm m_form;
@@ -72,8 +72,8 @@ public:
     static bool isMamResultIq(const QDomElement &element);
 
 protected:
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
 
 private:
     QXmppResultSetReply m_resultSetReply;

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -73,7 +73,7 @@ public:
                  const QString& body = QString(), const QString& thread = QString());
 
     QXmppMessage(const QXmppMessage &other);
-    ~QXmppMessage();
+    ~QXmppMessage() override;
 
     QXmppMessage& operator=(const QXmppMessage &other);
 
@@ -133,7 +133,7 @@ public:
     bool isPrivate() const;
     void setPrivate(const bool);
 
-    bool isXmppStanza() const;
+    bool isXmppStanza() const override;
 
     // XEP-0066: Out of Band Data
     QString outOfBandUrl() const;
@@ -158,8 +158,8 @@ public:
     void setSpoilerHint(const QString&);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppMixIq.h
+++ b/src/base/QXmppMixIq.h
@@ -51,7 +51,7 @@ public:
     };
 
     QXmppMixIq();
-    ~QXmppMixIq();
+    ~QXmppMixIq() override;
 
     QXmppMixIq::Type actionType() const;
     void setActionType(QXmppMixIq::Type);
@@ -74,8 +74,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement&);
-    void toXmlElementFromChild(QXmlStreamWriter*) const;
+    void parseElementFromChild(const QDomElement&) override;
+    void toXmlElementFromChild(QXmlStreamWriter*) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppMucIq.h
+++ b/src/base/QXmppMucIq.h
@@ -113,8 +113,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -141,8 +141,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppNonSASLAuth.h
+++ b/src/base/QXmppNonSASLAuth.h
@@ -47,8 +47,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppPingIq.h
+++ b/src/base/QXmppPingIq.h
@@ -30,7 +30,7 @@ class QXMPP_EXPORT QXmppPingIq : public QXmppIq
 {
 public:
     QXmppPingIq();
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     static bool isPingIq(const QDomElement &element);
 };
 

--- a/src/base/QXmppPresence.h
+++ b/src/base/QXmppPresence.h
@@ -75,7 +75,7 @@ public:
 
     QXmppPresence(QXmppPresence::Type type = QXmppPresence::Available);
     QXmppPresence(const QXmppPresence &other);
-    ~QXmppPresence();
+    ~QXmppPresence() override;
 
     QXmppPresence& operator=(const QXmppPresence &other);
 
@@ -92,8 +92,8 @@ public:
     void setStatusText(const QString& statusText);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 
     // XEP-0045: Multi-User Chat
@@ -139,7 +139,7 @@ public:
     QString mixUserNick() const;
     void setMixUserNick(const QString&);
 
-    bool isXmppStanza() const;
+    bool isXmppStanza() const override;
 
 private:
     QSharedDataPointer<QXmppPresencePrivate> d;

--- a/src/base/QXmppPubSubIq.h
+++ b/src/base/QXmppPubSubIq.h
@@ -92,8 +92,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement&);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement&) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppRegisterIq.h
+++ b/src/base/QXmppRegisterIq.h
@@ -59,8 +59,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppRosterIq.h
+++ b/src/base/QXmppRosterIq.h
@@ -98,7 +98,7 @@ public:
     };
 
     QXmppRosterIq();
-    ~QXmppRosterIq();
+    ~QXmppRosterIq() override;
 
     QString version() const;
     void setVersion(const QString&);
@@ -116,8 +116,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppRpcIq.h
+++ b/src/base/QXmppRpcIq.h
@@ -60,8 +60,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -92,8 +92,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -117,8 +117,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppRtpChannel.cpp
+++ b/src/base/QXmppRtpChannel.cpp
@@ -213,12 +213,12 @@ QXmppRtpAudioChannelPrivate::QXmppRtpAudioChannelPrivate()
     , incomingMaximum(0)
     , incomingPos(0)
     , incomingSequence(0)
-    , outgoingCodec(0)
+    , outgoingCodec(nullptr)
     , outgoingMarker(true)
     , outgoingPayloadNumbered(false)
     , outgoingSequence(1)
     , outgoingStamp(0)
-    , outgoingTimer(0)
+    , outgoingTimer(nullptr)
 {
     qRegisterMetaType<QXmppRtpAudioChannel::Tone>("QXmppRtpAudioChannel::Tone");
 }
@@ -240,7 +240,7 @@ QXmppCodec *QXmppRtpAudioChannelPrivate::codecForPayloadType(const QXmppJinglePa
     else if (payloadType.name().toLower() == "opus")
         return new QXmppOpusCodec(payloadType.clockrate(), payloadType.channels());
 #endif
-    return 0;
+    return nullptr;
 }
 
 /// Constructs a new RTP audio channel with the given \a parent.
@@ -349,7 +349,7 @@ void QXmppRtpAudioChannel::datagramReceived(const QByteArray &ba)
     d->incomingSequence = packet.sequence();
 
     // get or create codec
-    QXmppCodec *codec = 0;
+    QXmppCodec *codec = nullptr;
     const quint8 packetType = packet.type();
     if (!d->incomingCodecs.contains(packetType)) {
         foreach (const QXmppJinglePayloadType &payload, m_incomingPayloadTypes) {
@@ -497,7 +497,7 @@ void QXmppRtpAudioChannel::payloadTypesChanged()
     // delete outgoing codec
     if (d->outgoingCodec) {
         delete d->outgoingCodec;
-        d->outgoingCodec = 0;
+        d->outgoingCodec = nullptr;
     }
 
     // create outgoing codec
@@ -797,7 +797,7 @@ public:
 };
 
 QXmppRtpVideoChannelPrivate::QXmppRtpVideoChannelPrivate()
-    : encoder(0),
+    : encoder(nullptr),
     outgoingId(0),
     outgoingSequence(1),
     outgoingStamp(0)
@@ -925,7 +925,7 @@ void QXmppRtpVideoChannel::payloadTypesChanged()
         delete decoder;
     d->decoders.clear();
     foreach (const QXmppJinglePayloadType &payload, m_incomingPayloadTypes) {
-        QXmppVideoDecoder *decoder = 0;
+        QXmppVideoDecoder *decoder = nullptr;
         if (false)
             {}
 #ifdef QXMPP_USE_THEORA
@@ -945,10 +945,10 @@ void QXmppRtpVideoChannel::payloadTypesChanged()
     // refresh encoder
     if (d->encoder) {
         delete d->encoder;
-        d->encoder = 0;
+        d->encoder = nullptr;
     }
     foreach (const QXmppJinglePayloadType &payload, m_outgoingPayloadTypes) {
-        QXmppVideoEncoder *encoder = 0;
+        QXmppVideoEncoder *encoder = nullptr;
         if (false)
             {}
 #ifdef QXMPP_USE_THEORA

--- a/src/base/QXmppRtpChannel.h
+++ b/src/base/QXmppRtpChannel.h
@@ -98,16 +98,16 @@ public:
         Tone_D      ///< Tone for the D key.
     };
 
-    QXmppRtpAudioChannel(QObject *parent = 0);
-    ~QXmppRtpAudioChannel();
+    QXmppRtpAudioChannel(QObject *parent = nullptr);
+    ~QXmppRtpAudioChannel() override;
 
-    qint64 bytesAvailable() const;
-    void close();
-    bool isSequential() const;
-    QIODevice::OpenMode openMode() const;
+    qint64 bytesAvailable() const override;
+    void close() override;
+    bool isSequential() const override;
+    QIODevice::OpenMode openMode() const override;
     QXmppJinglePayloadType payloadType() const;
-    qint64 pos() const;
-    bool seek(qint64 pos);
+    qint64 pos() const override;
+    bool seek(qint64 pos) override;
 
 signals:
     /// \brief This signal is emitted when a datagram needs to be sent.
@@ -143,9 +143,9 @@ protected:
         emit logMessage(QXmppLogger::SentMessage, qxmpp_loggable_trace(message));
     }
 
-    void payloadTypesChanged();
-    qint64 readData(char * data, qint64 maxSize);
-    qint64 writeData(const char * data, qint64 maxSize);
+    void payloadTypesChanged() override;
+    qint64 readData(char * data, qint64 maxSize) override;
+    qint64 writeData(const char * data, qint64 maxSize) override;
     /// \endcond
 
 private slots:
@@ -263,11 +263,11 @@ class QXMPP_EXPORT QXmppRtpVideoChannel : public QXmppLoggable, public QXmppRtpC
     Q_OBJECT
 
 public:
-    QXmppRtpVideoChannel(QObject *parent = 0);
-    ~QXmppRtpVideoChannel();
+    QXmppRtpVideoChannel(QObject *parent = nullptr);
+    ~QXmppRtpVideoChannel() override;
 
-    void close();
-    QIODevice::OpenMode openMode() const;
+    void close() override;
+    QIODevice::OpenMode openMode() const override;
 
     // incoming stream
     QXmppVideoFormat decoderFormat() const;
@@ -287,7 +287,7 @@ public slots:
 
 protected:
     /// \cond
-    void payloadTypesChanged();
+    void payloadTypesChanged() override;
     /// \endcond
 
 private:

--- a/src/base/QXmppSasl.cpp
+++ b/src/base/QXmppSasl.cpp
@@ -298,7 +298,7 @@ QXmppSaslClient* QXmppSaslClient::create(const QString &mechanism, QObject *pare
     } else if (mechanism == "X-OAUTH2") {
         return new QXmppSaslClientGoogle(parent);
     } else {
-        return 0;
+        return nullptr;
     }
 }
 
@@ -491,7 +491,7 @@ bool QXmppSaslClientFacebook::respond(const QByteArray &challenge, QByteArray &r
         QUrlQuery responseUrl;
         responseUrl.addQueryItem("access_token", password());
         responseUrl.addQueryItem("api_key", username());
-        responseUrl.addQueryItem("call_id", 0);
+        responseUrl.addQueryItem("call_id", nullptr);
         responseUrl.addQueryItem("method", requestUrl.queryItemValue("method"));
         responseUrl.addQueryItem("nonce", requestUrl.queryItemValue("nonce"));
         responseUrl.addQueryItem("v", "1.0");
@@ -681,7 +681,7 @@ QXmppSaslServer* QXmppSaslServer::create(const QString &mechanism, QObject *pare
     } else if (mechanism == "ANONYMOUS") {
         return new QXmppSaslServerAnonymous(parent);
     } else {
-        return 0;
+        return nullptr;
     }
 }
 

--- a/src/base/QXmppSasl_p.h
+++ b/src/base/QXmppSasl_p.h
@@ -52,8 +52,8 @@ class QXmppSaslServerPrivate;
 class QXMPP_AUTOTEST_EXPORT QXmppSaslClient : public QXmppLoggable
 {
 public:
-    QXmppSaslClient(QObject *parent = 0);
-    virtual ~QXmppSaslClient();
+    QXmppSaslClient(QObject *parent = nullptr);
+    ~QXmppSaslClient() override;
 
     QString host() const;
     void setHost(const QString &host);
@@ -71,7 +71,7 @@ public:
     virtual bool respond(const QByteArray &challenge, QByteArray &response) = 0;
 
     static QStringList availableMechanisms();
-    static QXmppSaslClient* create(const QString &mechanism, QObject *parent = 0);
+    static QXmppSaslClient* create(const QString &mechanism, QObject *parent = nullptr);
 
 private:
     QXmppSaslClientPrivate *d;
@@ -87,8 +87,8 @@ public:
         InputNeeded = 3
     };
 
-    QXmppSaslServer(QObject *parent = 0);
-    virtual ~QXmppSaslServer();
+    QXmppSaslServer(QObject *parent = nullptr);
+    ~QXmppSaslServer() override;
 
     QString username() const;
     void setUsername(const QString &username);
@@ -105,7 +105,7 @@ public:
     virtual QString mechanism() const = 0;
     virtual Response respond(const QByteArray &challenge, QByteArray &response) = 0;
 
-    static QXmppSaslServer* create(const QString &mechanism, QObject *parent = 0);
+    static QXmppSaslServer* create(const QString &mechanism, QObject *parent = nullptr);
 
 private:
     QXmppSaslServerPrivate *d;
@@ -133,8 +133,8 @@ public:
     void setValue(const QByteArray &value);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -151,8 +151,8 @@ public:
     void setValue(const QByteArray &value);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -168,8 +168,8 @@ public:
     void setCondition(const QString &condition);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -185,8 +185,8 @@ public:
     void setValue(const QByteArray &value);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:
@@ -199,17 +199,17 @@ public:
     QXmppSaslSuccess();
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 };
 
 class QXmppSaslClientAnonymous : public QXmppSaslClient
 {
 public:
-    QXmppSaslClientAnonymous(QObject *parent = 0);
-    QString mechanism() const;
-    bool respond(const QByteArray &challenge, QByteArray &response);
+    QXmppSaslClientAnonymous(QObject *parent = nullptr);
+    QString mechanism() const override;
+    bool respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;
@@ -218,9 +218,9 @@ private:
 class QXmppSaslClientDigestMd5 : public QXmppSaslClient
 {
 public:
-    QXmppSaslClientDigestMd5(QObject *parent = 0);
-    QString mechanism() const;
-    bool respond(const QByteArray &challenge, QByteArray &response);
+    QXmppSaslClientDigestMd5(QObject *parent = nullptr);
+    QString mechanism() const override;
+    bool respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     QByteArray m_cnonce;
@@ -233,9 +233,9 @@ private:
 class QXmppSaslClientFacebook : public QXmppSaslClient
 {
 public:
-    QXmppSaslClientFacebook(QObject *parent = 0);
-    QString mechanism() const;
-    bool respond(const QByteArray &challenge, QByteArray &response);
+    QXmppSaslClientFacebook(QObject *parent = nullptr);
+    QString mechanism() const override;
+    bool respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;
@@ -244,9 +244,9 @@ private:
 class QXmppSaslClientGoogle : public QXmppSaslClient
 {
 public:
-    QXmppSaslClientGoogle(QObject *parent = 0);
-    QString mechanism() const;
-    bool respond(const QByteArray &challenge, QByteArray &response);
+    QXmppSaslClientGoogle(QObject *parent = nullptr);
+    QString mechanism() const override;
+    bool respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;
@@ -255,9 +255,9 @@ private:
 class QXmppSaslClientPlain : public QXmppSaslClient
 {
 public:
-    QXmppSaslClientPlain(QObject *parent = 0);
-    QString mechanism() const;
-    bool respond(const QByteArray &challenge, QByteArray &response);
+    QXmppSaslClientPlain(QObject *parent = nullptr);
+    QString mechanism() const override;
+    bool respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;
@@ -266,9 +266,9 @@ private:
 class QXmppSaslClientScram : public QXmppSaslClient
 {
 public:
-    QXmppSaslClientScram(QCryptographicHash::Algorithm algorithm, QObject *parent = 0);
-    QString mechanism() const;
-    bool respond(const QByteArray &challenge, QByteArray &response);
+    QXmppSaslClientScram(QCryptographicHash::Algorithm algorithm, QObject *parent = nullptr);
+    QString mechanism() const override;
+    bool respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     QCryptographicHash::Algorithm m_algorithm;
@@ -284,9 +284,9 @@ private:
 class QXmppSaslClientWindowsLive : public QXmppSaslClient
 {
 public:
-    QXmppSaslClientWindowsLive(QObject *parent = 0);
-    QString mechanism() const;
-    bool respond(const QByteArray &challenge, QByteArray &response);
+    QXmppSaslClientWindowsLive(QObject *parent = nullptr);
+    QString mechanism() const override;
+    bool respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;
@@ -295,10 +295,10 @@ private:
 class QXmppSaslServerAnonymous : public QXmppSaslServer
 {
 public:
-    QXmppSaslServerAnonymous(QObject *parent = 0);
-    QString mechanism() const;
+    QXmppSaslServerAnonymous(QObject *parent = nullptr);
+    QString mechanism() const override;
 
-    Response respond(const QByteArray &challenge, QByteArray &response);
+    Response respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;
@@ -307,10 +307,10 @@ private:
 class QXmppSaslServerDigestMd5 : public QXmppSaslServer
 {
 public:
-    QXmppSaslServerDigestMd5(QObject *parent = 0);
-    QString mechanism() const;
+    QXmppSaslServerDigestMd5(QObject *parent = nullptr);
+    QString mechanism() const override;
 
-    Response respond(const QByteArray &challenge, QByteArray &response);
+    Response respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     QByteArray m_cnonce;
@@ -323,10 +323,10 @@ private:
 class QXmppSaslServerFacebook : public QXmppSaslServer
 {
 public:
-    QXmppSaslServerFacebook(QObject *parent = 0);
-    QString mechanism() const;
+    QXmppSaslServerFacebook(QObject *parent = nullptr);
+    QString mechanism() const override;
 
-    Response respond(const QByteArray &challenge, QByteArray &response);
+    Response respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;
@@ -335,10 +335,10 @@ private:
 class QXmppSaslServerPlain : public QXmppSaslServer
 {
 public:
-    QXmppSaslServerPlain(QObject *parent = 0);
-    QString mechanism() const;
+    QXmppSaslServerPlain(QObject *parent = nullptr);
+    QString mechanism() const override;
 
-    Response respond(const QByteArray &challenge, QByteArray &response);
+    Response respond(const QByteArray &challenge, QByteArray &response) override;
 
 private:
     int m_step;

--- a/src/base/QXmppSessionIq.h
+++ b/src/base/QXmppSessionIq.h
@@ -42,7 +42,7 @@ public:
 
 private:
     /// \cond
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 };
 

--- a/src/base/QXmppSocks.h
+++ b/src/base/QXmppSocks.h
@@ -36,7 +36,7 @@ class QXMPP_EXPORT QXmppSocksClient : public QTcpSocket
     Q_OBJECT
 
 public:
-    QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, QObject *parent=0);
+    QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, QObject *parent=nullptr);
     void connectToHost(const QString &hostName, quint16 hostPort);
 
 signals:
@@ -59,7 +59,7 @@ class QXMPP_EXPORT QXmppSocksServer : public QObject
     Q_OBJECT
 
 public:
-    QXmppSocksServer(QObject *parent=0);
+    QXmppSocksServer(QObject *parent=nullptr);
     void close();
     bool listen(quint16 port = 0);
 

--- a/src/base/QXmppStream.cpp
+++ b/src/base/QXmppStream.cpp
@@ -61,7 +61,7 @@ public:
 };
 
 QXmppStreamPrivate::QXmppStreamPrivate()
-    : socket(0), streamManagementEnabled(false), lastOutgoingSequenceNumber(0), lastIncomingSequenceNumber(0)
+    : socket(nullptr), streamManagementEnabled(false), lastOutgoingSequenceNumber(0), lastIncomingSequenceNumber(0)
 {
 }
 

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -44,7 +44,7 @@ class QXMPP_EXPORT QXmppStream : public QXmppLoggable
 
 public:
     QXmppStream(QObject *parent);
-    ~QXmppStream();
+    ~QXmppStream() override;
 
     virtual bool isConnected() const;
     bool sendPacket(const QXmppStanza&);

--- a/src/base/QXmppStreamFeatures.h
+++ b/src/base/QXmppStreamFeatures.h
@@ -74,8 +74,8 @@ public:
     void setClientStateIndicationMode(Mode mode);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
     /// \endcond
 
     static bool isStreamFeatures(const QDomElement &element);

--- a/src/base/QXmppStreamInitiationIq_p.h
+++ b/src/base/QXmppStreamInitiationIq_p.h
@@ -70,8 +70,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppStun.cpp
+++ b/src/base/QXmppStun.cpp
@@ -1683,8 +1683,8 @@ CandidatePair::CandidatePair(int component, bool controlling, QObject *parent)
     : QXmppLoggable(parent)
     , nominated(false)
     , nominating(false)
-    , transport(0)
-    , transaction(0)
+    , transport(nullptr)
+    , transaction(nullptr)
     , m_component(component)
     , m_controlling(controlling)
     , m_state(WaitingState)
@@ -1790,14 +1790,14 @@ private:
 };
 
 QXmppIceComponentPrivate::QXmppIceComponentPrivate(int component_, QXmppIcePrivate *config_, QXmppIceComponent *qq)
-    : activePair(0)
+    : activePair(nullptr)
     , component(component_)
     , config(config_)
-    , fallbackPair(0)
+    , fallbackPair(nullptr)
     , gatheringState(QXmppIceConnection::NewGatheringState)
     , peerReflexivePriority(0)
-    , timer(0)
-    , turnAllocation(0)
+    , timer(nullptr)
+    , turnAllocation(nullptr)
     , turnConfigured(false)
     , q(qq)
 {
@@ -1845,7 +1845,7 @@ CandidatePair* QXmppIceComponentPrivate::findPair(QXmppStunTransaction *transact
         if (pair->transaction == transaction)
             return pair;
     }
-    return 0;
+    return nullptr;
 }
 
 void QXmppIceComponentPrivate::performCheck(CandidatePair *pair, bool nominate)
@@ -2029,7 +2029,7 @@ void QXmppIceComponent::close()
         transport->disconnectFromHost();
     d->turnAllocation->disconnectFromHost();
     d->timer->stop();
-    d->activePair = 0;
+    d->activePair = nullptr;
 }
 
 /// Starts ICE connectivity checks.
@@ -2047,7 +2047,7 @@ void QXmppIceComponent::connectToHost()
 
 bool QXmppIceComponent::isConnected() const
 {
-    return d->activePair != 0;
+    return d->activePair != nullptr;
 }
 
 /// Returns the list of local candidates.
@@ -2082,7 +2082,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
     }
 
     // check if it's STUN
-    QXmppStunTransaction *stunTransaction = 0;
+    QXmppStunTransaction *stunTransaction = nullptr;
     foreach (QXmppStunTransaction *t, d->stunTransactions.keys()) {
         if (t->request().id() == messageId &&
             d->stunTransactions.value(t) == transport) {
@@ -2125,7 +2125,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
     }
 
     // process message from peer
-    CandidatePair *pair = 0;
+    CandidatePair *pair = nullptr;
     if (message.messageClass() == QXmppStunMessage::Request)
     {
         // check for role conflict
@@ -2238,7 +2238,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
         if (!d->activePair || pair->priority() > d->activePair->priority()) {
             info(QString("ICE pair selected %1 (priority: %2)").arg(
                 pair->toString(), QString::number(pair->priority())));
-            const bool wasConnected = (d->activePair != 0);
+            const bool wasConnected = (d->activePair != nullptr);
             d->activePair = pair;
             if (!wasConnected)
                 emit connected();
@@ -2273,7 +2273,7 @@ void QXmppIceComponent::transactionFinished()
                 transaction->response().errorPhrase));
             pair->setState(CandidatePair::FailedState);
         }
-        pair->transaction = 0;
+        pair->transaction = nullptr;
         return;
     }
 
@@ -2518,7 +2518,7 @@ public:
 };
 
 QXmppIceConnectionPrivate::QXmppIceConnectionPrivate()
-    : connectTimer(NULL)
+    : connectTimer(nullptr)
     , gatheringState(QXmppIceConnection::NewGatheringState)
     , turnPort(0)
 {

--- a/src/base/QXmppStun.h
+++ b/src/base/QXmppStun.h
@@ -113,7 +113,7 @@ public:
     void setUsername(const QString &username);
 
     QByteArray encode(const QByteArray &key = QByteArray(), bool addFingerprint = true) const;
-    bool decode(const QByteArray &buffer, const QByteArray &key = QByteArray(), QStringList *errors = 0);
+    bool decode(const QByteArray &buffer, const QByteArray &key = QByteArray(), QStringList *errors = nullptr);
     QString toString() const;
     static quint16 peekType(const QByteArray &buffer, quint32 &cookie, QByteArray &id);
 
@@ -167,14 +167,14 @@ class QXMPP_EXPORT QXmppIceComponent : public QXmppLoggable
     Q_OBJECT
 
 public:
-    ~QXmppIceComponent();
+    ~QXmppIceComponent() override;
 
     int component() const;
     bool isConnected() const;
     QList<QXmppJingleCandidate> localCandidates() const;
 
     static QList<QHostAddress> discoverAddresses();
-    static QList<QUdpSocket*> reservePorts(const QList<QHostAddress> &addresses, int count, QObject *parent = 0);
+    static QList<QUdpSocket*> reservePorts(const QList<QHostAddress> &addresses, int count, QObject *parent = nullptr);
 
 public slots:
     void close();
@@ -203,7 +203,7 @@ signals:
     void localCandidatesChanged();
 
 private:
-    QXmppIceComponent(int component, QXmppIcePrivate *config, QObject *parent=0);
+    QXmppIceComponent(int component, QXmppIcePrivate *config, QObject *parent=nullptr);
 
     QXmppIceComponentPrivate *d;
     friend class QXmppIceComponentPrivate;
@@ -252,8 +252,8 @@ public:
         CompleteGatheringState
     };
 
-    QXmppIceConnection(QObject *parent = 0);
-    ~QXmppIceConnection();
+    QXmppIceConnection(QObject *parent = nullptr);
+    ~QXmppIceConnection() override;
 
     QXmppIceComponent *component(int component);
     void addComponent(int component);

--- a/src/base/QXmppStun_p.h
+++ b/src/base/QXmppStun_p.h
@@ -77,8 +77,8 @@ class QXMPP_EXPORT QXmppIceTransport : public QXmppLoggable
     Q_OBJECT
 
 public:
-    QXmppIceTransport(QObject *parent = 0);
-    ~QXmppIceTransport();
+    QXmppIceTransport(QObject *parent = nullptr);
+    ~QXmppIceTransport() override;
 
     virtual QXmppJingleCandidate localCandidate(int component) const = 0;
     virtual qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port) = 0;
@@ -110,8 +110,8 @@ public:
         ClosingState
     };
 
-    QXmppTurnAllocation(QObject *parent = 0);
-    ~QXmppTurnAllocation();
+    QXmppTurnAllocation(QObject *parent = nullptr);
+    ~QXmppTurnAllocation() override;
 
     QHostAddress relayedHost() const;
     quint16 relayedPort() const;
@@ -121,8 +121,8 @@ public:
     void setUser(const QString &user);
     void setPassword(const QString &password);
 
-    QXmppJingleCandidate localCandidate(int component) const;
-    qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port);
+    QXmppJingleCandidate localCandidate(int component) const override;
+    qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port) override;
 
 signals:
     /// \brief This signal is emitted once TURN allocation succeeds.
@@ -133,7 +133,7 @@ signals:
 
 public slots:
     void connectToHost();
-    void disconnectFromHost();
+    void disconnectFromHost() override;
 
 private slots:
     void readyRead();
@@ -180,14 +180,14 @@ class QXMPP_EXPORT QXmppUdpTransport : public QXmppIceTransport
     Q_OBJECT
 
 public:
-    QXmppUdpTransport(QUdpSocket *socket, QObject *parent = 0);
-    ~QXmppUdpTransport();
+    QXmppUdpTransport(QUdpSocket *socket, QObject *parent = nullptr);
+    ~QXmppUdpTransport() override;
 
-    QXmppJingleCandidate localCandidate(int component) const;
-    qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port);
+    QXmppJingleCandidate localCandidate(int component) const override;
+    qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port) override;
 
 public slots:
-    void disconnectFromHost();
+    void disconnectFromHost() override;
 
 private slots:
     void readyRead();

--- a/src/base/QXmppVCardIq.h
+++ b/src/base/QXmppVCardIq.h
@@ -228,7 +228,7 @@ class QXMPP_EXPORT QXmppVCardIq : public QXmppIq
 public:
     QXmppVCardIq(const QString& bareJid = QString());
     QXmppVCardIq(const QXmppVCardIq &other);
-    ~QXmppVCardIq();
+    ~QXmppVCardIq() override;
 
     QXmppVCardIq& operator=(const QXmppVCardIq &other);
 
@@ -283,8 +283,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement&);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement&) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/base/QXmppVersionIq.h
+++ b/src/base/QXmppVersionIq.h
@@ -49,8 +49,8 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
 private:

--- a/src/client/QXmppArchiveManager.h
+++ b/src/client/QXmppArchiveManager.h
@@ -63,8 +63,8 @@ public:
     void retrieveCollection(const QString &jid, const QDateTime &start, int max);
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppBookmarkManager.cpp
+++ b/src/client/QXmppBookmarkManager.cpp
@@ -44,8 +44,8 @@ public:
     static bool isPrivateStorageIq(const QDomElement &element);
 
 protected:
-    void parseElementFromChild(const QDomElement &element);
-    void toXmlElementFromChild(QXmlStreamWriter *writer) const;
+    void parseElementFromChild(const QDomElement &element) override;
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
 
 private:
     QXmppBookmarkSet m_bookmarks;

--- a/src/client/QXmppBookmarkManager.h
+++ b/src/client/QXmppBookmarkManager.h
@@ -41,14 +41,14 @@ class QXMPP_EXPORT QXmppBookmarkManager : public QXmppClientExtension
 
 public:
     QXmppBookmarkManager();
-    ~QXmppBookmarkManager();
+    ~QXmppBookmarkManager() override;
 
     bool areBookmarksReceived() const;
     QXmppBookmarkSet bookmarks() const;
     bool setBookmarks(const QXmppBookmarkSet &bookmarks);
 
     /// \cond
-    bool handleStanza(const QDomElement &stanza);
+    bool handleStanza(const QDomElement &stanza) override;
     /// \endcond
 
 signals:
@@ -57,7 +57,7 @@ signals:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client);
+    void setClient(QXmppClient* client) override;
     /// \endcond
 
 private slots:

--- a/src/client/QXmppCallManager.cpp
+++ b/src/client/QXmppCallManager.cpp
@@ -105,7 +105,7 @@ private:
 
 QXmppCallPrivate::QXmppCallPrivate(QXmppCall *qq)
     : direction(QXmppCall::IncomingDirection),
-    manager(0),
+    manager(nullptr),
     state(QXmppCall::ConnectingState),
     sendVideo(false),
     audioMode(QIODevice::NotOpen),
@@ -120,7 +120,7 @@ QXmppCallPrivate::Stream *QXmppCallPrivate::findStreamByMedia(const QString &med
     foreach (Stream *stream, streams)
         if (stream->media == media)
             return stream;
-    return 0;
+    return nullptr;
 }
 
 QXmppCallPrivate::Stream *QXmppCallPrivate::findStreamByName(const QString &name)
@@ -128,7 +128,7 @@ QXmppCallPrivate::Stream *QXmppCallPrivate::findStreamByName(const QString &name
     foreach (Stream *stream, streams)
         if (stream->name == name)
             return stream;
-    return 0;
+    return nullptr;
 }
 
 void QXmppCallPrivate::handleAck(const QXmppIq &ack)
@@ -297,7 +297,7 @@ QXmppCallPrivate::Stream *QXmppCallPrivate::createStream(const QString &media)
     stream->media = media;
 
     // RTP channel
-    QObject *channelObject = 0;
+    QObject *channelObject = nullptr;
     if (media == AUDIO_MEDIA) {
         QXmppRtpAudioChannel *audioChannel = new QXmppRtpAudioChannel(q);
         stream->channel = audioChannel;
@@ -309,7 +309,7 @@ QXmppCallPrivate::Stream *QXmppCallPrivate::createStream(const QString &media)
     } else {
         q->warning(QString("Unsupported media type %1").arg(media));
         delete stream;
-        return 0;
+        return nullptr;
     }
 
     // ICE connection
@@ -510,7 +510,7 @@ QXmppRtpAudioChannel *QXmppCall::audioChannel() const
     if (stream)
         return static_cast<QXmppRtpAudioChannel*>(stream->channel);
     else
-        return 0;
+        return nullptr;
 }
 
 /// Returns the audio mode.
@@ -529,7 +529,7 @@ QXmppRtpVideoChannel *QXmppCall::videoChannel() const
     if (stream)
         return static_cast<QXmppRtpVideoChannel*>(stream->channel);
     else
-        return 0;
+        return nullptr;
 }
 
 /// Returns the video mode.
@@ -574,7 +574,7 @@ void QXmppCall::localCandidatesChanged()
 {
     // find the stream
     QXmppIceConnection *conn = qobject_cast<QXmppIceConnection*>(sender());
-    QXmppCallPrivate::Stream *stream = 0;
+    QXmppCallPrivate::Stream *stream = nullptr;
     foreach (QXmppCallPrivate::Stream *ptr, d->streams) {
         if (ptr->connection == conn) {
             stream = ptr;
@@ -704,7 +704,7 @@ QXmppCall *QXmppCallManagerPrivate::findCall(const QString &sid) const
     foreach (QXmppCall *call, calls)
         if (call->sid() == sid)
            return call;
-    return 0;
+    return nullptr;
 }
 
 QXmppCall *QXmppCallManagerPrivate::findCall(const QString &sid, QXmppCall::Direction direction) const
@@ -712,7 +712,7 @@ QXmppCall *QXmppCallManagerPrivate::findCall(const QString &sid, QXmppCall::Dire
     foreach (QXmppCall *call, calls)
         if (call->sid() == sid && call->direction() == direction)
            return call;
-    return 0;
+    return nullptr;
 }
 
 /// Constructs a QXmppCallManager object to handle incoming and outgoing
@@ -791,12 +791,12 @@ QXmppCall *QXmppCallManager::call(const QString &jid)
 
     if (jid.isEmpty()) {
         warning("Refusing to call an empty jid");
-        return 0;
+        return nullptr;
     }
 
     if (jid == client()->configuration().jid()) {
         warning("Refusing to call self");
-        return 0;
+        return nullptr;
     }
 
     QXmppCall *call = new QXmppCall(jid, QXmppCall::OutgoingDirection, this);

--- a/src/client/QXmppCallManager.h
+++ b/src/client/QXmppCallManager.h
@@ -78,7 +78,7 @@ public:
         FinishedState = 3       ///< The call is finished.
     };
 
-    ~QXmppCall();
+    ~QXmppCall() override;
 
     QXmppCall::Direction direction() const;
     QString jid() const;
@@ -163,15 +163,15 @@ class QXMPP_EXPORT QXmppCallManager : public QXmppClientExtension
 
 public:
     QXmppCallManager();
-    ~QXmppCallManager();
+    ~QXmppCallManager() override;
     void setStunServer(const QHostAddress &host, quint16 port = 3478);
     void setTurnServer(const QHostAddress &host, quint16 port = 3478);
     void setTurnUser(const QString &user);
     void setTurnPassword(const QString &password);
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:
@@ -189,7 +189,7 @@ public slots:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client);
+    void setClient(QXmppClient* client) override;
     /// \endcond
 
 private slots:

--- a/src/client/QXmppCarbonManager.h
+++ b/src/client/QXmppCarbonManager.h
@@ -43,14 +43,14 @@ class QXMPP_EXPORT QXmppCarbonManager : public QXmppClientExtension
 
 public:
     QXmppCarbonManager();
-    ~QXmppCarbonManager();
+    ~QXmppCarbonManager() override;
 
     bool carbonsEnabled() const;
     void setCarbonsEnabled(bool enabled);
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -66,11 +66,11 @@ private:
 
 QXmppClientPrivate::QXmppClientPrivate(QXmppClient *qq)
     : clientPresence(QXmppPresence::Available)
-    , logger(0)
-    , stream(0)
+    , logger(nullptr)
+    , stream(nullptr)
     , receivedConflict(false)
     , reconnectionTries(0)
-    , reconnectionTimer(0)
+    , reconnectionTimer(nullptr)
     , isActive(true)
     , q(qq)
 {

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -103,8 +103,8 @@ public:
         ConnectedState      ///< Connected to the server.
     };
 
-    QXmppClient(QObject *parent = 0);
-    ~QXmppClient();
+    QXmppClient(QObject *parent = nullptr);
+    ~QXmppClient() override;
 
     bool addExtension(QXmppClientExtension* extension);
     bool insertExtension(int index, QXmppClientExtension* extension);
@@ -134,7 +134,7 @@ public:
             if(extension)
                 return extension;
         }
-        return 0;
+        return nullptr;
     }
 
     bool isAuthenticated() const;

--- a/src/client/QXmppClientExtension.cpp
+++ b/src/client/QXmppClientExtension.cpp
@@ -37,7 +37,7 @@ public:
 QXmppClientExtension::QXmppClientExtension()
     : d(new QXmppClientExtensionPrivate)
 {
-    d->client = 0;
+    d->client = nullptr;
 }
 
 /// Destroys a QXmppClient extension.

--- a/src/client/QXmppClientExtension.h
+++ b/src/client/QXmppClientExtension.h
@@ -50,7 +50,7 @@ class QXMPP_EXPORT QXmppClientExtension : public QXmppLoggable
 
 public:
     QXmppClientExtension();
-    virtual ~QXmppClientExtension();
+    ~QXmppClientExtension() override;
 
     virtual QStringList discoveryFeatures() const;
     virtual QList<QXmppDiscoveryIq::Identity> discoveryIdentities() const;

--- a/src/client/QXmppDiscoveryManager.h
+++ b/src/client/QXmppDiscoveryManager.h
@@ -41,7 +41,7 @@ class QXMPP_EXPORT QXmppDiscoveryManager : public QXmppClientExtension
 
 public:
     QXmppDiscoveryManager();
-    ~QXmppDiscoveryManager();
+    ~QXmppDiscoveryManager() override;
 
     QXmppDiscoveryIq capabilities();
 
@@ -65,8 +65,8 @@ public:
     void setClientInfoForm(const QXmppDataForm &form);
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppEntityTimeManager.h
+++ b/src/client/QXmppEntityTimeManager.h
@@ -42,8 +42,8 @@ public:
     QString requestTime(const QString& jid);
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppInvokable.cpp
+++ b/src/client/QXmppInvokable.cpp
@@ -58,7 +58,7 @@ QVariant QXmppInvokable::dispatch( const QByteArray & method, const QList< QVari
     const char *typeName = metaObject()->method(idx).typeName();
     int resultType = QMetaType::type(typeName);
 
-    void *result = QMetaType::create(resultType, 0);
+    void *result = QMetaType::create(resultType, nullptr);
 
     QGenericReturnArgument ret( typeName, result );
     QList<QGenericArgument> genericArgs;

--- a/src/client/QXmppInvokable.h
+++ b/src/client/QXmppInvokable.h
@@ -41,9 +41,9 @@ class QXMPP_EXPORT QXmppInvokable : public QObject
 {
         Q_OBJECT
 public:
-        QXmppInvokable( QObject *parent = 0 );
+        QXmppInvokable( QObject *parent = nullptr );
 
-        ~QXmppInvokable();
+        ~QXmppInvokable() override;
 
         /**
          * Execute a method on an object. with a set of arguments. This method is reentrant, and the method

--- a/src/client/QXmppMamManager.h
+++ b/src/client/QXmppMamManager.h
@@ -57,8 +57,8 @@ public:
                                      const QXmppResultSetQuery &resultSetQuery = QXmppResultSetQuery());
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppMessageReceiptManager.h
+++ b/src/client/QXmppMessageReceiptManager.h
@@ -40,8 +40,8 @@ public:
     QXmppMessageReceiptManager();
 
     /// \cond
-    virtual QStringList discoveryFeatures() const;
-    virtual bool handleStanza(const QDomElement &stanza);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &stanza) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -63,14 +63,14 @@ class QXMPP_EXPORT QXmppMucManager : public QXmppClientExtension
 
 public:
     QXmppMucManager();
-    ~QXmppMucManager();
+    ~QXmppMucManager() override;
 
     QXmppMucRoom *addRoom(const QString &roomJid);
     QList<QXmppMucRoom*> rooms() const;
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:
@@ -82,7 +82,7 @@ signals:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client);
+    void setClient(QXmppClient* client) override;
     /// \endcond
 
 private slots:
@@ -123,7 +123,7 @@ public:
     };
     Q_DECLARE_FLAGS(Actions, Action)
 
-    ~QXmppMucRoom();
+    ~QXmppMucRoom() override;
 
     Actions allowedActions() const;
     bool isJoined() const;

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -124,14 +124,14 @@ QXmppOutgoingClientPrivate::QXmppOutgoingClientPrivate(QXmppOutgoingClient *qq)
     , sessionAvailable(false)
     , sessionStarted(false)
     , isAuthenticated(false)
-    , saslClient(0)
+    , saslClient(nullptr)
     , streamManagementAvailable(false)
     , canResume(false)
     , isResuming(false)
     , resumePort(0)
     , clientStateIndicationEnabled(false)
-    , pingTimer(0)
-    , timeoutTimer(0)
+    , pingTimer(nullptr)
+    , timeoutTimer(nullptr)
     , q(qq)
 {
 }
@@ -359,7 +359,7 @@ void QXmppOutgoingClient::handleStart()
     // reset authentication step
     if (d->saslClient) {
         delete d->saslClient;
-        d->saslClient = 0;
+        d->saslClient = nullptr;
     }
 
     // reset session information

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -50,11 +50,11 @@ class QXMPP_EXPORT QXmppOutgoingClient : public QXmppStream
 
 public:
     QXmppOutgoingClient(QObject *parent);
-    ~QXmppOutgoingClient();
+    ~QXmppOutgoingClient() override;
 
     void connectToHost();
     bool isAuthenticated() const;
-    bool isConnected() const;
+    bool isConnected() const override;
     bool isClientStateIndicationEnabled() const;
 
     QSslSocket *socket() const { return QXmppStream::socket(); };
@@ -84,13 +84,13 @@ signals:
 protected:
     /// \cond
     // Overridable methods
-    virtual void handleStart();
-    virtual void handleStanza(const QDomElement &element);
-    virtual void handleStream(const QDomElement &element);
+    void handleStart() override;
+    void handleStanza(const QDomElement &element) override;
+    void handleStream(const QDomElement &element) override;
     /// \endcond
 
 public slots:
-    virtual void disconnectFromHost();
+    void disconnectFromHost() override;
 
 private slots:
     void _q_dnsLookupFinished();

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -67,7 +67,7 @@ class QXMPP_EXPORT QXmppRosterManager : public QXmppClientExtension
 
 public:
     QXmppRosterManager(QXmppClient* stream);
-    ~QXmppRosterManager();
+    ~QXmppRosterManager() override;
 
     bool isRosterReceived() const;
     QStringList getRosterBareJids() const;
@@ -80,7 +80,7 @@ public:
                               const QString& resource) const;
 
     /// \cond
-    bool handleStanza(const QDomElement &element);
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 public slots:

--- a/src/client/QXmppRpcManager.h
+++ b/src/client/QXmppRpcManager.h
@@ -73,9 +73,9 @@ public:
                                               const QVariant &arg10 = QVariant() );
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    virtual QList<QXmppDiscoveryIq::Identity> discoveryIdentities() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    QList<QXmppDiscoveryIq::Identity> discoveryIdentities() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -219,17 +219,17 @@ public:
 
 QXmppTransferJobPrivate::QXmppTransferJobPrivate()
     : blockSize(16384),
-    client(0),
+    client(nullptr),
     direction(QXmppTransferJob::IncomingDirection),
     done(0),
     error(QXmppTransferJob::NoError),
     hash(QCryptographicHash::Md5),
-    iodevice(0),
+    iodevice(nullptr),
     method(QXmppTransferJob::NoMethod),
     state(QXmppTransferJob::OfferState),
     deviceIsOwn(false),
     ibbSequence(0),
-    socksSocket(0)
+    socksSocket(nullptr)
 {
 }
 
@@ -446,8 +446,8 @@ void QXmppTransferJob::terminate(QXmppTransferJob::Error cause)
 /// \cond
 QXmppTransferIncomingJob::QXmppTransferIncomingJob(const QString& jid, QXmppClient* client, QObject* parent)
     : QXmppTransferJob(jid, IncomingDirection, client, parent)
-    , m_candidateClient(0)
-    , m_candidateTimer(0)
+    , m_candidateClient(nullptr)
+    , m_candidateTimer(nullptr)
 {
 }
 
@@ -551,9 +551,9 @@ void QXmppTransferIncomingJob::_q_candidateReady()
 
     setState(QXmppTransferJob::TransferState);
     d->socksSocket = m_candidateClient;
-    m_candidateClient = 0;
+    m_candidateClient = nullptr;
     m_candidateTimer->deleteLater();
-    m_candidateTimer = 0;
+    m_candidateTimer = nullptr;
 
     check = connect(d->socksSocket, SIGNAL(readyRead()),
                     this, SLOT(_q_receiveData()));
@@ -583,9 +583,9 @@ void QXmppTransferIncomingJob::_q_candidateDisconnected()
             QString::number(m_candidateHost.port())));
 
     m_candidateClient->deleteLater();
-    m_candidateClient = 0;
+    m_candidateClient = nullptr;
     m_candidateTimer->deleteLater();
-    m_candidateTimer = 0;
+    m_candidateTimer = nullptr;
 
     // try next host
     connectToNextHost();
@@ -749,7 +749,7 @@ private:
 QXmppTransferManagerPrivate::QXmppTransferManagerPrivate(QXmppTransferManager *qq)
     : ibbBlockSize(4096)
     , proxyOnly(false)
-    , socksServer(0)
+    , socksServer(nullptr)
     , supportedMethods(QXmppTransferJob::AnyMethod)
     , q(qq)
 {
@@ -762,7 +762,7 @@ QXmppTransferJob* QXmppTransferManagerPrivate::getJobByRequestId(QXmppTransferJo
             job->d->jid == jid &&
             job->d->requestId == id)
             return job;
-    return 0;
+    return nullptr;
 }
 
 QXmppTransferIncomingJob *QXmppTransferManagerPrivate::getIncomingJobByRequestId(const QString &jid, const QString &id)
@@ -777,7 +777,7 @@ QXmppTransferIncomingJob* QXmppTransferManagerPrivate::getIncomingJobBySid(const
             job->d->jid == jid &&
             job->d->sid == sid)
             return static_cast<QXmppTransferIncomingJob*>(job);
-    return 0;
+    return nullptr;
 }
 
 QXmppTransferOutgoingJob *QXmppTransferManagerPrivate::getOutgoingJobByRequestId(const QString &jid, const QString &id)
@@ -1298,7 +1298,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, const QStri
 {
     if (QXmppUtils::jidToResource(jid).isEmpty()) {
         warning("The file recipient's JID must be a full JID");
-        return 0;
+        return nullptr;
     }
 
     QFileInfo info(filePath);
@@ -1315,7 +1315,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, const QStri
     {
         warning(QString("Could not read from %1").arg(filePath));
         delete device;
-        device = 0;
+        device = nullptr;
     }
 
     // hash file
@@ -1356,7 +1356,7 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, QIODevice *
 
     if (QXmppUtils::jidToResource(jid).isEmpty()) {
         warning("The file recipient's JID must be a full JID");
-        return 0;
+        return nullptr;
     }
 
     QXmppTransferOutgoingJob *job = new QXmppTransferOutgoingJob(jid, client(), this);

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -134,7 +134,7 @@ public:
         FinishedState = 3  ///< The transfer is finished.
     };
 
-    ~QXmppTransferJob();
+    ~QXmppTransferJob() override;
 
     QXmppTransferJob::Direction direction() const;
     QXmppTransferJob::Error error() const;
@@ -225,7 +225,7 @@ class QXMPP_EXPORT QXmppTransferManager : public QXmppClientExtension
 
 public:
     QXmppTransferManager();
-    ~QXmppTransferManager();
+    ~QXmppTransferManager() override;
 
     QString proxy() const;
     void setProxy(const QString &proxyJid);
@@ -237,8 +237,8 @@ public:
     void setSupportedMethods(QXmppTransferJob::Methods methods);
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:
@@ -262,7 +262,7 @@ public slots:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client);
+    void setClient(QXmppClient* client) override;
     /// \endcond
 
 private slots:

--- a/src/client/QXmppVCardManager.h
+++ b/src/client/QXmppVCardManager.h
@@ -59,7 +59,7 @@ class QXMPP_EXPORT QXmppVCardManager : public QXmppClientExtension
 
 public:
     QXmppVCardManager();
-    ~QXmppVCardManager();
+    ~QXmppVCardManager() override;
 
     QString requestVCard(const QString& bareJid = QString());
 
@@ -70,8 +70,8 @@ public:
     bool isClientVCardReceived() const;
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/client/QXmppVersionManager.h
+++ b/src/client/QXmppVersionManager.h
@@ -40,7 +40,7 @@ class QXMPP_EXPORT QXmppVersionManager : public QXmppClientExtension
 
 public:
     QXmppVersionManager();
-    ~QXmppVersionManager();
+    ~QXmppVersionManager() override;
 
     QString requestVersion(const QString& jid);
 
@@ -53,8 +53,8 @@ public:
     QString clientOs() const;
 
     /// \cond
-    QStringList discoveryFeatures() const;
-    bool handleStanza(const QDomElement &element);
+    QStringList discoveryFeatures() const override;
+    bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
 signals:

--- a/src/server/QXmppDialback.h
+++ b/src/server/QXmppDialback.h
@@ -54,8 +54,8 @@ public:
     void setType(const QString &type);
 
     /// \cond
-    void parse(const QDomElement &element);
-    void toXml(QXmlStreamWriter *writer) const;
+    void parse(const QDomElement &element) override;
+    void toXml(QXmlStreamWriter *writer) const override;
 
     static bool isDialback(const QDomElement &element);
     /// \endcond

--- a/src/server/QXmppIncomingClient.cpp
+++ b/src/server/QXmppIncomingClient.cpp
@@ -58,9 +58,9 @@ private:
 };
 
 QXmppIncomingClientPrivate::QXmppIncomingClientPrivate(QXmppIncomingClient *qq)
-    : idleTimer(0)
-    , passwordChecker(0)
-    , saslServer(0)
+    : idleTimer(nullptr)
+    , passwordChecker(nullptr)
+    , saslServer(nullptr)
     , q(qq)
 {
 }
@@ -184,9 +184,9 @@ void QXmppIncomingClient::handleStream(const QDomElement &streamElement)
 {
     if (d->idleTimer->interval())
         d->idleTimer->start();
-    if (d->saslServer != 0) {
+    if (d->saslServer != nullptr) {
         delete d->saslServer;
-        d->saslServer = 0;
+        d->saslServer = nullptr;
     }
 
     // start stream

--- a/src/server/QXmppIncomingClient.h
+++ b/src/server/QXmppIncomingClient.h
@@ -41,10 +41,10 @@ class QXMPP_EXPORT QXmppIncomingClient : public QXmppStream
     Q_OBJECT
 
 public:
-    QXmppIncomingClient(QSslSocket *socket, const QString &domain, QObject *parent = 0);
-    ~QXmppIncomingClient();
+    QXmppIncomingClient(QSslSocket *socket, const QString &domain, QObject *parent = nullptr);
+    ~QXmppIncomingClient() override;
 
-    bool isConnected() const;
+    bool isConnected() const override;
     QString jid() const;
 
     void setInactivityTimeout(int secs);
@@ -56,8 +56,8 @@ signals:
 
 protected:
     /// \cond
-    void handleStream(const QDomElement &element);
-    void handleStanza(const QDomElement &element);
+    void handleStream(const QDomElement &element) override;
+    void handleStanza(const QDomElement &element) override;
     /// \endcond
 
 private slots:

--- a/src/server/QXmppIncomingServer.h
+++ b/src/server/QXmppIncomingServer.h
@@ -40,9 +40,9 @@ class QXMPP_EXPORT QXmppIncomingServer : public QXmppStream
 
 public:
     QXmppIncomingServer(QSslSocket *socket, const QString &domain, QObject *parent);
-    ~QXmppIncomingServer();
+    ~QXmppIncomingServer() override;
 
-    bool isConnected() const;
+    bool isConnected() const override;
     QString localStreamId() const;
 
 signals:
@@ -54,8 +54,8 @@ signals:
 
 protected:
     /// \cond
-    void handleStanza(const QDomElement &stanzaElement);
-    void handleStream(const QDomElement &streamElement);
+    void handleStanza(const QDomElement &stanzaElement) override;
+    void handleStream(const QDomElement &streamElement) override;
     /// \endcond
 
 private slots:

--- a/src/server/QXmppOutgoingServer.h
+++ b/src/server/QXmppOutgoingServer.h
@@ -43,9 +43,9 @@ class QXMPP_EXPORT QXmppOutgoingServer : public QXmppStream
 
 public:
     QXmppOutgoingServer(const QString &domain, QObject *parent);
-    ~QXmppOutgoingServer();
+    ~QXmppOutgoingServer() override;
 
-    bool isConnected() const;
+    bool isConnected() const override;
 
     QString localStreamKey() const;
     void setLocalStreamKey(const QString &key);
@@ -59,9 +59,9 @@ signals:
 
 protected:
     /// \cond
-    void handleStart();
-    void handleStream(const QDomElement &streamElement);
-    void handleStanza(const QDomElement &stanzaElement);
+    void handleStart() override;
+    void handleStream(const QDomElement &streamElement) override;
+    void handleStanza(const QDomElement &stanzaElement) override;
     /// \endcond
 
 public slots:

--- a/src/server/QXmppPasswordChecker.h
+++ b/src/server/QXmppPasswordChecker.h
@@ -67,7 +67,7 @@ public:
         TemporaryError
     };
 
-    QXmppPasswordReply(QObject *parent = 0);
+    QXmppPasswordReply(QObject *parent = nullptr);
 
     QByteArray digest() const;
     void setDigest(const QByteArray &digest);

--- a/src/server/QXmppServer.cpp
+++ b/src/server/QXmppServer.cpp
@@ -111,8 +111,8 @@ private:
 };
 
 QXmppServerPrivate::QXmppServerPrivate(QXmppServer *qq)
-    : logger(0),
-    passwordChecker(0),
+    : logger(nullptr),
+    passwordChecker(nullptr),
     loaded(false),
     started(false),
     q(qq)
@@ -166,7 +166,7 @@ bool QXmppServerPrivate::routeData(const QString &to, const QByteArray &data)
 
         // if we did not find an outgoing server,
         // we need to establish the S2S connection
-        QXmppOutgoingServer *conn = new QXmppOutgoingServer(domain, 0);
+        QXmppOutgoingServer *conn = new QXmppOutgoingServer(domain, nullptr);
         conn->setLocalStreamKey(QXmppUtils::generateStanzaHash().toLatin1());
         conn->moveToThread(q->thread());
         conn->setParent(q);

--- a/src/server/QXmppServer.h
+++ b/src/server/QXmppServer.h
@@ -62,8 +62,8 @@ class QXMPP_EXPORT QXmppServer : public QXmppLoggable
     Q_PROPERTY(QXmppLogger* logger READ logger WRITE setLogger NOTIFY loggerChanged)
 
 public:
-    QXmppServer(QObject *parent = 0);
-    ~QXmppServer();
+    QXmppServer(QObject *parent = nullptr);
+    ~QXmppServer() override;
 
     void addExtension(QXmppServerExtension *extension);
     QList<QXmppServerExtension*> extensions();
@@ -131,8 +131,8 @@ class QXMPP_EXPORT QXmppSslServer : public QTcpServer
     Q_OBJECT
 
 public:
-    QXmppSslServer(QObject *parent = 0);
-    ~QXmppSslServer();
+    QXmppSslServer(QObject *parent = nullptr);
+    ~QXmppSslServer() override;
 
     void addCaCertificates(const QList<QSslCertificate> &certificates);
     void setLocalCertificate(const QSslCertificate &certificate);

--- a/src/server/QXmppServerExtension.cpp
+++ b/src/server/QXmppServerExtension.cpp
@@ -38,7 +38,7 @@ public:
 QXmppServerExtension::QXmppServerExtension()
     : d(new QXmppServerExtensionPrivate)
 {
-    d->server = 0;
+    d->server = nullptr;
 }
 
 QXmppServerExtension::~QXmppServerExtension()

--- a/src/server/QXmppServerExtension.h
+++ b/src/server/QXmppServerExtension.h
@@ -51,7 +51,7 @@ class QXMPP_EXPORT QXmppServerExtension : public QXmppLoggable
 
 public:
     QXmppServerExtension();
-    ~QXmppServerExtension();
+    ~QXmppServerExtension() override;
     virtual QString extensionName() const;
     virtual int extensionPriority() const;
 

--- a/src/server/QXmppServerPlugin.h
+++ b/src/server/QXmppServerPlugin.h
@@ -55,11 +55,11 @@ public:
     /// Creates and returns the specified QXmppServerExtension.
     ///
     /// \param key The key for the QXmppServerExtension.
-    virtual QXmppServerExtension *create(const QString &key) = 0;
+    QXmppServerExtension *create(const QString &key) override = 0;
 
     /// Returns the list of keys supported by this plugin.
     ///
-    virtual QStringList keys() const = 0;
+    QStringList keys() const override = 0;
 };
 
 #endif

--- a/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
+++ b/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
@@ -47,7 +47,7 @@ private:
 
 void tst_QXmppCallManager::init()
 {
-    receiverCall = 0;
+    receiverCall = nullptr;
 }
 
 void tst_QXmppCallManager::acceptCall(QXmppCall *call)

--- a/tests/qxmppsocks/tst_qxmppsocks.cpp
+++ b/tests/qxmppsocks/tst_qxmppsocks.cpp
@@ -48,7 +48,7 @@ private:
 
 void tst_QXmppSocks::init()
 {
-    m_connectionSocket = 0;
+    m_connectionSocket = nullptr;
     m_connectionHostName = QString();
     m_connectionPort = 0;
 }

--- a/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
+++ b/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
@@ -51,7 +51,7 @@ void tst_QXmppTransferManager::init()
 {
     receiverBuffer.close();
     receiverBuffer.setData(QByteArray());
-    receiverJob = 0;
+    receiverJob = nullptr;
 }
 
 void tst_QXmppTransferManager::acceptFile(QXmppTransferJob *job)

--- a/tests/util.h
+++ b/tests/util.h
@@ -57,7 +57,7 @@ public:
     };
 
     /// Retrieves the password for the given username.
-    QXmppPasswordReply::Error getPassword(const QXmppPasswordRequest &request, QString &password)
+    QXmppPasswordReply::Error getPassword(const QXmppPasswordRequest &request, QString &password) override
     {
         if (m_credentials.contains(request.username()))
         {
@@ -69,7 +69,7 @@ public:
     };
 
     /// Returns whether getPassword() is enabled.
-    bool hasGetPassword() const
+    bool hasGetPassword() const override
     {
         return true;
     };


### PR DESCRIPTION
Using the following checks:
 * modernize-use-nullptr
 * modernize-use-override
 * modernize-use-using
 * modernize-use-bool-literals

This results can be reproduced running the following commands:
```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
run-clang-tidy-6.0 -header-filter='.*' -checks='-*,modernize-use-nullptr,modernize-use-override,modernize-use-using,modernize-use-bool-literals' -fix
```

[<img src="https://user-images.githubusercontent.com/13609393/57555763-6e469c80-7375-11e9-8d79-5d48d32e7ed0.png" width=160>](https://user-images.githubusercontent.com/13609393/57555763-6e469c80-7375-11e9-8d79-5d48d32e7ed0.png)


