### PR TITLE
Implement XEP-0334: Message Processing Hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ QXmpp 1.0.1 (UNRELEASED)
 
 New features:
  - Add support for SCRAM-SHA-1 and SCRAM-SHA-256 (#183, @jlaine)
+ - Add XEP-0334: Message Processing Hints (v0.3.0) (#212, @lnjX, @jaragont,
+   @sam-truscott)
  - Add XEP-0367: Message Attaching (v0.3.0) (#196, @lnjX)
  - Add XEP-0380: Explicit Message Encryption (v0.3.0) (#199, @lnjX)
  - Add XEP-0382: Spoiler messages (v0.2.0) (#195, @lnjX)

--- a/doc/xep.doc
+++ b/doc/xep.doc
@@ -40,6 +40,7 @@ Complete:
 - XEP-0308: Last Message Correction
 - XEP-0313: Message Archive Management
 - XEP-0319: Last User Interaction in Presence
+- XEP-0334: Message Processing Hints (v0.3.0)
 - XEP-0352: Client State Indication
 - XEP-0367: Message Attaching (v0.3.0)
 - XEP-0380: Explicit Message Encryption (v0.3.0)

--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -133,6 +133,8 @@ const char* ns_mam = "urn:xmpp:mam:1";
 const char* ns_idle = "urn:xmpp:idle:1";
 // XEP-0333: Chat Markers
 const char* ns_chat_markers = "urn:xmpp:chat-markers:0";
+// XEP-0334: Message Processing Hints
+const char* ns_message_processing_hints = "urn:xmpp:hints";
 // XEP-0352: Client State Indication
 const char* ns_csi = "urn:xmpp:csi:0";
 // XEP-0363: HTTP File Upload

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -145,6 +145,8 @@ extern const char* ns_mam;
 extern const char* ns_idle;
 // XEP-0333: Char Markers
 extern const char* ns_chat_markers;
+// XEP-0334: Message Processing Hints:
+extern const char* ns_message_processing_hints;
 // XEP-0352: Client State Indication
 extern const char* ns_csi;
 // XEP-0363: HTTP File Upload

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -66,6 +66,14 @@ public:
         Acknowledged
     };
 
+    /// XEP-0334: Message Processing Hints
+    enum Hint {
+        NoPermanentStore = 1 << 0,  ///< Do not allow permanent storage
+        NoStore = 1 << 1,           ///< Do not store at all
+        NoCopy = 1 << 2,            ///< Do not copy the message
+        Store = 1 << 3              ///< Do store the message
+    };
+
     /// This enum describes different end-to-end encryption methods. These can
     /// be used to mark a message explicitly as encrypted with a specific
     /// algothim. See XEP-0380: Explicit Message Encryption for details.
@@ -151,6 +159,12 @@ public:
     // XEP-0308: Last Message Correction
     QString replaceId() const;
     void setReplaceId(const QString&);
+
+    // XEP-0334: Message Processing Hints
+    bool hasHint(const Hint hint) const;
+    void addHint(const Hint hint);
+    void removeHint(const Hint hint);
+    void removeAllHints();
 
     // XEP-0367: Message Attaching
     QString attachId() const;


### PR DESCRIPTION
REPLACES #10!

This implements parsing and serialization of XEP-0334: Message
Processing Hints in version 0.3.0.

https://xmpp.org/extensions/xep-0334.html

Co-authored-by: Juan Aragon <jaaragont@gmail.com>
Co-authored-by: Sam Truscott <sam@wumpus.co.uk>