### PR TITLE
Add register stream feature

### DIFF
--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -63,6 +63,7 @@ const char* ns_oob = "jabber:x:oob";
 const char *ns_xhtml_im = "http://jabber.org/protocol/xhtml-im";
 // XEP-0077: In-Band Registration
 const char* ns_register = "jabber:iq:register";
+const char* ns_register_feature = "http://jabber.org/features/iq-register";
 // XEP-0078: Non-SASL Authentication
 const char* ns_auth = "jabber:iq:auth";
 const char* ns_authFeature = "http://jabber.org/features/iq-auth";

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -75,6 +75,7 @@ extern const char* ns_oob;
 extern const char *ns_xhtml_im;
 // XEP-0077: In-Band Registration
 extern const char* ns_register;
+extern const char* ns_register_feature;
 // XEP-0078: Non-SASL Authentication
 extern const char* ns_auth;
 extern const char* ns_authFeature;

--- a/src/base/QXmppStreamFeatures.cpp
+++ b/src/base/QXmppStreamFeatures.cpp
@@ -116,6 +116,16 @@ void QXmppStreamFeatures::setClientStateIndicationMode(QXmppStreamFeatures::Mode
     m_csiMode = mode;
 }
 
+QXmppStreamFeatures::Mode QXmppStreamFeatures::registerMode() const
+{
+    return m_registerMode;
+}
+
+void QXmppStreamFeatures::setRegisterMode(const QXmppStreamFeatures::Mode &registerMode)
+{
+    m_registerMode = registerMode;
+}
+
 /// \cond
 bool QXmppStreamFeatures::isStreamFeatures(const QDomElement &element)
 {
@@ -148,6 +158,7 @@ void QXmppStreamFeatures::parse(const QDomElement &element)
     m_tlsMode = readFeature(element, "starttls", ns_tls);
     m_streamManagementMode = readFeature(element, "sm", ns_stream_management);
     m_csiMode = readFeature(element, "csi", ns_csi);
+    m_registerMode = readFeature(element, "register", ns_register_feature);
 
     // parse advertised compression methods
     QDomElement compression = element.firstChildElement("compression");
@@ -194,6 +205,7 @@ void QXmppStreamFeatures::toXml(QXmlStreamWriter *writer) const
     writeFeature(writer, "starttls", ns_tls, m_tlsMode);
     writeFeature(writer, "sm", ns_stream_management, m_streamManagementMode);
     writeFeature(writer, "csi", ns_csi, m_csiMode);
+    writeFeature(writer, "register", ns_register_feature, m_registerMode);
 
     if (!m_compressionMethods.isEmpty())
     {

--- a/src/base/QXmppStreamFeatures.h
+++ b/src/base/QXmppStreamFeatures.h
@@ -73,6 +73,14 @@ public:
     /// \pa mode The mode to set.
     void setClientStateIndicationMode(Mode mode);
 
+    /// Returns the mode for XEP-0077: In-Band Registration
+    Mode registerMode() const;
+
+    /// Sets the mode for XEP-0077: In-Band Registration
+    ///
+    /// \pa mode The mode to set.
+    void setRegisterMode(const Mode &registerMode);
+
     /// \cond
     void parse(const QDomElement &element);
     void toXml(QXmlStreamWriter *writer) const;
@@ -87,6 +95,7 @@ private:
     Mode m_tlsMode;
     Mode m_streamManagementMode;
     Mode m_csiMode;
+    Mode m_registerMode;
     QStringList m_authMechanisms;
     QStringList m_compressionMethods;
 };

--- a/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
+++ b/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
@@ -30,6 +30,7 @@ class tst_QXmppStreamFeatures : public QObject
 
 private slots:
     void testEmpty();
+    void testRequired();
     void testFull();
 };
 
@@ -44,8 +45,24 @@ void tst_QXmppStreamFeatures::testEmpty()
     QCOMPARE(features.nonSaslAuthMode(), QXmppStreamFeatures::Disabled);
     QCOMPARE(features.tlsMode(), QXmppStreamFeatures::Disabled);
     QCOMPARE(features.clientStateIndicationMode(), QXmppStreamFeatures::Disabled);
