### PR TITLE
Revert "Implement MIX-PAM XEP-0405: Roster IQ extension"

### DIFF
--- a/src/base/QXmppRosterIq.cpp
+++ b/src/base/QXmppRosterIq.cpp
@@ -36,8 +36,6 @@ public:
     QList<QXmppRosterIq::Item> items;
     // XEP-0237 Roster Versioning
     QString version;
-    // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    bool mixAnnotate = false;
 };
 
 QXmppRosterIq::QXmppRosterIq()
@@ -85,21 +83,6 @@ void QXmppRosterIq::setVersion(const QString &version)
     d->version = version;
 }
 
-/// Whether to annotate which items are MIX channels.
-
-bool QXmppRosterIq::mixAnnotate() const
-{
-    return d->mixAnnotate;
-}
-
-/// Sets whether to include which roster items are MIX channels. This MUST only
-/// be enabled in get requests.
-
-void QXmppRosterIq::setMixAnnotate(bool mixAnnotate)
-{
-    d->mixAnnotate = mixAnnotate;
-}
-
 /// \cond
 bool QXmppRosterIq::isRosterIq(const QDomElement &element)
 {
@@ -109,20 +92,16 @@ bool QXmppRosterIq::isRosterIq(const QDomElement &element)
 void QXmppRosterIq::parseElementFromChild(const QDomElement &element)
 {
     QDomElement queryElement = element.firstChildElement("query");
-    setVersion(queryElement.attribute("ver"));
-
     QDomElement itemElement = queryElement.firstChildElement("item");
+
+    setVersion(queryElement.attribute("ver"));
     while(!itemElement.isNull())
     {
         QXmppRosterIq::Item item;
         item.parse(itemElement);
         d->items.append(item);
-        itemElement = itemElement.nextSiblingElement("item");
+        itemElement = itemElement.nextSiblingElement();
     }
-
-    QDomElement annotateElement = queryElement.firstChildElement("annotate");
-    setMixAnnotate(!annotateElement.isNull() && annotateElement.namespaceURI()
-                   == ns_mix_roster);
 }
 
 void QXmppRosterIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
@@ -131,17 +110,9 @@ void QXmppRosterIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     writer->writeAttribute( "xmlns", ns_roster);
 
     // XEP-0237 roster versioning - If the server does not advertise support for roster versioning, the client MUST NOT include the 'ver' attribute.
-    if (!version().isEmpty())
-        writer->writeAttribute("ver", version());
-
-    // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    if (d->mixAnnotate) {
-        writer->writeStartElement("annotate");
-        writer->writeAttribute("xmlns", ns_mix_roster);
-        writer->writeEndElement();
-    }
-
-    for (int i = 0; i < d->items.count(); ++i)
+    if(!version().isEmpty())
+        writer->writeAttribute( "ver", version());
+    for(int i = 0; i < d->items.count(); ++i)
         d->items.at(i).toXml(writer);
     writer->writeEndElement();
 }
@@ -156,9 +127,6 @@ public:
     // can be subscribe/unsubscribe (attribute "ask")
     QString subscriptionStatus;
     QSet<QString> groups;
-    // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    bool isMixChannel = false;
-    QString mixParticipantId;
 };
 
 /// Constructs a new roster entry.
@@ -321,34 +289,6 @@ void QXmppRosterIq::Item::setSubscriptionTypeFromStr(const QString& type)
         qWarning("QXmppRosterIq::Item::setTypeFromStr(): invalid type");
 }
 
-/// Returns whether this is a MIX channel.
-
-bool QXmppRosterIq::Item::isMixChannel() const
-{
-    return d->isMixChannel;
-}
-
-/// Sets whether this is a MIX channel.
-
-void QXmppRosterIq::Item::setIsMixChannel(bool isMixChannel)
-{
-    d->isMixChannel = isMixChannel;
-}
-
-/// Returns the participant id for this MIX channel.
-
-QString QXmppRosterIq::Item::mixParticipantId() const
-{
-    return d->mixParticipantId;
-}
-
-/// Sets the participant id for this MIX channel.
-
-void QXmppRosterIq::Item::setMixParticipantId(const QString& participantId)
-{
-    d->mixParticipantId = participantId;
-}
-
 /// \cond
 void QXmppRosterIq::Item::parse(const QDomElement &element)
 {
@@ -362,13 +302,6 @@ void QXmppRosterIq::Item::parse(const QDomElement &element)
     {
         d->groups << groupElement.text();
         groupElement = groupElement.nextSiblingElement("group");
-    }
-
-    // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    QDomElement channelElement = element.firstChildElement("channel");
-    if (!channelElement.isNull() && channelElement.namespaceURI() == ns_mix_roster) {
-        d->isMixChannel = true;
-        d->mixParticipantId = channelElement.attribute("participant-id");
     }
 }
 
