### PR TITLE
Replace emails in copyright headers by entries in the AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,5 @@ Georg Rudoy <0xd34df00d@gmail.com>
 Niels Ole Salscheider <niels_ole@salscheider-online.de>
  * Build system, cleanups.
 
+Oliver Goffart <ogoffart@woboq.com>
+ * Author of QXmppResultSet.

--- a/src/base/QXmppHttpUploadIq.cpp
+++ b/src/base/QXmppHttpUploadIq.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Authors:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/base/QXmppHttpUploadIq.h
+++ b/src/base/QXmppHttpUploadIq.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Authors:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/base/QXmppMixIq.cpp
+++ b/src/base/QXmppMixIq.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/base/QXmppMixIq.h
+++ b/src/base/QXmppMixIq.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/base/QXmppMixItem.cpp
+++ b/src/base/QXmppMixItem.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/base/QXmppMixItem.h
+++ b/src/base/QXmppMixItem.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/base/QXmppResultSet.cpp
+++ b/src/base/QXmppResultSet.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Olivier Goffart <ogoffart@woboq.com>
+ *  Olivier Goffart
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/base/QXmppResultSet.h
+++ b/src/base/QXmppResultSet.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Olivier Goffart <ogoffart@woboq.com>
+ *  Olivier Goffart
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/client/QXmppUploadRequestManager.cpp
+++ b/src/client/QXmppUploadRequestManager.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp

--- a/src/client/QXmppUploadRequestManager.h
+++ b/src/client/QXmppUploadRequestManager.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2008-2019 The QXmpp developers
  *
  * Author:
- *  Linus Jahn <lnj@kaidan.im>
+ *  Linus Jahn
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp


### PR DESCRIPTION
Mostly this was a mistake by me in earlier contributions.