+    QCOMPARE(features.registerMode(), QXmppStreamFeatures::Disabled);
     QCOMPARE(features.authMechanisms(), QStringList());
     QCOMPARE(features.compressionMethods(), QStringList());
+    serializePacket(features, xml);
+}
+
+void tst_QXmppStreamFeatures::testRequired()
+{
+    const QByteArray xml(
+        "<stream:features>"
+            "<starttls xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\">"
+                "<required/>"
+            "</starttls>"
+        "</stream:features>");
+
+    QXmppStreamFeatures features;
+    parsePacket(features, xml);
+    QCOMPARE(features.tlsMode(), QXmppStreamFeatures::Required);
     serializePacket(features, xml);
 }
 
@@ -57,6 +74,7 @@ void tst_QXmppStreamFeatures::testFull()
         "<auth xmlns=\"http://jabber.org/features/iq-auth\"/>"
         "<starttls xmlns=\"urn:ietf:params:xml:ns:xmpp-tls\"/>"
         "<csi xmlns=\"urn:xmpp:csi:0\"/>"
+        "<register xmlns=\"http://jabber.org/features/iq-register\"/>"
         "<compression xmlns=\"http://jabber.org/features/compress\"><method>zlib</method></compression>"
         "<mechanisms xmlns=\"urn:ietf:params:xml:ns:xmpp-sasl\"><mechanism>PLAIN</mechanism></mechanisms>"
         "</stream:features>");
@@ -68,6 +86,7 @@ void tst_QXmppStreamFeatures::testFull()
     QCOMPARE(features.nonSaslAuthMode(), QXmppStreamFeatures::Enabled);
     QCOMPARE(features.tlsMode(), QXmppStreamFeatures::Enabled);
     QCOMPARE(features.clientStateIndicationMode(), QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.registerMode(), QXmppStreamFeatures::Enabled);
     QCOMPARE(features.authMechanisms(), QStringList() << "PLAIN");
     QCOMPARE(features.compressionMethods(), QStringList() << "zlib");
     serializePacket(features, xml);

--- a/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
+++ b/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
@@ -32,6 +32,7 @@ private slots:
     void testEmpty();
     void testRequired();
     void testFull();
+    void testSetters();
 };
 
 void tst_QXmppStreamFeatures::testEmpty()
@@ -90,6 +91,30 @@ void tst_QXmppStreamFeatures::testFull()
     QCOMPARE(features.authMechanisms(), QStringList() << "PLAIN");
     QCOMPARE(features.compressionMethods(), QStringList() << "zlib");
     serializePacket(features, xml);
+}
+
+void tst_QXmppStreamFeatures::testSetters()
+{
+    QXmppStreamFeatures features;
+    features.setBindMode(QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.bindMode(), QXmppStreamFeatures::Enabled);
+    features.setSessionMode(QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.sessionMode(), QXmppStreamFeatures::Enabled);
+    features.setNonSaslAuthMode(QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.nonSaslAuthMode(), QXmppStreamFeatures::Enabled);
+    features.setTlsMode(QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.tlsMode(), QXmppStreamFeatures::Enabled);
+    features.setClientStateIndicationMode(QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.clientStateIndicationMode(), QXmppStreamFeatures::Enabled);
+    features.setClientStateIndicationMode(QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.clientStateIndicationMode(), QXmppStreamFeatures::Enabled);
+    features.setRegisterMode(QXmppStreamFeatures::Enabled);
+    QCOMPARE(features.registerMode(), QXmppStreamFeatures::Enabled);
+
+    features.setAuthMechanisms(QStringList() << "custom-mechanism");
+    QCOMPARE(features.authMechanisms(), QStringList() << "custom-mechanism");
+    features.setCompressionMethods(QStringList() << "compression-methods");
+    QCOMPARE(features.compressionMethods(), QStringList() << "compression-methods");
 }
 
 QTEST_MAIN(tst_QXmppStreamFeatures)


### PR DESCRIPTION
This adds parsing, serialization and a test for the 'register' stream
feature of XEP-0077: In-Band Registration.

Co-authored-by: Linus Jahn <lnj@kaidan.im>

---

This will be required for actually registering with a server (PRs for that will follow).