@@ -386,15 +319,6 @@ void QXmppRosterIq::Item::toXml(QXmlStreamWriter *writer) const
         helperToXmlAddTextElement(writer,"group", *i);
         ++i;
     }
-
-    // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    if (d->isMixChannel) {
-        writer->writeStartElement("channel");
-        writer->writeAttribute("xmlns", ns_mix_roster);
-        helperToXmlAddAttribute(writer, "participant-id", d->mixParticipantId);
-        writer->writeEndElement();
-    }
-
     writer->writeEndElement();
 }
 /// \endcond

--- a/src/base/QXmppRosterIq.h
+++ b/src/base/QXmppRosterIq.h
@@ -80,13 +80,6 @@ public:
         void setSubscriptionStatus(const QString&);
         void setSubscriptionType(SubscriptionType);
 
-        // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-        bool isMixChannel() const;
-        void setIsMixChannel(bool);
-
-        QString mixParticipantId() const;
-        void setMixParticipantId(const QString&);
-
         /// \cond
         void parse(const QDomElement &element);
         void toXml(QXmlStreamWriter *writer) const;
@@ -110,10 +103,6 @@ public:
 
     void addItem(const Item&);
     QList<Item> items() const;
-
-    // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    bool mixAnnotate() const;
-    void setMixAnnotate(bool);
 
     /// \cond
     static bool isRosterIq(const QDomElement &element);

--- a/tests/qxmpprosteriq/tst_qxmpprosteriq.cpp
+++ b/tests/qxmpprosteriq/tst_qxmpprosteriq.cpp
@@ -34,8 +34,6 @@ private slots:
     void testItem();
     void testVersion_data();
     void testVersion();
-    void testMixAnnotate();
-    void testMixChannel();
 };
 
 void tst_QXmppRosterIq::testItem_data()
@@ -114,46 +112,6 @@ void tst_QXmppRosterIq::testVersion()
     parsePacket(iq, xml);
     QCOMPARE(iq.version(), version);
     serializePacket(iq, xml);
-}
-
-void tst_QXmppRosterIq::testMixAnnotate()
-{
-    const QByteArray xml(
-        "<iq from=\"juliet@example.com/balcony\" "
-            "type=\"get\">"
-            "<query xmlns=\"jabber:iq:roster\">"
-                "<annotate xmlns=\"urn:xmpp:mix:roster:0\"/>"
-            "</query>"
-        "</iq>"
-    );
-
-    QXmppRosterIq iq;
-    parsePacket(iq, xml);
-    QCOMPARE(iq.mixAnnotate(), true);
-    serializePacket(iq, xml);
-
-    iq.setMixAnnotate(false);
-    QCOMPARE(iq.mixAnnotate(), false);
-}
-
-void tst_QXmppRosterIq::testMixChannel()
-{
-    const QByteArray xml(
-        "<item jid=\"balcony@example.net\">"
-            "<channel xmlns=\"urn:xmpp:mix:roster:0\" participant-id=\"123456\"/>"
-        "</item>"
-    );
-
-    QXmppRosterIq::Item item;
-    parsePacket(item, xml);
-    QCOMPARE(item.isMixChannel(), true);
-    QCOMPARE(item.mixParticipantId(), QString("123456"));
-    serializePacket(item, xml);
-
-    item.setIsMixChannel(false);
-    QCOMPARE(item.isMixChannel(), false);
-    item.setMixParticipantId("23a7n");
-    QCOMPARE(item.mixParticipantId(), QString("23a7n"));
 }
 
 QTEST_MAIN(tst_QXmppRosterIq)


### PR DESCRIPTION
This reverts commit 740a085ef7ac707e2cc2217edf02e296c3f7692e.

There were talks on the standards mailing list that the XEP will be
changed and a private PEP node is used for distributing joined channels.
Also no server (that I am aware of) supports the MIX roster extension,
so I think it is the best we remove before the next release, so we do
not have problems with deprecations and ABI compatibility.