### PR TITLE
cmake: Set minimum version first and increase it to 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
+cmake_minimum_required(VERSION 3.3)
 project(qxmpp)
-
-cmake_minimum_required(VERSION 3.2)
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)


### PR DESCRIPTION
This is required to make cmake correctly detect compiler features in a macOS cross compiling environment (https://git.kaidan.im/kaidan/dockerfiles/blob/master/mac-osxcross/Dockerfile) and probably also for some clang setups on a native macOS machine.