### PR TITLE
Fix potential SEGFAULT on connection error

### DIFF
--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -165,11 +165,10 @@ void QXmppOutgoingClientPrivate::connectToHost(const QString &host, quint16 port
 
 void QXmppOutgoingClientPrivate::connectToNextDNSHost()
 {
+    auto curIdx = nextSrvRecordIdx++;
     connectToHost(
-        dns.serviceRecords().at(nextSrvRecordIdx).target(),
-        dns.serviceRecords().at(nextSrvRecordIdx).port());
-
-    nextSrvRecordIdx++;
+        dns.serviceRecords().at(curIdx).target(),
+        dns.serviceRecords().at(curIdx).port());
 }
 
 /// Constructs an outgoing client stream.


### PR DESCRIPTION
`socketError()` calls `connectToNextDNSHost()` which might cause `socketError()` synchronously (and recursively), thus not giving a change for updating `nextSrvRecordIdx`.

Overall, this results in attempting to connect to the same DNS record recursively, until the stack is exhausted, resulting in SEGFAULT.

One of the solutions (done in this commit) is to increment the record index _before_ attempting to connect.

Despite "potential" in the name, it turns out to be a real issue one of the users of my software has faced, resulting in ~76000 frames of
```
#76768 0x00007fb51e57cdea in QAbstractSocket::connectToHost(QString const&, unsigned short, QFlags<QIODevice::OpenModeFlag>, QAbstractSocket::NetworkLayerProtocol) () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76769 0x00007fb51e5ae8b5 in QSslSocket::connectToHost(QString const&, unsigned short, QFlags<QIODevice::OpenModeFlag>, QAbstractSocket::NetworkLayerProtocol) () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76770 0x00007fb4e5769014 in QXmppOutgoingClientPrivate::connectToHost(QString const&, unsigned short) () at /usr/lib/x86_64-linux-gnu/libqxmpp.so.1
#76771 0x00007fb4e576966c in QXmppOutgoingClientPrivate::connectToNextDNSHost() () at /usr/lib/x86_64-linux-gnu/libqxmpp.so.1
#76772 0x00007fb4e5769a23 in QXmppOutgoingClient::socketError(QAbstractSocket::SocketError) () at /usr/lib/x86_64-linux-gnu/libqxmpp.so.1
#76773 0x00007fb51d53c906 in QMetaObject::activate(QObject*, int, int, void**) () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#76774 0x00007fb51e578de1 in QAbstractSocket::error(QAbstractSocket::SocketError) () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76775 0x00007fb51e5ac50e in  () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76776 0x00007fb51e5b3dcf in  () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76777 0x00007fb51d53c906 in QMetaObject::activate(QObject*, int, int, void**) () at /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
#76778 0x00007fb51e578de1 in QAbstractSocket::error(QAbstractSocket::SocketError) () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76779 0x00007fb51e57cdea in QAbstractSocket::connectToHost(QString const&, unsigned short, QFlags<QIODevice::OpenModeFlag>, QAbstractSocket::NetworkLayerProtocol) () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76780 0x00007fb51e5ae8b5 in QSslSocket::connectToHost(QString const&, unsigned short, QFlags<QIODevice::OpenModeFlag>, QAbstractSocket::NetworkLayerProtocol) () at /usr/lib/x86_64-linux-gnu/libQt5Network.so.5
#76781 0x00007fb4e5769014 in QXmppOutgoingClientPrivate::connectToHost(QString const&, unsigned short) () at /usr/lib/x86_64-linux-gnu/libqxmpp.so.1
#76782 0x00007fb4e576966c in QXmppOutgoingClientPrivate::connectToNextDNSHost() () at /usr/lib/x86_64-linux-gnu/libqxmpp.so.1
#76783 0x00007fb4e5769a23 in QXmppOutgoingClient::socketError(QAbstractSocket::SocketError) () at /usr/lib/x86_64-linux-gnu/libqxmpp.so.1
```