### PR TITLE
QXmppGlobal: Use QT_VERSION_CHECK() to generate QXMPP_VERSION

### DIFF
--- a/src/base/QXmppGlobal.h.in
+++ b/src/base/QXmppGlobal.h.in
@@ -46,7 +46,7 @@
 /// available.
 ///
 
-#define QXMPP_VERSION (0x@VERSION_MAJOR@ << 16) | (0x@VERSION_MINOR@ << 8) | 0x@VERSION_PATCH@
+#define QXMPP_VERSION QT_VERSION_CHECK(@VERSION_MAJOR@, @VERSION_MINOR@, @VERSION_PATCH@)
 
 inline QLatin1String QXmppVersion()
 {


### PR DESCRIPTION
QT_VERSION_CHECK() returns the same format as is currently used, it is
easier to read and fixes a problem that could occur with the previous
marco. The macro was unenclosed causing comparison to fail. This also
happened in Kaidan [1].

[1]: https://invent.kde.org/kde/kaidan/commit/5a3e5e8a748488f4d55302b4beacce880dde381a