### PR TITLE
Port away from deprecated qt features

### DIFF
--- a/src/base/QXmppDiscoveryIq.cpp
+++ b/src/base/QXmppDiscoveryIq.cpp
@@ -199,9 +199,9 @@ QByteArray QXmppDiscoveryIq::verificationString() const
 {
     QString S;
     QList<QXmppDiscoveryIq::Identity> sortedIdentities = m_identities;
-    qSort(sortedIdentities.begin(), sortedIdentities.end(), identityLessThan);
+    std::sort(sortedIdentities.begin(), sortedIdentities.end(), identityLessThan);
     QStringList sortedFeatures = m_features;
-    qSort(sortedFeatures);
+    std::sort(sortedFeatures.begin(), sortedFeatures.end());
     sortedFeatures.removeDuplicates();
     foreach (const QXmppDiscoveryIq::Identity &identity, sortedIdentities)
         S += QString("%1/%2/%3/%4<").arg(identity.category(), identity.type(), identity.language(), identity.name());
@@ -219,7 +219,7 @@ QByteArray QXmppDiscoveryIq::verificationString() const
             S += field.value().toString() + QLatin1String("<");
 
             QStringList keys = fieldMap.keys();
-            qSort(keys);
+            std::sort(keys.begin(), keys.end());
             foreach (const QString &key, keys) {
                 const QXmppDataForm::Field field = fieldMap.value(key);
                 S += key + QLatin1String("<");

--- a/src/base/QXmppJingleIq.cpp
+++ b/src/base/QXmppJingleIq.cpp
@@ -576,7 +576,7 @@ QString QXmppJingleIq::Content::toSdp() const
     QHostAddress localRtpAddress = QHostAddress::Any;
     quint16 localRtpPort = 0;
     QList<QXmppJingleCandidate> sortedCandidates = d->transportCandidates;
-    qSort(sortedCandidates.begin(), sortedCandidates.end(), candidateLessThan);
+    std::sort(sortedCandidates.begin(), sortedCandidates.end(), candidateLessThan);
     foreach (const QXmppJingleCandidate &candidate, sortedCandidates) {
         if (candidate.component() == RTP_COMPONENT) {
             localRtpAddress = candidate.host();

--- a/src/base/QXmppStun.cpp
+++ b/src/base/QXmppStun.cpp
@@ -1834,7 +1834,7 @@ bool QXmppIceComponentPrivate::addRemoteCandidate(const QXmppJingleCandidate &ca
             fallbackPair = pair;
     }
 
-    qSort(pairs.begin(), pairs.end(), candidatePairPtrLessThan);
+    std::sort(pairs.begin(), pairs.end(), candidatePairPtrLessThan);
 
     return true;
 }
@@ -2184,7 +2184,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
             pair->transport = transport;
             d->pairs << pair;
 
-            qSort(d->pairs.begin(), d->pairs.end(), candidatePairPtrLessThan);
+            std::sort(d->pairs.begin(), d->pairs.end(), candidatePairPtrLessThan);
         }
 
         switch (pair->state()) {
@@ -2621,7 +2621,7 @@ bool QXmppIceConnection::bind(const QList<QHostAddress> &addresses)
 
     // assign sockets
     QList<int> keys = d->components.keys();
-    qSort(keys);
+    std::sort(keys.begin(), keys.end());
     int s = 0;
     foreach (int k, keys) {
         d->components[k]->d->setSockets(sockets.mid(s, addresses.size()));

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -25,6 +25,7 @@
 #include <QCryptographicHash>
 #include <QNetworkProxy>
 #include <QSslSocket>
+#include <QSslConfiguration>
 #include <QUrl>
 #include <QDnsLookup>
 
@@ -141,8 +142,11 @@ void QXmppOutgoingClientPrivate::connectToHost(const QString &host, quint16 port
     q->info(QString("Connecting to %1:%2").arg(host, QString::number(port)));
 
     // override CA certificates if requested
-    if (!config.caCertificates().isEmpty())
-        q->socket()->setCaCertificates(config.caCertificates());
+    if (!config.caCertificates().isEmpty()) {
+        QSslConfiguration newSslConfig;
+        newSslConfig.setCaCertificates(config.caCertificates());
+        q->socket()->setSslConfiguration(newSslConfig);
+    }
 
     // respect proxy
     q->socket()->setProxy(config.networkProxy());


### PR DESCRIPTION
This fixes multiple warnings when compiling with Qt 5.13 and will simplify the transition to Qt 6 once it's released.

The next thing to do (in a new PR) is porting away from the deprecated foreach (also known as Q_FOREACH) macro which is unfortunately used 155 times...