### PR TITLE
Replace deprecated Q_ENUMS with Q_ENUM

### DIFF
--- a/src/base/QXmppIq.h
+++ b/src/base/QXmppIq.h
@@ -43,8 +43,7 @@ class QXMPP_EXPORT QXmppIq : public QXmppStanza
 {
 public:
     /// This enum describes the type of IQ.
-    enum Type
-    {
+    enum Type {
         Error = 0,  ///< Error response.
         Get,        ///< Get request.
         Set,        ///< Set request.

--- a/src/base/QXmppLogger.h
+++ b/src/base/QXmppLogger.h
@@ -45,7 +45,6 @@ class QXmppLoggerPrivate;
 class QXMPP_EXPORT QXmppLogger : public QObject
 {
     Q_OBJECT
-    Q_ENUMS(LoggingType)
     Q_FLAGS(MessageType MessageTypes)
     Q_PROPERTY(QString logFilePath READ logFilePath WRITE setLogFilePath)
     Q_PROPERTY(LoggingType loggingType READ loggingType WRITE setLoggingType)
@@ -60,6 +59,7 @@ public:
         StdoutLogging = 2,  ///< Log messages are written to the standard output
         SignalLogging = 4   ///< Log messages are emitted as a signal
     };
+    Q_ENUM(LoggingType)
 
     /// This enum describes a type of log message.
     enum MessageType

--- a/src/base/QXmppRtpChannel.h
+++ b/src/base/QXmppRtpChannel.h
@@ -75,7 +75,6 @@ private:
 class QXMPP_EXPORT QXmppRtpAudioChannel : public QIODevice, public QXmppRtpChannel
 {
     Q_OBJECT
-    Q_ENUMS(Tone)
 
 public:
     /// This enum is used to describe a DTMF tone.
@@ -97,6 +96,7 @@ public:
         Tone_C,     ///< Tone for the C key.
         Tone_D      ///< Tone for the D key.
     };
+    Q_ENUM(Tone)
 
     QXmppRtpAudioChannel(QObject *parent = nullptr);
     ~QXmppRtpAudioChannel() override;

--- a/src/base/QXmppStun.h
+++ b/src/base/QXmppStun.h
@@ -241,16 +241,15 @@ private:
 class QXMPP_EXPORT QXmppIceConnection : public QXmppLoggable
 {
     Q_OBJECT
-    Q_ENUMS(GatheringState)
     Q_PROPERTY(QXmppIceConnection::GatheringState gatheringState READ gatheringState NOTIFY gatheringStateChanged)
 
 public:
-    enum GatheringState
-    {
+    enum GatheringState {
         NewGatheringState,
         BusyGatheringState,
         CompleteGatheringState
     };
+    Q_ENUM(GatheringState)
 
     QXmppIceConnection(QObject *parent = nullptr);
     ~QXmppIceConnection() override;

--- a/src/client/QXmppCallManager.h
+++ b/src/client/QXmppCallManager.h
@@ -53,7 +53,6 @@ class QXmppRtpVideoChannel;
 class QXMPP_EXPORT QXmppCall : public QXmppLoggable
 {
     Q_OBJECT
-    Q_ENUMS(Direction State)
     Q_FLAGS(QIODevice::OpenModeFlag QIODevice::OpenMode)
     Q_PROPERTY(Direction direction READ direction CONSTANT)
     Q_PROPERTY(QString jid READ jid CONSTANT)
@@ -63,20 +62,20 @@ class QXMPP_EXPORT QXmppCall : public QXmppLoggable
 
 public:
     /// This enum is used to describe the direction of a call.
-    enum Direction
-    {
+    enum Direction {
         IncomingDirection, ///< The call is incoming.
         OutgoingDirection  ///< The call is outgoing.
     };
+    Q_ENUM(Direction)
 
     /// This enum is used to describe the state of a call.
-    enum State
-    {
+    enum State {
         ConnectingState = 0,    ///< The call is being connected.
         ActiveState = 1,        ///< The call is active.
         DisconnectingState = 2, ///< The call is being disconnected.
         FinishedState = 3       ///< The call is finished.
     };
+    Q_ENUM(State)
 
     ~QXmppCall() override;
 

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -80,28 +80,27 @@ class QXmppVersionManager;
 class QXMPP_EXPORT QXmppClient : public QXmppLoggable
 {
     Q_OBJECT
-    Q_ENUMS(Error State)
     Q_PROPERTY(QXmppLogger* logger READ logger WRITE setLogger NOTIFY loggerChanged)
     Q_PROPERTY(State state READ state NOTIFY stateChanged)
 
 public:
     /// An enumeration for type of error.
     /// Error could come due a TCP socket or XML stream or due to various stanzas.
-    enum Error
-    {
+    enum Error {
         NoError,            ///< No error.
         SocketError,        ///< Error due to TCP socket.
         KeepAliveError,     ///< Error due to no response to a keep alive.
         XmppStreamError     ///< Error due to XML stream.
     };
+    Q_ENUM(Error)
 
     /// This enumeration describes a client state.
-    enum State
-    {
+    enum State {
         DisconnectedState,  ///< Disconnected from the server.
         ConnectingState,    ///< Trying to connect to the server.
         ConnectedState      ///< Connected to the server.
     };
+    Q_ENUM(State)
 
     QXmppClient(QObject *parent = nullptr);
     ~QXmppClient() override;

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -86,7 +86,6 @@ private:
 class QXMPP_EXPORT QXmppTransferJob : public QXmppLoggable
 {
     Q_OBJECT
-    Q_ENUMS(Direction Error State)
     Q_FLAGS(Method Methods)
     Q_PROPERTY(Direction direction READ direction CONSTANT)
     Q_PROPERTY(QUrl localFileUrl READ localFileUrl WRITE setLocalFileUrl NOTIFY localFileUrlChanged)
@@ -99,30 +98,30 @@ class QXMPP_EXPORT QXmppTransferJob : public QXmppLoggable
 
 public:
     /// This enum is used to describe the direction of a transfer job.
-    enum Direction
-    {
+    enum Direction {
         IncomingDirection, ///< The file is being received.
         OutgoingDirection  ///< The file is being sent.
     };
+    Q_ENUM(Direction)
 
     /// This enum is used to describe the type of error encountered by a transfer job.
-    enum Error
-    {
+    enum Error {
         NoError = 0,      ///< No error occurred.
         AbortError,       ///< The file transfer was aborted.
         FileAccessError,  ///< An error was encountered trying to access a local file.
         FileCorruptError, ///< The file is corrupt: the file size or hash do not match.
         ProtocolError     ///< An error was encountered in the file transfer protocol.
     };
+    Q_ENUM(Error)
 
     /// This enum is used to describe a transfer method.
-    enum Method
-    {
+    enum Method {
         NoMethod = 0,     ///< No transfer method.
         InBandMethod = 1, ///< XEP-0047: In-Band Bytestreams
         SocksMethod = 2,  ///< XEP-0065: SOCKS5 Bytestreams
         AnyMethod = 3     ///< Any supported transfer method.
     };
+    Q_ENUM(Method)
     Q_DECLARE_FLAGS(Methods, Method)
 
     /// This enum is used to describe the state of a transfer job.
@@ -133,6 +132,7 @@ public:
         TransferState = 2, ///< The transfer is ongoing.
         FinishedState = 3  ///< The transfer is finished.
     };
+    Q_ENUM(State)
 
     ~QXmppTransferJob() override;
 

--- a/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
+++ b/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
@@ -29,8 +29,6 @@
 #include "QXmppServer.h"
 #include "util.h"
 
-//Q_DECLARE_METATYPE(QXmppTransferJob::Method)
-
 class tst_QXmppCallManager : public QObject
 {
     Q_OBJECT

--- a/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
+++ b/tests/qxmpptransfermanager/tst_qxmpptransfermanager.cpp
@@ -29,8 +29,6 @@
 #include "QXmppTransferManager.h"
 #include "util.h"
 
-Q_DECLARE_METATYPE(QXmppTransferJob::Method)
-
 class tst_QXmppTransferManager : public QObject
 {
     Q_OBJECT


### PR DESCRIPTION
Q_ENUM exists since Qt 5.5, more details can be found here:
https://woboq.com/blog/q_enum.html