### PR TITLE
Refactor & clean up QXmppMessage

### DIFF
--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -62,6 +62,7 @@ const char* ns_bytestreams = "http://jabber.org/protocol/bytestreams";
 // XEP-0066: Out of Band Data
 const char* ns_oob = "jabber:x:oob";
 // XEP-0071: XHTML-IM
+const char *ns_xhtml = "http://www.w3.org/1999/xhtml";
 const char *ns_xhtml_im = "http://jabber.org/protocol/xhtml-im";
 // XEP-0077: In-Band Registration
 const char* ns_register = "jabber:iq:register";

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -74,6 +74,7 @@ extern const char* ns_bytestreams;
 // XEP-0066: Out of Band Data
 extern const char* ns_oob;
 // XEP-0071: XHTML-IM
+extern const char *ns_xhtml;
 extern const char *ns_xhtml_im;
 // XEP-0077: In-Band Registration
 extern const char* ns_register;

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -3,6 +3,8 @@
  *
  * Author:
  *  Manjeet Dahiya
+ *  Jeremy Lainé
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp
@@ -24,7 +26,6 @@
 #ifndef QXMPPMESSAGE_H
 #define QXMPPMESSAGE_H
 
-#include <QDateTime>
 #include "QXmppStanza.h"
 
 class QXmppMessagePrivate;
@@ -36,9 +37,8 @@ class QXmppMessagePrivate;
 class QXMPP_EXPORT QXmppMessage : public QXmppStanza
 {
 public:
-    /// This enum described a message type.
-    enum Type
-    {
+    /// This enum describes a message type.
+    enum Type {
         Error = 0,
         Normal,
         Chat,
@@ -48,8 +48,7 @@ public:
 
     /// This enum describes a chat state as defined by XEP-0085: Chat State
     /// Notifications.
-    enum State
-    {
+    enum State {
         None = 0,   ///< The message does not contain any chat state information.
         Active,     ///< User is actively participating in the chat session.
         Inactive,   ///< User has not been actively participating in the chat session.
@@ -94,6 +93,8 @@ public:
 
     QXmppMessage& operator=(const QXmppMessage &other);
 
+    bool isXmppStanza() const override;
+
     QString body() const;
     void setBody(const QString&);
 
@@ -133,7 +134,7 @@ public:
     QString xhtml() const;
     void setXhtml(const QString &xhtml);
 
-    // XEP-0333: Chat Markers
+    // XEP-0333: Chat State Markers
     bool isMarkable() const;
     void setMarkable(const bool);
 
@@ -149,8 +150,6 @@ public:
     // XEP-0280: Message Carbons
     bool isPrivate() const;
     void setPrivate(const bool);
-
-    bool isXmppStanza() const override;
 
     // XEP-0066: Out of Band Data
     QString outOfBandUrl() const;
@@ -199,6 +198,9 @@ public:
     /// \endcond
 
 private:
+    void parseExtension(const QDomElement &element, QXmppElementList &unknownElements);
+    void parseXElement(const QDomElement &element, QXmppElementList &unknownElements);
+
     QSharedDataPointer<QXmppMessagePrivate> d;
 };
 


### PR DESCRIPTION
This simplifies parsing and fixes a possible bug:
The bug case looks like this:
 - We have one element we want to parse (e,g, "attachment" with namespace xyz)
 - There is another element called "attachment" in the stanza and it's
   located before the other element.
 - QXmppMessage tries to parse the attachment element using
   firstChildElement("attachment") and checks the namespace
 - The namespace (of the first) element doesn't match
 - The actual "attachment" element is not parsed

This also fixes the "constructor does not initialize these fields: […]"
warnings for QXmppMessagePrivate.