### PR TITLE
Add a .clang-format somewhat close to the current style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+AlignAfterOpenBracket: Align
+AlignTrailingComments: true
+BasedOnStyle: WebKit
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakConstructorInitializers: BeforeColon
+DerivePointerAlignment: true
+DisableFormat: false
+Language: Cpp
+SortIncludes: false
+SpaceAfterTemplateKeyword: false
+SpacesBeforeTrailingComments: 2

--- a/examples/example_1_echoClient/example_1_echoClient.h
+++ b/examples/example_1_echoClient/example_1_echoClient.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef ECHOCLIENT_H
 #define ECHOCLIENT_H
 
@@ -36,7 +35,7 @@ public:
     ~echoClient() override;
 
 public slots:
-    void messageReceived(const QXmppMessage&);
+    void messageReceived(const QXmppMessage &);
 };
 
-#endif // ECHOCLIENT_H
+#endif  // ECHOCLIENT_H

--- a/examples/example_2_rosterHandling/example_2_rosterHandling.h
+++ b/examples/example_2_rosterHandling/example_2_rosterHandling.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef XMPPCLIENT_H
 #define XMPPCLIENT_H
 
@@ -34,7 +33,7 @@ class xmppClient : public QXmppClient
     Q_OBJECT
 
 public:
-    xmppClient(QObject *parent = nullptr);
+    xmppClient(QObject* parent = nullptr);
     ~xmppClient() override;
 
 public slots:
@@ -43,7 +42,7 @@ public slots:
     void presenceChanged(const QString& bareJid, const QString& resource);
 
 private:
-    QXmppRosterManager *m_rosterManager;
+    QXmppRosterManager* m_rosterManager;
 };
 
-#endif // XMPPCLIENT_H
+#endif  // XMPPCLIENT_H

--- a/examples/example_3_transferHandling/example_3_transferHandling.h
+++ b/examples/example_3_transferHandling/example_3_transferHandling.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef IBBCLIENT_H
 #define IBBCLIENT_H
 
@@ -48,4 +47,4 @@ private:
     QXmppTransferManager *transferManager;
 };
 
-#endif // IBBCLIENT_H
+#endif  // IBBCLIENT_H

--- a/examples/example_5_rpcInterface/remoteinterface.h
+++ b/examples/example_5_rpcInterface/remoteinterface.h
@@ -9,12 +9,11 @@ class RemoteInterface : public QXmppInvokable
 public:
     RemoteInterface(QObject *parent = nullptr);
 
-    bool isAuthorized( const QString &jid ) const override;
+    bool isAuthorized(const QString &jid) const override;
 
-// RPC Interface
+    // RPC Interface
 public slots:
-    QString echoString( const QString &message );
-
+    QString echoString(const QString &message);
 };
 
-#endif // REMOTEINTERFACE_H
+#endif  // REMOTEINTERFACE_H

--- a/examples/example_6_rpcClient/rpcClient.h
+++ b/examples/example_6_rpcClient/rpcClient.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef RPCCLIENT_H
 #define RPCCLIENT_H
 
@@ -47,4 +46,4 @@ private:
     QXmppRpcManager *m_rpcManager;
 };
 
-#endif // RPCCLIENT_H
+#endif  // RPCCLIENT_H

--- a/examples/example_7_archiveHandling/example_7_archiveHandling.h
+++ b/examples/example_7_archiveHandling/example_7_archiveHandling.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef XMPPCLIENT_H
 #define XMPPCLIENT_H
 
@@ -63,4 +62,4 @@ private:
     int m_pageSize;
 };
 
-#endif // XMPPCLIENT_H
+#endif  // XMPPCLIENT_H

--- a/examples/example_9_vCard/example_9_vCard.h
+++ b/examples/example_9_vCard/example_9_vCard.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef XMPPCLIENT_H
 #define XMPPCLIENT_H
 
@@ -42,11 +41,11 @@ public:
 public slots:
     void clientConnected();
     void rosterReceived();
-    void vCardReceived(const QXmppVCardIq&);
+    void vCardReceived(const QXmppVCardIq &);
 
 private:
     QXmppRosterManager *m_rosterManager;
     QXmppVCardManager *m_vCardManager;
 };
 
-#endif // XMPPCLIENT_H
+#endif  // XMPPCLIENT_H

--- a/src/base/QXmppArchiveIq.h
+++ b/src/base/QXmppArchiveIq.h
@@ -133,13 +133,13 @@ public:
     void setChats(const QList<QXmppArchiveChat> &chats);
 
     QString with() const;
-    void setWith( const QString &with );
+    void setWith(const QString &with);
 
     QDateTime start() const;
-    void setStart(const QDateTime &start );
+    void setStart(const QDateTime &start);
 
     QDateTime end() const;
-    void setEnd(const QDateTime &end );
+    void setEnd(const QDateTime &end);
 
     QXmppResultSetQuery resultSetQuery() const;
     void setResultSetQuery(const QXmppResultSetQuery &rsm);
@@ -174,13 +174,13 @@ class QXMPP_EXPORT QXmppArchiveRemoveIq : public QXmppIq
 {
 public:
     QString with() const;
-    void setWith( const QString &with );
+    void setWith(const QString &with);
 
     QDateTime start() const;
-    void setStart(const QDateTime &start );
+    void setStart(const QDateTime &start);
 
     QDateTime end() const;
-    void setEnd(const QDateTime &end );
+    void setEnd(const QDateTime &end);
 
     /// \cond
     static bool isArchiveRemoveIq(const QDomElement &element);
@@ -244,4 +244,4 @@ protected:
     /// \endcond
 };
 
-#endif // QXMPPARCHIVEIQ_H
+#endif  // QXMPPARCHIVEIQ_H

--- a/src/base/QXmppBindIq.h
+++ b/src/base/QXmppBindIq.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef QXMPPBINDIQ_H
 #define QXMPPBINDIQ_H
 
@@ -37,10 +36,10 @@ class QXMPP_EXPORT QXmppBindIq : public QXmppIq
 {
 public:
     QString jid() const;
-    void setJid(const QString&);
+    void setJid(const QString &);
 
     QString resource() const;
-    void setResource(const QString&);
+    void setResource(const QString &);
 
     /// \cond
     static bool isBindIq(const QDomElement &element);
@@ -57,4 +56,4 @@ private:
     QString m_resource;
 };
 
-#endif // QXMPPBIND_H
+#endif  // QXMPPBIND_H

--- a/src/base/QXmppBitsOfBinaryContentId.h
+++ b/src/base/QXmppBitsOfBinaryContentId.h
@@ -67,4 +67,4 @@ private:
     QSharedDataPointer<QXmppBitsOfBinaryContentIdPrivate> d;
 };
 
-#endif // QXMPPBITSOFBINARYCONTENTID_H
+#endif  // QXMPPBITSOFBINARYCONTENTID_H

--- a/src/base/QXmppBitsOfBinaryData.h
+++ b/src/base/QXmppBitsOfBinaryData.h
@@ -68,11 +68,11 @@ public:
     void parseElementFromChild(const QDomElement &dataElement);
     void toXmlElementFromChild(QXmlStreamWriter *writer) const;
     /// \endcond
-    
+
     bool operator==(const QXmppBitsOfBinaryData &other) const;
 
 private:
     QSharedDataPointer<QXmppBitsOfBinaryDataPrivate> d;
 };
 
-#endif // QXMPPBITSOFBINARYDATA_H
+#endif  // QXMPPBITSOFBINARYDATA_H

--- a/src/base/QXmppBitsOfBinaryDataList.h
+++ b/src/base/QXmppBitsOfBinaryDataList.h
@@ -48,4 +48,4 @@ public:
     /// \endcond
 };
 
-#endif // QXMPPBITSOFBINARYDATACONTAINER_H
+#endif  // QXMPPBITSOFBINARYDATACONTAINER_H

--- a/src/base/QXmppBitsOfBinaryIq.h
+++ b/src/base/QXmppBitsOfBinaryIq.h
@@ -47,4 +47,4 @@ protected:
     /// \endcond
 };
 
-#endif // QXMPPBITSOFBINARYIQ_H
+#endif  // QXMPPBITSOFBINARYIQ_H

--- a/src/base/QXmppCodec_p.h
+++ b/src/base/QXmppCodec_p.h
@@ -228,7 +228,7 @@ private:
 class QXMPP_AUTOTEST_EXPORT QXmppVpxEncoder : public QXmppVideoEncoder
 {
 public:
-    QXmppVpxEncoder(uint clockrate=0);
+    QXmppVpxEncoder(uint clockrate = 0);
     ~QXmppVpxEncoder();
 
     bool setFormat(const QXmppVideoFormat &format);

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPCONSTANTS_H
 #define QXMPPCONSTANTS_H
 
@@ -70,14 +69,14 @@ extern const char* ns_vcard;
 // XEP-0059: Result Set Management
 extern const char* ns_rsm;
 // XEP-0060: Publish-Subscribe
-extern const char *ns_pubsub;
+extern const char* ns_pubsub;
 // XEP-0065: SOCKS5 Bytestreams
 extern const char* ns_bytestreams;
 // XEP-0066: Out of Band Data
 extern const char* ns_oob;
 // XEP-0071: XHTML-IM
-extern const char *ns_xhtml;
-extern const char *ns_xhtml_im;
+extern const char* ns_xhtml;
+extern const char* ns_xhtml_im;
 // XEP-0077: In-Band Registration
 extern const char* ns_register;
 extern const char* ns_register_feature;
@@ -180,4 +179,4 @@ extern const char* ns_mix_pam;
 extern const char* ns_mix_roster;
 extern const char* ns_mix_presence;
 
-#endif // QXMPPCONSTANTS_H
+#endif  // QXMPPCONSTANTS_H

--- a/src/base/QXmppDataForm.h
+++ b/src/base/QXmppDataForm.h
@@ -90,7 +90,7 @@ public:
         Media(const QXmppDataForm::Media &other);
         ~Media();
 
-        QXmppDataForm::Media& operator=(const QXmppDataForm::Media &other);
+        QXmppDataForm::Media &operator=(const QXmppDataForm::Media &other);
 
         QT_DEPRECATED_X("Use QXmppDataForm::Field::mediaSize().height() instead")
         int height() const;
@@ -103,9 +103,9 @@ public:
         void setWidth(int width);
 
         QT_DEPRECATED_X("Use QXmppDataForm::Field::mediaSources() instead")
-        QList<QPair<QString, QString> > uris() const;
+        QList<QPair<QString, QString>> uris() const;
         QT_DEPRECATED_X("Use QXmppDataForm::Field::setMediaSources() instead")
-        void setUris(const QList<QPair<QString, QString> > &uris);
+        void setUris(const QList<QPair<QString, QString>> &uris);
 
         QT_DEPRECATED_X("Use QXmppDataForm::Field::mediaSources().isEmpty() instead")
         bool isNull() const;
@@ -122,8 +122,7 @@ public:
     {
     public:
         /// This enum is used to describe a field's type.
-        enum Type
-        {
+        enum Type {
             BooleanField,
             FixedField,
             HiddenField,
@@ -140,7 +139,7 @@ public:
         Field(const QXmppDataForm::Field &other);
         ~Field();
 
-        QXmppDataForm::Field& operator=(const QXmppDataForm::Field &other);
+        QXmppDataForm::Field &operator=(const QXmppDataForm::Field &other);
 
         QString description() const;
         void setDescription(const QString &description);
@@ -159,8 +158,8 @@ public:
         void setMedia(const Media &media);
 #endif
 
-        QList<QPair<QString, QString> > options() const;
-        void setOptions(const QList<QPair<QString, QString> > &options);
+        QList<QPair<QString, QString>> options() const;
+        void setOptions(const QList<QPair<QString, QString>> &options);
 
         bool isRequired() const;
         void setRequired(bool required);
@@ -186,25 +185,24 @@ public:
     };
 
     /// This enum is used to describe a form's type.
-    enum Type
-    {
-        None,   ///< Unknown form type
-        Form,   ///< The form-processing entity is asking the form-submitting
-                ///< entity to complete a form.
-        Submit, ///< The form-submitting entity is submitting data to the
-                ///< form-processing entity.
-        Cancel, ///< The form-submitting entity has cancelled submission
-                ///< of data to the form-processing entity.
-        Result  ///< The form-processing entity is returning data
-                ///< (e.g., search results) to the form-submitting entity,
-                ///< or the data is a generic data set.
+    enum Type {
+        None,    ///< Unknown form type
+        Form,    ///< The form-processing entity is asking the form-submitting
+                 ///< entity to complete a form.
+        Submit,  ///< The form-submitting entity is submitting data to the
+                 ///< form-processing entity.
+        Cancel,  ///< The form-submitting entity has cancelled submission
+                 ///< of data to the form-processing entity.
+        Result   ///< The form-processing entity is returning data
+                 ///< (e.g., search results) to the form-submitting entity,
+                 ///< or the data is a generic data set.
     };
 
     QXmppDataForm(QXmppDataForm::Type type = QXmppDataForm::None);
     QXmppDataForm(const QXmppDataForm &other);
     ~QXmppDataForm();
 
-    QXmppDataForm& operator=(const QXmppDataForm &other);
+    QXmppDataForm &operator=(const QXmppDataForm &other);
 
     QString instructions() const;
     void setInstructions(const QString &instructions);

--- a/src/base/QXmppEntityTimeIq.h
+++ b/src/base/QXmppEntityTimeIq.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPENTITYTIMEIQ_H
 #define QXMPPENTITYTIMEIQ_H
 
@@ -53,4 +52,4 @@ private:
     QDateTime m_utc;
 };
 
-#endif //QXMPPENTITYTIMEIQ_H
+#endif  //QXMPPENTITYTIMEIQ_H

--- a/src/base/QXmppHttpUploadIq.h
+++ b/src/base/QXmppHttpUploadIq.h
@@ -108,4 +108,4 @@ private:
     QSharedDataPointer<QXmppHttpUploadSlotIqPrivate> d;
 };
 
-#endif // QXMPPHTTPUPLOADIQ_H
+#endif  // QXMPPHTTPUPLOADIQ_H

--- a/src/base/QXmppIbbIq.h
+++ b/src/base/QXmppIbbIq.h
@@ -27,16 +27,16 @@
 
 #include "QXmppIq.h"
 
-class QXmppIbbOpenIq: public QXmppIq
+class QXmppIbbOpenIq : public QXmppIq
 {
 public:
     QXmppIbbOpenIq();
 
     long blockSize() const;
-    void setBlockSize( long block_size );
+    void setBlockSize(long block_size);
 
     QString sid() const;
-    void setSid( const QString &sid );
+    void setSid(const QString &sid);
 
     static bool isIbbOpenIq(const QDomElement &element);
 
@@ -51,13 +51,13 @@ private:
     QString m_sid;
 };
 
-class QXmppIbbCloseIq: public QXmppIq
+class QXmppIbbCloseIq : public QXmppIq
 {
 public:
     QXmppIbbCloseIq();
 
     QString sid() const;
-    void setSid( const QString &sid );
+    void setSid(const QString &sid);
 
     static bool isIbbCloseIq(const QDomElement &element);
 
@@ -77,13 +77,13 @@ public:
     QXmppIbbDataIq();
 
     quint16 sequence() const;
-    void setSequence( quint16 seq );
+    void setSequence(quint16 seq);
 
     QString sid() const;
-    void setSid( const QString &sid );
+    void setSid(const QString &sid);
 
     QByteArray payload() const;
-    void setPayload( const QByteArray &data );
+    void setPayload(const QByteArray &data);
 
     static bool isIbbDataIq(const QDomElement &element);
 
@@ -99,4 +99,4 @@ private:
     QByteArray m_payload;
 };
 
-#endif // QXMPPIBBIQS_H
+#endif  // QXMPPIBBIQS_H

--- a/src/base/QXmppIq.h
+++ b/src/base/QXmppIq.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPIQ_H
 #define QXMPPIQ_H
 
@@ -54,7 +53,7 @@ public:
     QXmppIq(const QXmppIq &other);
     ~QXmppIq() override;
 
-    QXmppIq& operator=(const QXmppIq &other);
+    QXmppIq &operator=(const QXmppIq &other);
 
     QXmppIq::Type type() const;
     void setType(QXmppIq::Type);
@@ -74,4 +73,4 @@ private:
     QSharedDataPointer<QXmppIqPrivate> d;
 };
 
-#endif // QXMPPIQ_H
+#endif  // QXMPPIQ_H

--- a/src/base/QXmppJingleIq.h
+++ b/src/base/QXmppJingleIq.h
@@ -70,7 +70,7 @@ public:
     void toXml(QXmlStreamWriter *writer) const;
     /// \endcond
 
-    QXmppJinglePayloadType& operator=(const QXmppJinglePayloadType &other);
+    QXmppJinglePayloadType &operator=(const QXmppJinglePayloadType &other);
     bool operator==(const QXmppJinglePayloadType &other) const;
 
 private:
@@ -85,22 +85,21 @@ class QXMPP_EXPORT QXmppJingleCandidate
 {
 public:
     /// This enum is used to describe a candidate's type.
-    enum Type
-    {
-        HostType,               ///< Host candidate, a local address/port.
-        PeerReflexiveType,      ///< Peer-reflexive candidate,
-                                ///< the address/port as seen from the peer.
-        ServerReflexiveType,    ///< Server-reflexive candidate,
-                                ///< the address/port as seen by the STUN server
-        RelayedType             ///< Relayed candidate, a candidate from
-                                ///< a TURN relay.
+    enum Type {
+        HostType,             ///< Host candidate, a local address/port.
+        PeerReflexiveType,    ///< Peer-reflexive candidate,
+                              ///< the address/port as seen from the peer.
+        ServerReflexiveType,  ///< Server-reflexive candidate,
+                              ///< the address/port as seen by the STUN server
+        RelayedType           ///< Relayed candidate, a candidate from
+                              ///< a TURN relay.
     };
 
     QXmppJingleCandidate();
     QXmppJingleCandidate(const QXmppJingleCandidate &other);
     ~QXmppJingleCandidate();
 
-    QXmppJingleCandidate& operator=(const QXmppJingleCandidate &other);
+    QXmppJingleCandidate &operator=(const QXmppJingleCandidate &other);
 
     int component() const;
     void setComponent(int component);
@@ -185,7 +184,7 @@ public:
         Content(const QXmppJingleIq::Content &other);
         ~Content();
 
-        Content& operator=(const Content &other);
+        Content &operator=(const Content &other);
 
         QString creator() const;
         void setCreator(const QString &creator);
@@ -291,7 +290,7 @@ public:
     QXmppJingleIq(const QXmppJingleIq &other);
     ~QXmppJingleIq() override;
 
-    QXmppJingleIq& operator=(const QXmppJingleIq &other);
+    QXmppJingleIq &operator=(const QXmppJingleIq &other);
 
     Action action() const;
     void setAction(Action action);
@@ -303,8 +302,8 @@ public:
     QString initiator() const;
     void setInitiator(const QString &initiator);
 
-    Reason& reason();
-    const Reason& reason() const;
+    Reason &reason();
+    const Reason &reason() const;
 
     QString responder() const;
     void setResponder(const QString &responder);

--- a/src/base/QXmppLogger.h
+++ b/src/base/QXmppLogger.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef QXMPPLOGGER_H
 #define QXMPPLOGGER_H
 
@@ -52,8 +51,7 @@ class QXMPP_EXPORT QXmppLogger : public QObject
 
 public:
     /// This enum describes how log message are handled.
-    enum LoggingType
-    {
+    enum LoggingType {
         NoLogging = 0,      ///< Log messages are discarded
         FileLogging = 1,    ///< Log messages are written to a file
         StdoutLogging = 2,  ///< Log messages are written to the standard output
@@ -62,22 +60,21 @@ public:
     Q_ENUM(LoggingType)
 
     /// This enum describes a type of log message.
-    enum MessageType
-    {
-        NoMessage = 0,          ///< No message type
-        DebugMessage = 1,       ///< Debugging message
-        InformationMessage = 2, ///< Informational message
-        WarningMessage = 4,     ///< Warning message
-        ReceivedMessage = 8,    ///< Message received from server
-        SentMessage = 16,       ///< Message sent to server
-        AnyMessage = 31         ///< Any message type
+    enum MessageType {
+        NoMessage = 0,           ///< No message type
+        DebugMessage = 1,        ///< Debugging message
+        InformationMessage = 2,  ///< Informational message
+        WarningMessage = 4,      ///< Warning message
+        ReceivedMessage = 8,     ///< Message received from server
+        SentMessage = 16,        ///< Message sent to server
+        AnyMessage = 31          ///< Any message type
     };
     Q_DECLARE_FLAGS(MessageTypes, MessageType)
 
     QXmppLogger(QObject *parent = nullptr);
     ~QXmppLogger() override;
 
-    static QXmppLogger* getLogger();
+    static QXmppLogger *getLogger();
 
     QXmppLogger::LoggingType loggingType();
     void setLoggingType(QXmppLogger::LoggingType type);
@@ -92,7 +89,7 @@ public slots:
     virtual void setGauge(const QString &gauge, double value);
     virtual void updateCounter(const QString &counter, qint64 amount);
 
-    void log(QXmppLogger::MessageType type, const QString& text);
+    void log(QXmppLogger::MessageType type, const QString &text);
     void reopen();
 
 signals:
@@ -100,7 +97,7 @@ signals:
     void message(QXmppLogger::MessageType type, const QString &text);
 
 private:
-    static QXmppLogger* m_logger;
+    static QXmppLogger *m_logger;
     QXmppLoggerPrivate *d;
 };
 
@@ -177,4 +174,4 @@ signals:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(QXmppLogger::MessageTypes)
-#endif // QXMPPLOGGER_H
+#endif  // QXMPPLOGGER_H

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -85,26 +85,26 @@ public:
     ///
     /// \since QXmpp 1.1
     enum EncryptionMethod {
-        NoEncryption,      ///< No encryption
-        UnknownEncryption, ///< Unknown encryption
-        OTR,               ///< XEP-0364: Current Off-the-Record Messaging Usage
-        LegacyOpenPGP,     ///< XEP-0027: Current Jabber OpenPGP Usage
-        OX,                ///< XEP-0373: OpenPGP for XMPP
-        OMEMO              ///< XEP-0384: OMEMO Encryption
+        NoEncryption,       ///< No encryption
+        UnknownEncryption,  ///< Unknown encryption
+        OTR,                ///< XEP-0364: Current Off-the-Record Messaging Usage
+        LegacyOpenPGP,      ///< XEP-0027: Current Jabber OpenPGP Usage
+        OX,                 ///< XEP-0373: OpenPGP for XMPP
+        OMEMO               ///< XEP-0384: OMEMO Encryption
     };
 
-    QXmppMessage(const QString& from = QString(), const QString& to = QString(),
-                 const QString& body = QString(), const QString& thread = QString());
+    QXmppMessage(const QString &from = QString(), const QString &to = QString(),
+                 const QString &body = QString(), const QString &thread = QString());
 
     QXmppMessage(const QXmppMessage &other);
     ~QXmppMessage() override;
 
-    QXmppMessage& operator=(const QXmppMessage &other);
+    QXmppMessage &operator=(const QXmppMessage &other);
 
     bool isXmppStanza() const override;
 
     QString body() const;
-    void setBody(const QString&);
+    void setBody(const QString &);
 
     bool isAttentionRequested() const;
     void setAttentionRequested(bool requested);
@@ -131,10 +131,10 @@ public:
     void setState(QXmppMessage::State);
 
     QString subject() const;
-    void setSubject(const QString&);
+    void setSubject(const QString &);
 
     QString thread() const;
-    void setThread(const QString&);
+    void setThread(const QString &);
 
     QXmppMessage::Type type() const;
     void setType(QXmppMessage::Type);
@@ -147,10 +147,10 @@ public:
     void setMarkable(const bool);
 
     QString markedId() const;
-    void setMarkerId(const QString&);
+    void setMarkerId(const QString &);
 
     QString markedThread() const;
-    void setMarkedThread(const QString&);
+    void setMarkedThread(const QString &);
 
     Marker marker() const;
     void setMarker(const Marker);
@@ -166,11 +166,11 @@ public:
 
     // XEP-0066: Out of Band Data
     QString outOfBandUrl() const;
-    void setOutOfBandUrl(const QString&);
+    void setOutOfBandUrl(const QString &);
 
     // XEP-0308: Last Message Correction
     QString replaceId() const;
-    void setReplaceId(const QString&);
+    void setReplaceId(const QString &);
 
     // XEP-0334: Message Processing Hints
     bool hasHint(const Hint hint) const;
@@ -180,30 +180,30 @@ public:
 
     // XEP-0367: Message Attaching
     QString attachId() const;
-    void setAttachId(const QString&);
+    void setAttachId(const QString &);
 
     // XEP-0369: Mediated Information eXchange (MIX)
     QString mixUserJid() const;
-    void setMixUserJid(const QString&);
+    void setMixUserJid(const QString &);
 
     QString mixUserNick() const;
-    void setMixUserNick(const QString&);
+    void setMixUserNick(const QString &);
 
     // XEP-0380: Explicit Message Encryption
     EncryptionMethod encryptionMethod() const;
     void setEncryptionMethod(EncryptionMethod);
     QString encryptionMethodNs() const;
-    void setEncryptionMethodNs(const QString&);
+    void setEncryptionMethodNs(const QString &);
 
     QString encryptionName() const;
-    void setEncryptionName(const QString&);
+    void setEncryptionName(const QString &);
 
     // XEP-0382: Spoiler messages
     bool isSpoiler() const;
     void setIsSpoiler(bool);
 
     QString spoilerHint() const;
-    void setSpoilerHint(const QString&);
+    void setSpoilerHint(const QString &);
 
     /// \cond
     void parse(const QDomElement &element) override;
@@ -217,4 +217,4 @@ private:
     QSharedDataPointer<QXmppMessagePrivate> d;
 };
 
-#endif // QXMPPMESSAGE_H
+#endif  // QXMPPMESSAGE_H

--- a/src/base/QXmppMixIq.h
+++ b/src/base/QXmppMixIq.h
@@ -63,29 +63,29 @@ public:
     void setActionType(QXmppMixIq::Type);
 
     QString jid() const;
-    void setJid(const QString&);
+    void setJid(const QString &);
 
     QString channelName() const;
-    void setChannelName(const QString&);
+    void setChannelName(const QString &);
 
     QStringList nodes() const;
-    void setNodes(const QStringList&);
+    void setNodes(const QStringList &);
 
     QString nick() const;
-    void setNick(const QString&);
+    void setNick(const QString &);
 
     /// \cond
-    static bool isMixIq(const QDomElement&);
+    static bool isMixIq(const QDomElement &);
     /// \endcond
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement&) override;
-    void toXmlElementFromChild(QXmlStreamWriter*) const override;
+    void parseElementFromChild(const QDomElement &) override;
+    void toXmlElementFromChild(QXmlStreamWriter *) const override;
     /// \endcond
 
 private:
     QSharedDataPointer<QXmppMixIqPrivate> d;
 };
 
-#endif // QXMPPMIXIQ_H
+#endif  // QXMPPMIXIQ_H

--- a/src/base/QXmppMixItem.h
+++ b/src/base/QXmppMixItem.h
@@ -49,18 +49,18 @@ public:
     QXmppMixInfoItem &operator=(const QXmppMixInfoItem &);
 
     QString name() const;
-    void setName(const QString&);
+    void setName(const QString &);
 
     QString description() const;
-    void setDescription(const QString&);
+    void setDescription(const QString &);
 
     QStringList contactJids() const;
-    void setContactJids(const QStringList&);
+    void setContactJids(const QStringList &);
 
-    void parse(const QXmppElement& itemContent);
+    void parse(const QXmppElement &itemContent);
     QXmppElement toElement() const;
 
-    static bool isMixChannelInfo(const QDomElement&);
+    static bool isMixChannelInfo(const QDomElement &);
 
 private:
     QSharedDataPointer<QXmppMixInfoItemPrivate> d;
@@ -84,18 +84,18 @@ public:
     QXmppMixParticipantItem &operator=(const QXmppMixParticipantItem &);
 
     QString nick() const;
-    void setNick(const QString&);
+    void setNick(const QString &);
 
     QString jid() const;
-    void setJid(const QString&);
+    void setJid(const QString &);
 
-    void parse(const QXmppElement& itemContent);
+    void parse(const QXmppElement &itemContent);
     QXmppElement toElement() const;
 
-    static bool isMixParticipantItem(const QDomElement&);
+    static bool isMixParticipantItem(const QDomElement &);
 
 private:
     QSharedDataPointer<QXmppMixParticipantItemPrivate> d;
 };
 
-#endif // QXMPPMIXITEM_H
+#endif  // QXMPPMIXITEM_H

--- a/src/base/QXmppNonSASLAuth.h
+++ b/src/base/QXmppNonSASLAuth.h
@@ -58,4 +58,4 @@ private:
     QString m_resource;
 };
 
-#endif // QXmppNonSASLAuth_H
+#endif  // QXmppNonSASLAuth_H

--- a/src/base/QXmppPresence.h
+++ b/src/base/QXmppPresence.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPPRESENCE_H
 #define QXMPPPRESENCE_H
 
@@ -37,40 +36,37 @@ class QXMPP_EXPORT QXmppPresence : public QXmppStanza
 {
 public:
     /// This enum is used to describe a presence type.
-    enum Type
-    {
-        Error = 0,      ///< An error has occurred regarding processing or delivery of a previously-sent presence stanza.
-        Available,      ///< Signals that the sender is online and available for communication.
-        Unavailable,    ///< Signals that the sender is no longer available for communication.
-        Subscribe,      ///< The sender wishes to subscribe to the recipient's  presence.
-        Subscribed,     ///< The sender has allowed the recipient to receive their presence.
-        Unsubscribe,    ///< The sender is unsubscribing from another entity's presence.
-        Unsubscribed,   ///< The subscription request has been denied or a previously-granted subscription has been cancelled.
-        Probe           ///< A request for an entity's current presence; SHOULD be generated only by a server on behalf of a user.
+    enum Type {
+        Error = 0,     ///< An error has occurred regarding processing or delivery of a previously-sent presence stanza.
+        Available,     ///< Signals that the sender is online and available for communication.
+        Unavailable,   ///< Signals that the sender is no longer available for communication.
+        Subscribe,     ///< The sender wishes to subscribe to the recipient's  presence.
+        Subscribed,    ///< The sender has allowed the recipient to receive their presence.
+        Unsubscribe,   ///< The sender is unsubscribing from another entity's presence.
+        Unsubscribed,  ///< The subscription request has been denied or a previously-granted subscription has been cancelled.
+        Probe          ///< A request for an entity's current presence; SHOULD be generated only by a server on behalf of a user.
     };
 
     /// This enum is used to describe an availability status.
-    enum AvailableStatusType
-    {
-        Online = 0,      ///< The entity or resource is online.
-        Away,           ///< The entity or resource is temporarily away.
-        XA,             ///< The entity or resource is away for an extended period.
-        DND,            ///< The entity or resource is busy ("Do Not Disturb").
-        Chat,           ///< The entity or resource is actively interested in chatting.
-        Invisible       ///< obsolete XEP-0018: Invisible Presence
+    enum AvailableStatusType {
+        Online = 0,  ///< The entity or resource is online.
+        Away,        ///< The entity or resource is temporarily away.
+        XA,          ///< The entity or resource is away for an extended period.
+        DND,         ///< The entity or resource is busy ("Do Not Disturb").
+        Chat,        ///< The entity or resource is actively interested in chatting.
+        Invisible    ///< obsolete XEP-0018: Invisible Presence
     };
 
     /// This enum is used to describe vCard updates as defined by
     /// XEP-0153: vCard-Based Avatars
-    enum VCardUpdateType
-    {
+    enum VCardUpdateType {
         VCardUpdateNone = 0,    ///< Protocol is not supported
         VCardUpdateNoPhoto,     ///< User is not using any image
         VCardUpdateValidPhoto,  ///< User is advertising an image
         VCardUpdateNotReady     ///< User is not ready to advertise an image
 
-/// \note This enables recipients to distinguish between the absence of an image
-/// (empty photo element) and mere support for the protocol (empty update child).
+        /// \note This enables recipients to distinguish between the absence of an image
+        /// (empty photo element) and mere support for the protocol (empty update child).
     };
 
     QXmppPresence(QXmppPresence::Type type = QXmppPresence::Available);
@@ -91,7 +87,7 @@ public:
     void setType(QXmppPresence::Type);
 
     QString statusText() const;
-    void setStatusText(const QString& statusText);
+    void setStatusText(const QString &statusText);
 
     // XEP-0045: Multi-User Chat
     QXmppMucItem mucItem() const;
@@ -108,33 +104,33 @@ public:
 
     /// XEP-0153: vCard-Based Avatars
     QByteArray photoHash() const;
-    void setPhotoHash(const QByteArray&);
+    void setPhotoHash(const QByteArray &);
 
     VCardUpdateType vCardUpdateType() const;
     void setVCardUpdateType(VCardUpdateType type);
 
     // XEP-0115: Entity Capabilities
     QString capabilityHash() const;
-    void setCapabilityHash(const QString&);
+    void setCapabilityHash(const QString &);
 
     QString capabilityNode() const;
-    void setCapabilityNode(const QString&);
+    void setCapabilityNode(const QString &);
 
     QByteArray capabilityVer() const;
-    void setCapabilityVer(const QByteArray&);
+    void setCapabilityVer(const QByteArray &);
 
     QStringList capabilityExt() const;
 
     // XEP-0319: Last User Interaction in Presence
     QDateTime lastUserInteraction() const;
-    void setLastUserInteraction(const QDateTime&);
+    void setLastUserInteraction(const QDateTime &);
 
     // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
     QString mixUserJid() const;
-    void setMixUserJid(const QString&);
+    void setMixUserJid(const QString &);
 
     QString mixUserNick() const;
-    void setMixUserNick(const QString&);
+    void setMixUserNick(const QString &);
 
     /// \cond
     void parse(const QDomElement &element) override;
@@ -149,4 +145,4 @@ private:
     QSharedDataPointer<QXmppPresencePrivate> d;
 };
 
-#endif // QXMPPPRESENCE_H
+#endif  // QXMPPPRESENCE_H

--- a/src/base/QXmppPubSubIq.h
+++ b/src/base/QXmppPubSubIq.h
@@ -80,7 +80,7 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement&) override;
+    void parseElementFromChild(const QDomElement &) override;
     void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
@@ -88,4 +88,4 @@ private:
     QSharedDataPointer<QXmppPubSubIqPrivate> d;
 };
 
-#endif // QXMPPPUBSUBIQ_H
+#endif  // QXMPPPUBSUBIQ_H

--- a/src/base/QXmppPubSubItem.h
+++ b/src/base/QXmppPubSubItem.h
@@ -61,4 +61,4 @@ private:
     QSharedDataPointer<QXmppPubSubItemPrivate> d;
 };
 
-#endif // QXMPPPUBSUBITEM_H
+#endif  // QXMPPPUBSUBITEM_H

--- a/src/base/QXmppResultSet.h
+++ b/src/base/QXmppResultSet.h
@@ -43,10 +43,10 @@ public:
     void setIndex(int index);
 
     QString before() const;
-    void setBefore(const QString &before );
+    void setBefore(const QString &before);
 
     QString after() const;
-    void setAfter(const QString &after );
+    void setAfter(const QString &after);
 
     bool isNull() const;
 
@@ -71,10 +71,10 @@ public:
     QXmppResultSetReply();
 
     QString first() const;
-    void setFirst(const QString &first );
+    void setFirst(const QString &first);
 
     QString last() const;
-    void setLast(const QString &last );
+    void setLast(const QString &last);
 
     int count() const;
     void setCount(int count);
@@ -96,4 +96,4 @@ private:
     QString m_last;
 };
 
-#endif // QXMPPRESULTSET_H
+#endif  // QXMPPRESULTSET_H

--- a/src/base/QXmppRosterIq.h
+++ b/src/base/QXmppRosterIq.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef QXMPPROSTERIQ_H
 #define QXMPPROSTERIQ_H
 
@@ -47,19 +46,18 @@ public:
     {
     public:
         /// An enumeration for type of subscription with the bareJid in the roster.
-        enum SubscriptionType
-        {
-            None = 0,   ///< the user does not have a subscription to the
-                        ///< contact's presence information, and the contact does
-                        ///< not have a subscription to the user's presence information
-            From = 1,   ///< the contact has a subscription to the user's presence information,
-                        ///< but the user does not have a subscription to the contact's presence information
-            To = 2,     ///< the user has a subscription to the contact's presence information,
-                        ///< but the contact does not have a subscription to the user's presence information
-            Both = 3,   ///< both the user and the contact have subscriptions to each
-                        ///< other's presence information
-            Remove = 4, ///< to delete a roster item
-            NotSet = 8  ///< the subscription state was not specified
+        enum SubscriptionType {
+            None = 0,    ///< the user does not have a subscription to the
+                         ///< contact's presence information, and the contact does
+                         ///< not have a subscription to the user's presence information
+            From = 1,    ///< the contact has a subscription to the user's presence information,
+                         ///< but the user does not have a subscription to the contact's presence information
+            To = 2,      ///< the user has a subscription to the contact's presence information,
+                         ///< but the contact does not have a subscription to the user's presence information
+            Both = 3,    ///< both the user and the contact have subscriptions to each
+                         ///< other's presence information
+            Remove = 4,  ///< to delete a roster item
+            NotSet = 8   ///< the subscription state was not specified
         };
 
         Item();
@@ -74,10 +72,10 @@ public:
         QString subscriptionStatus() const;
         SubscriptionType subscriptionType() const;
 
-        void setBareJid(const QString&);
-        void setGroups(const QSet<QString>&);
-        void setName(const QString&);
-        void setSubscriptionStatus(const QString&);
+        void setBareJid(const QString &);
+        void setGroups(const QSet<QString> &);
+        void setName(const QString &);
+        void setSubscriptionStatus(const QString &);
         void setSubscriptionType(SubscriptionType);
 
         /// \cond
@@ -87,7 +85,7 @@ public:
 
     private:
         QString getSubscriptionTypeStr() const;
-        void setSubscriptionTypeFromStr(const QString&);
+        void setSubscriptionTypeFromStr(const QString &);
 
         QSharedDataPointer<ItemPrivate> d;
     };
@@ -99,9 +97,9 @@ public:
     QXmppRosterIq &operator=(const QXmppRosterIq &);
 
     QString version() const;
-    void setVersion(const QString&);
+    void setVersion(const QString &);
 
-    void addItem(const Item&);
+    void addItem(const Item &);
     QList<Item> items() const;
 
     /// \cond
@@ -118,4 +116,4 @@ private:
     QSharedDataPointer<QXmppRosterIqPrivate> d;
 };
 
-#endif // QXMPPROSTERIQ_H
+#endif  // QXMPPROSTERIQ_H

--- a/src/base/QXmppRpcIq.h
+++ b/src/base/QXmppRpcIq.h
@@ -31,7 +31,7 @@
 class QXMPP_EXPORT QXmppRpcMarshaller
 {
 public:
-    static void marshall( QXmlStreamWriter *writer, const QVariant &value);
+    static void marshall(QXmlStreamWriter *writer, const QVariant &value);
     static QVariant demarshall(const QDomElement &elem, QStringList &errors);
 };
 
@@ -81,7 +81,7 @@ public:
     QXmppRpcInvokeIq();
 
     QString method() const;
-    void setMethod( const QString &method );
+    void setMethod(const QString &method);
 
     QVariantList arguments() const;
     void setArguments(const QVariantList &arguments);
@@ -125,4 +125,4 @@ private:
     QXmppRpcInvokeIq m_query;
 };
 
-#endif // QXMPPRPCIQ_H
+#endif  // QXMPPRPCIQ_H

--- a/src/base/QXmppRtcpPacket.h
+++ b/src/base/QXmppRtcpPacket.h
@@ -44,10 +44,10 @@ class QXMPP_EXPORT QXmppRtcpPacket
 {
 public:
     enum Type {
-        SenderReport        = 200,
-        ReceiverReport      = 201,
-        SourceDescription   = 202,
-        Goodbye             = 203,
+        SenderReport = 200,
+        ReceiverReport = 201,
+        SourceDescription = 202,
+        Goodbye = 203,
     };
 
     QXmppRtcpPacket();

--- a/src/base/QXmppRtpChannel.h
+++ b/src/base/QXmppRtpChannel.h
@@ -79,22 +79,22 @@ class QXMPP_EXPORT QXmppRtpAudioChannel : public QIODevice, public QXmppRtpChann
 public:
     /// This enum is used to describe a DTMF tone.
     enum Tone {
-        Tone_0 = 0, ///< Tone for the 0 key.
-        Tone_1,     ///< Tone for the 1 key.
-        Tone_2,     ///< Tone for the 2 key.
-        Tone_3,     ///< Tone for the 3 key.
-        Tone_4,     ///< Tone for the 4 key.
-        Tone_5,     ///< Tone for the 5 key.
-        Tone_6,     ///< Tone for the 6 key.
-        Tone_7,     ///< Tone for the 7 key.
-        Tone_8,     ///< Tone for the 8 key.
-        Tone_9,     ///< Tone for the 9 key.
-        Tone_Star,  ///< Tone for the * key.
-        Tone_Pound, ///< Tone for the # key.
-        Tone_A,     ///< Tone for the A key.
-        Tone_B,     ///< Tone for the B key.
-        Tone_C,     ///< Tone for the C key.
-        Tone_D      ///< Tone for the D key.
+        Tone_0 = 0,  ///< Tone for the 0 key.
+        Tone_1,      ///< Tone for the 1 key.
+        Tone_2,      ///< Tone for the 2 key.
+        Tone_3,      ///< Tone for the 3 key.
+        Tone_4,      ///< Tone for the 4 key.
+        Tone_5,      ///< Tone for the 5 key.
+        Tone_6,      ///< Tone for the 6 key.
+        Tone_7,      ///< Tone for the 7 key.
+        Tone_8,      ///< Tone for the 8 key.
+        Tone_9,      ///< Tone for the 9 key.
+        Tone_Star,   ///< Tone for the * key.
+        Tone_Pound,  ///< Tone for the # key.
+        Tone_A,      ///< Tone for the A key.
+        Tone_B,      ///< Tone for the B key.
+        Tone_C,      ///< Tone for the C key.
+        Tone_D       ///< Tone for the D key.
     };
     Q_ENUM(Tone)
 
@@ -144,8 +144,8 @@ protected:
     }
 
     void payloadTypesChanged() override;
-    qint64 readData(char * data, qint64 maxSize) override;
-    qint64 writeData(const char * data, qint64 maxSize) override;
+    qint64 readData(char *data, qint64 maxSize) override;
+    qint64 writeData(const char *data, qint64 maxSize) override;
     /// \endcond
 
 private slots:
@@ -154,7 +154,7 @@ private slots:
 
 private:
     friend class QXmppRtpAudioChannelPrivate;
-    QXmppRtpAudioChannelPrivate * d;
+    QXmppRtpAudioChannelPrivate *d;
 };
 
 /// \brief The QXmppVideoFrame class provides a representation of a frame of video data.
@@ -166,23 +166,23 @@ class QXMPP_EXPORT QXmppVideoFrame
 public:
     /// This enum describes a pixel format.
     enum PixelFormat {
-        Format_Invalid = 0,     ///< The frame is invalid.
-        Format_RGB32 = 3,       ///< The frame stored using a 32-bit RGB format (0xffRRGGBB).
-        Format_RGB24 = 4,       ///< The frame is stored using a 24-bit RGB format (8-8-8).
-        Format_YUV420P = 18,    ///< The frame is stored using an 8-bit per component planar
-                                ///< YUV format with the U and V planes horizontally and
-                                ///< vertically sub-sampled, i.e. the height and width of the
-                                ///< U and V planes are half that of the Y plane.
-        Format_UYVY = 20,       ///< The frame is stored using an 8-bit per component packed
-                                ///< YUV format with the U and V planes horizontally
-                                ///< sub-sampled (U-Y-V-Y), i.e. two horizontally adjacent
-                                ///< pixels are stored as a 32-bit macropixel which has a Y
-                                ///< value for each pixel and common U and V values.
-        Format_YUYV = 21        ///< The frame is stored using an 8-bit per component packed
-                                ///< YUV format with the U and V planes horizontally
-                                ///< sub-sampled (Y-U-Y-V), i.e. two horizontally adjacent
-                                ///< pixels are stored as a 32-bit macropixel which has a Y
-                                ///< value for each pixel and common U and V values.
+        Format_Invalid = 0,   ///< The frame is invalid.
+        Format_RGB32 = 3,     ///< The frame stored using a 32-bit RGB format (0xffRRGGBB).
+        Format_RGB24 = 4,     ///< The frame is stored using a 24-bit RGB format (8-8-8).
+        Format_YUV420P = 18,  ///< The frame is stored using an 8-bit per component planar
+                              ///< YUV format with the U and V planes horizontally and
+                              ///< vertically sub-sampled, i.e. the height and width of the
+                              ///< U and V planes are half that of the Y plane.
+        Format_UYVY = 20,     ///< The frame is stored using an 8-bit per component packed
+                              ///< YUV format with the U and V planes horizontally
+                              ///< sub-sampled (U-Y-V-Y), i.e. two horizontally adjacent
+                              ///< pixels are stored as a 32-bit macropixel which has a Y
+                              ///< value for each pixel and common U and V values.
+        Format_YUYV = 21      ///< The frame is stored using an 8-bit per component packed
+                              ///< YUV format with the U and V planes horizontally
+                              ///< sub-sampled (Y-U-Y-V), i.e. two horizontally adjacent
+                              ///< pixels are stored as a 32-bit macropixel which has a Y
+                              ///< value for each pixel and common U and V values.
     };
 
     QXmppVideoFrame();
@@ -210,40 +210,47 @@ class QXMPP_EXPORT QXmppVideoFormat
 {
 public:
     QXmppVideoFormat()
-        : m_frameRate(15.0)
-        , m_frameSize(QSize(320, 240))
-        , m_pixelFormat(QXmppVideoFrame::Format_YUYV)
-    {}
+        : m_frameRate(15.0), m_frameSize(QSize(320, 240)), m_pixelFormat(QXmppVideoFrame::Format_YUYV)
+    {
+    }
 
-    int frameHeight() const {
+    int frameHeight() const
+    {
         return m_frameSize.height();
     }
 
-    int frameWidth() const {
+    int frameWidth() const
+    {
         return m_frameSize.width();
     }
 
-    qreal frameRate() const {
+    qreal frameRate() const
+    {
         return m_frameRate;
     }
 
-    void setFrameRate(qreal frameRate) {
+    void setFrameRate(qreal frameRate)
+    {
         m_frameRate = frameRate;
     }
 
-    QSize frameSize() const {
+    QSize frameSize() const
+    {
         return m_frameSize;
     }
 
-    void setFrameSize(const QSize &frameSize) {
+    void setFrameSize(const QSize &frameSize)
+    {
         m_frameSize = frameSize;
     }
 
-    QXmppVideoFrame::PixelFormat pixelFormat() const {
+    QXmppVideoFrame::PixelFormat pixelFormat() const
+    {
         return m_pixelFormat;
     }
 
-    void setPixelFormat(QXmppVideoFrame::PixelFormat pixelFormat) {
+    void setPixelFormat(QXmppVideoFrame::PixelFormat pixelFormat)
+    {
         m_pixelFormat = pixelFormat;
     }
 
@@ -252,7 +259,6 @@ private:
     QSize m_frameSize;
     QXmppVideoFrame::PixelFormat m_pixelFormat;
 };
-
 
 /// \brief The QXmppRtpVideoChannel class represents an RTP video channel to a remote party.
 ///
@@ -292,7 +298,7 @@ protected:
 
 private:
     friend class QXmppRtpVideoChannelPrivate;
-    QXmppRtpVideoChannelPrivate * d;
+    QXmppRtpVideoChannelPrivate *d;
 };
 
 #endif

--- a/src/base/QXmppRtpPacket.h
+++ b/src/base/QXmppRtpPacket.h
@@ -41,7 +41,7 @@ public:
     QXmppRtpPacket(const QXmppRtpPacket &other);
     ~QXmppRtpPacket();
 
-    QXmppRtpPacket& operator=(const QXmppRtpPacket &other);
+    QXmppRtpPacket &operator=(const QXmppRtpPacket &other);
 
     bool decode(const QByteArray &ba);
     QByteArray encode() const;
@@ -61,7 +61,7 @@ public:
 
     quint32 ssrc() const;
     void setSsrc(quint32 ssrc);
-    
+
     quint32 stamp() const;
     void setStamp(quint32 stamp);
 

--- a/src/base/QXmppSasl_p.h
+++ b/src/base/QXmppSasl_p.h
@@ -71,7 +71,7 @@ public:
     virtual bool respond(const QByteArray &challenge, QByteArray &response) = 0;
 
     static QStringList availableMechanisms();
-    static QXmppSaslClient* create(const QString &mechanism, QObject *parent = nullptr);
+    static QXmppSaslClient *create(const QString &mechanism, QObject *parent = nullptr);
 
 private:
     QXmppSaslClientPrivate *d;
@@ -105,7 +105,7 @@ public:
     virtual QString mechanism() const = 0;
     virtual Response respond(const QByteArray &challenge, QByteArray &response) = 0;
 
-    static QXmppSaslServer* create(const QString &mechanism, QObject *parent = nullptr);
+    static QXmppSaslServer *create(const QString &mechanism, QObject *parent = nullptr);
 
 private:
     QXmppSaslServerPrivate *d;

--- a/src/base/QXmppSessionIq.h
+++ b/src/base/QXmppSessionIq.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef QXMPPSESSIONIQ_H
 #define QXMPPSESSIONIQ_H
 
@@ -46,4 +45,4 @@ private:
     /// \endcond
 };
 
-#endif // QXMPPSESSION_H
+#endif  // QXMPPSESSION_H

--- a/src/base/QXmppSocks.h
+++ b/src/base/QXmppSocks.h
@@ -36,7 +36,7 @@ class QXMPP_EXPORT QXmppSocksClient : public QTcpSocket
     Q_OBJECT
 
 public:
-    QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, QObject *parent=nullptr);
+    QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, QObject *parent = nullptr);
     void connectToHost(const QString &hostName, quint16 hostPort);
 
 signals:
@@ -59,7 +59,7 @@ class QXMPP_EXPORT QXmppSocksServer : public QObject
     Q_OBJECT
 
 public:
-    QXmppSocksServer(QObject *parent=nullptr);
+    QXmppSocksServer(QObject *parent = nullptr);
     void close();
     bool listen(quint16 port = 0);
 
@@ -75,7 +75,7 @@ private slots:
 private:
     QTcpServer *m_server;
     QTcpServer *m_server_v6;
-    QMap<QTcpSocket*, int> m_states;
+    QMap<QTcpSocket *, int> m_states;
 };
 
 #endif

--- a/src/base/QXmppStanza.h
+++ b/src/base/QXmppStanza.h
@@ -23,7 +23,6 @@
  *
  */
 
-
 #ifndef QXMPPSTANZA_H
 #define QXMPPSTANZA_H
 
@@ -51,10 +50,10 @@ class QXMPP_EXPORT QXmppExtendedAddress
 {
 public:
     QXmppExtendedAddress();
-    QXmppExtendedAddress(const QXmppExtendedAddress&);
+    QXmppExtendedAddress(const QXmppExtendedAddress &);
     ~QXmppExtendedAddress();
 
-    QXmppExtendedAddress& operator=(const QXmppExtendedAddress&);
+    QXmppExtendedAddress &operator=(const QXmppExtendedAddress &);
 
     QString description() const;
     void setDescription(const QString &description);
@@ -94,8 +93,7 @@ public:
     class QXMPP_EXPORT Error
     {
     public:
-        enum Type
-        {
+        enum Type {
             Cancel,
             Continue,
             Modify,
@@ -103,8 +101,7 @@ public:
             Wait
         };
 
-        enum Condition
-        {
+        enum Condition {
             BadRequest,
             Conflict,
             FeatureNotImplemented,
@@ -131,8 +128,8 @@ public:
 
         Error();
         Error(const Error &);
-        Error(Type type, Condition cond, const QString& text = QString());
-        Error(const QString& type, const QString& cond, const QString& text = QString());
+        Error(Type type, Condition cond, const QString &text = QString());
+        Error(const QString &type, const QString &cond, const QString &text = QString());
         ~Error();
 
         Error &operator=(const Error &);
@@ -141,7 +138,7 @@ public:
         void setCode(int code);
 
         QString text() const;
-        void setText(const QString& text);
+        void setText(const QString &text);
 
         Condition condition() const;
         void setCondition(Condition cond);
@@ -157,7 +154,7 @@ public:
         void setMaxFileSize(qint64);
 
         QDateTime retryDate() const;
-        void setRetryDate(const QDateTime&);
+        void setRetryDate(const QDateTime &);
 
         /// \cond
         void parse(const QDomElement &element);
@@ -166,34 +163,34 @@ public:
 
     private:
         QString getConditionStr() const;
-        void setConditionFromStr(const QString& cond);
+        void setConditionFromStr(const QString &cond);
 
         QString getTypeStr() const;
-        void setTypeFromStr(const QString& type);
+        void setTypeFromStr(const QString &type);
 
         QSharedDataPointer<QXmppStanzaErrorPrivate> d;
     };
 
-    QXmppStanza(const QString& from = QString(), const QString& to = QString());
+    QXmppStanza(const QString &from = QString(), const QString &to = QString());
     QXmppStanza(const QXmppStanza &other);
     virtual ~QXmppStanza();
 
-    QXmppStanza& operator=(const QXmppStanza &other);
+    QXmppStanza &operator=(const QXmppStanza &other);
 
     QString to() const;
-    void setTo(const QString&);
+    void setTo(const QString &);
 
     QString from() const;
-    void setFrom(const QString&);
+    void setFrom(const QString &);
 
     QString id() const;
-    void setId(const QString&);
+    void setId(const QString &);
 
     QString lang() const;
-    void setLang(const QString&);
+    void setLang(const QString &);
 
     QXmppStanza::Error error() const;
-    void setError(const QXmppStanza::Error& error);
+    void setError(const QXmppStanza::Error &error);
 
     QXmppElementList extensions() const;
     void setExtensions(const QXmppElementList &elements);
@@ -217,4 +214,4 @@ private:
     static uint s_uniqeIdNo;
 };
 
-#endif // QXMPPSTANZA_H
+#endif  // QXMPPSTANZA_H

--- a/src/base/QXmppStanza_p.h
+++ b/src/base/QXmppStanza_p.h
@@ -40,8 +40,7 @@
 
 static QString strFromCondition(const QXmppStanza::Error::Condition& condition)
 {
-    switch(condition)
-    {
+    switch (condition) {
     case QXmppStanza::Error::BadRequest:
         return "bad-request";
     case QXmppStanza::Error::Conflict:
@@ -93,53 +92,52 @@ static QString strFromCondition(const QXmppStanza::Error::Condition& condition)
 
 static QXmppStanza::Error::Condition conditionFromStr(const QString& string)
 {
-    if(string == "bad-request")
+    if (string == "bad-request")
         return QXmppStanza::Error::BadRequest;
-    else if(string == "conflict")
+    else if (string == "conflict")
         return QXmppStanza::Error::Conflict;
-    else if(string == "feature-not-implemented")
+    else if (string == "feature-not-implemented")
         return QXmppStanza::Error::FeatureNotImplemented;
-    else if(string == "forbidden")
+    else if (string == "forbidden")
         return QXmppStanza::Error::Forbidden;
-    else if(string == "gone")
+    else if (string == "gone")
         return QXmppStanza::Error::Gone;
-    else if(string == "internal-server-error")
+    else if (string == "internal-server-error")
         return QXmppStanza::Error::InternalServerError;
-    else if(string == "item-not-found")
+    else if (string == "item-not-found")
         return QXmppStanza::Error::ItemNotFound;
-    else if(string == "jid-malformed")
+    else if (string == "jid-malformed")
         return QXmppStanza::Error::JidMalformed;
-    else if(string == "not-acceptable")
+    else if (string == "not-acceptable")
         return QXmppStanza::Error::NotAcceptable;
-    else if(string == "not-allowed")
+    else if (string == "not-allowed")
         return QXmppStanza::Error::NotAllowed;
-    else if(string == "not-authorized")
+    else if (string == "not-authorized")
         return QXmppStanza::Error::NotAuthorized;
-    else if(string == "payment-required")
+    else if (string == "payment-required")
         return QXmppStanza::Error::PaymentRequired;
-    else if(string == "recipient-unavailable")
+    else if (string == "recipient-unavailable")
         return QXmppStanza::Error::RecipientUnavailable;
-    else if(string == "redirect")
+    else if (string == "redirect")
         return QXmppStanza::Error::Redirect;
-    else if(string == "registration-required")
+    else if (string == "registration-required")
         return QXmppStanza::Error::RegistrationRequired;
-    else if(string == "remote-server-not-found")
+    else if (string == "remote-server-not-found")
         return QXmppStanza::Error::RemoteServerNotFound;
-    else if(string == "remote-server-timeout")
+    else if (string == "remote-server-timeout")
         return QXmppStanza::Error::RemoteServerTimeout;
-    else if(string == "resource-constraint")
+    else if (string == "resource-constraint")
         return QXmppStanza::Error::ResourceConstraint;
-    else if(string == "service-unavailable")
+    else if (string == "service-unavailable")
         return QXmppStanza::Error::ServiceUnavailable;
-    else if(string == "subscription-required")
+    else if (string == "subscription-required")
         return QXmppStanza::Error::SubscriptionRequired;
-    else if(string == "undefined-condition")
+    else if (string == "undefined-condition")
         return QXmppStanza::Error::UndefinedCondition;
-    else if(string == "unexpected-request")
+    else if (string == "unexpected-request")
         return QXmppStanza::Error::UnexpectedRequest;
     else
         return static_cast<QXmppStanza::Error::Condition>(-1);
 }
 
 #endif
-

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef QXMPPSTREAM_H
 #define QXMPPSTREAM_H
 
@@ -47,7 +46,7 @@ public:
     ~QXmppStream() override;
 
     virtual bool isConnected() const;
-    bool sendPacket(const QXmppStanza&);
+    bool sendPacket(const QXmppStanza &);
 
 signals:
     /// This signal is emitted when the stream is connected.
@@ -100,7 +99,7 @@ private:
 
 public slots:
     virtual void disconnectFromHost();
-    virtual bool sendData(const QByteArray&);
+    virtual bool sendData(const QByteArray &);
 
 private slots:
     void _q_socketConnected();
@@ -109,7 +108,7 @@ private slots:
     void _q_socketReadyRead();
 
 private:
-    QXmppStreamPrivate * const d;
+    QXmppStreamPrivate *const d;
 };
 
-#endif // QXMPPSTREAM_H
+#endif  // QXMPPSTREAM_H

--- a/src/base/QXmppStreamFeatures.h
+++ b/src/base/QXmppStreamFeatures.h
@@ -31,8 +31,7 @@ class QXMPP_EXPORT QXmppStreamFeatures : public QXmppStanza
 public:
     QXmppStreamFeatures();
 
-    enum Mode
-    {
+    enum Mode {
         Disabled = 0,
         Enabled,
         Required

--- a/src/base/QXmppStreamManagement_p.h
+++ b/src/base/QXmppStreamManagement_p.h
@@ -100,13 +100,13 @@ private:
 class QXMPP_AUTOTEST_EXPORT QXmppStreamManagementResume
 {
 public:
-    QXmppStreamManagementResume(const unsigned h = 0, const QString& previd = QString());
+    QXmppStreamManagementResume(const unsigned h = 0, const QString &previd = QString());
 
     unsigned h() const;
     void setH(const unsigned h);
 
     QString prevId() const;
-    void setPrevId(const QString& id);
+    void setPrevId(const QString &id);
 
     static bool isStreamManagementResume(const QDomElement &element);
 
@@ -123,13 +123,13 @@ private:
 class QXMPP_AUTOTEST_EXPORT QXmppStreamManagementResumed
 {
 public:
-    QXmppStreamManagementResumed(const unsigned h = 0, const QString& previd = QString());
+    QXmppStreamManagementResumed(const unsigned h = 0, const QString &previd = QString());
 
     unsigned h() const;
     void setH(const unsigned h);
 
     QString prevId() const;
-    void setPrevId(const QString& id);
+    void setPrevId(const QString &id);
 
     static bool isStreamManagementResumed(const QDomElement &element);
 

--- a/src/base/QXmppStun.h
+++ b/src/base/QXmppStun.h
@@ -46,21 +46,21 @@ class QXMPP_EXPORT QXmppStunMessage
 {
 public:
     enum MethodType {
-        Binding      = 0x1,
+        Binding = 0x1,
         SharedSecret = 0x2,
-        Allocate     = 0x3,
-        Refresh      = 0x4,
-        Send         = 0x6,
-        Data         = 0x7,
+        Allocate = 0x3,
+        Refresh = 0x4,
+        Send = 0x6,
+        Data = 0x7,
         CreatePermission = 0x8,
-        ChannelBind  = 0x9
+        ChannelBind = 0x9
     };
 
     enum ClassType {
-        Request    = 0x000,
+        Request = 0x000,
         Indication = 0x010,
-        Response   = 0x100,
-        Error      = 0x110
+        Response = 0x100,
+        Error = 0x110
     };
 
     QXmppStunMessage();
@@ -174,7 +174,7 @@ public:
     QList<QXmppJingleCandidate> localCandidates() const;
 
     static QList<QHostAddress> discoverAddresses();
-    static QList<QUdpSocket*> reservePorts(const QList<QHostAddress> &addresses, int count, QObject *parent = nullptr);
+    static QList<QUdpSocket *> reservePorts(const QList<QHostAddress> &addresses, int count, QObject *parent = nullptr);
 
 public slots:
     void close();
@@ -203,7 +203,7 @@ signals:
     void localCandidatesChanged();
 
 private:
-    QXmppIceComponent(int component, QXmppIcePrivate *config, QObject *parent=nullptr);
+    QXmppIceComponent(int component, QXmppIcePrivate *config, QObject *parent = nullptr);
 
     QXmppIceComponentPrivate *d;
     friend class QXmppIceComponentPrivate;

--- a/src/base/QXmppStun_p.h
+++ b/src/base/QXmppStun_p.h
@@ -102,8 +102,7 @@ class QXMPP_EXPORT QXmppTurnAllocation : public QXmppIceTransport
     Q_OBJECT
 
 public:
-    enum AllocationState
-    {
+    enum AllocationState {
         UnconnectedState,
         ConnectingState,
         ConnectedState,
@@ -167,7 +166,7 @@ private:
     QString m_realm;
     QByteArray m_nonce;
     AllocationState m_state;
-    QList<QXmppStunTransaction*> m_transactions;
+    QList<QXmppStunTransaction *> m_transactions;
 };
 
 /// \internal

--- a/src/base/QXmppUtils.h
+++ b/src/base/QXmppUtils.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef QXMPPUTILS_H
 #define QXMPPUTILS_H
 
@@ -46,9 +45,9 @@ class QXMPP_EXPORT QXmppUtils
 {
 public:
     // XEP-0082: XMPP Date and Time Profiles
-    static QDateTime datetimeFromString(const QString &str);
-    static QString datetimeToString(const QDateTime &dt);
-    static int timezoneOffsetFromString(const QString &str);
+    static QDateTime datetimeFromString(const QString& str);
+    static QString datetimeToString(const QDateTime& dt);
+    static int timezoneOffsetFromString(const QString& str);
     static QString timezoneOffsetToString(int secs);
 
     static QString jidToDomain(const QString& jid);
@@ -56,17 +55,17 @@ public:
     static QString jidToUser(const QString& jid);
     static QString jidToBareJid(const QString& jid);
 
-    static quint32 generateCrc32(const QByteArray &input);
-    static QByteArray generateHmacMd5(const QByteArray &key, const QByteArray &text);
-    static QByteArray generateHmacSha1(const QByteArray &key, const QByteArray &text);
+    static quint32 generateCrc32(const QByteArray& input);
+    static QByteArray generateHmacMd5(const QByteArray& key, const QByteArray& text);
+    static QByteArray generateHmacSha1(const QByteArray& key, const QByteArray& text);
     static int generateRandomInteger(int N);
     static QByteArray generateRandomBytes(int length);
-    static QString generateStanzaHash(int length=32);
+    static QString generateStanzaHash(int length = 32);
 };
 
 void helperToXmlAddAttribute(QXmlStreamWriter* stream, const QString& name,
                              const QString& value);
 void helperToXmlAddTextElement(QXmlStreamWriter* stream, const QString& name,
-                           const QString& value);
+                               const QString& value);
 
-#endif // QXMPPUTILS_H
+#endif  // QXMPPUTILS_H

--- a/src/base/QXmppVCardIq.h
+++ b/src/base/QXmppVCardIq.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPVCARDIQ_H
 #define QXMPPVCARDIQ_H
 
@@ -43,11 +42,11 @@ class QXMPP_EXPORT QXmppVCardAddress
 public:
     /// \brief Describes e-mail address types.
     enum TypeFlag {
-        None        = 0x0,
-        Home        = 0x1,
-        Work        = 0x2,
-        Postal      = 0x4,
-        Preferred   = 0x8
+        None = 0x0,
+        Home = 0x1,
+        Work = 0x2,
+        Postal = 0x4,
+        Preferred = 0x8
     };
     Q_DECLARE_FLAGS(Type, TypeFlag)
 
@@ -55,7 +54,7 @@ public:
     QXmppVCardAddress(const QXmppVCardAddress &other);
     ~QXmppVCardAddress();
 
-    QXmppVCardAddress& operator=(const QXmppVCardAddress &other);
+    QXmppVCardAddress &operator=(const QXmppVCardAddress &other);
 
     QString country() const;
     void setCountry(const QString &country);
@@ -84,8 +83,8 @@ private:
     QSharedDataPointer<QXmppVCardAddressPrivate> d;
 };
 
-QXMPP_EXPORT bool operator==(const QXmppVCardAddress&, const QXmppVCardAddress&);
-QXMPP_EXPORT bool operator!=(const QXmppVCardAddress&, const QXmppVCardAddress&);
+QXMPP_EXPORT bool operator==(const QXmppVCardAddress &, const QXmppVCardAddress &);
+QXMPP_EXPORT bool operator!=(const QXmppVCardAddress &, const QXmppVCardAddress &);
 
 /// \brief Represents a vCard e-mail address.
 
@@ -94,12 +93,12 @@ class QXMPP_EXPORT QXmppVCardEmail
 public:
     /// \brief Describes e-mail address types.
     enum TypeFlag {
-        None        = 0x0,
-        Home        = 0x1,
-        Work        = 0x2,
-        Internet    = 0x4,
-        Preferred   = 0x8,
-        X400        = 0x10
+        None = 0x0,
+        Home = 0x1,
+        Work = 0x2,
+        Internet = 0x4,
+        Preferred = 0x8,
+        X400 = 0x10
     };
     Q_DECLARE_FLAGS(Type, TypeFlag)
 
@@ -107,7 +106,7 @@ public:
     QXmppVCardEmail(const QXmppVCardEmail &other);
     ~QXmppVCardEmail();
 
-    QXmppVCardEmail& operator=(const QXmppVCardEmail &other);
+    QXmppVCardEmail &operator=(const QXmppVCardEmail &other);
 
     QString address() const;
     void setAddress(const QString &address);
@@ -124,8 +123,8 @@ private:
     QSharedDataPointer<QXmppVCardEmailPrivate> d;
 };
 
-QXMPP_EXPORT bool operator==(const QXmppVCardEmail&, const QXmppVCardEmail&);
-QXMPP_EXPORT bool operator!=(const QXmppVCardEmail&, const QXmppVCardEmail&);
+QXMPP_EXPORT bool operator==(const QXmppVCardEmail &, const QXmppVCardEmail &);
+QXMPP_EXPORT bool operator!=(const QXmppVCardEmail &, const QXmppVCardEmail &);
 
 /// \brief Represents a vCard phone number.
 
@@ -134,20 +133,20 @@ class QXMPP_EXPORT QXmppVCardPhone
 public:
     /// \brief Describes phone number types.
     enum TypeFlag {
-        None        = 0x0,
-        Home        = 0x1,
-        Work        = 0x2,
-        Voice       = 0x4,
-        Fax         = 0x8,
-        Pager       = 0x10,
-        Messaging   = 0x20,
-        Cell        = 0x40,
-        Video       = 0x80,
-        BBS         = 0x100,
-        Modem       = 0x200,
-        ISDN        = 0x400,
-        PCS         = 0x800,
-        Preferred   = 0x1000
+        None = 0x0,
+        Home = 0x1,
+        Work = 0x2,
+        Voice = 0x4,
+        Fax = 0x8,
+        Pager = 0x10,
+        Messaging = 0x20,
+        Cell = 0x40,
+        Video = 0x80,
+        BBS = 0x100,
+        Modem = 0x200,
+        ISDN = 0x400,
+        PCS = 0x800,
+        Preferred = 0x1000
     };
     Q_DECLARE_FLAGS(Type, TypeFlag)
 
@@ -155,7 +154,7 @@ public:
     QXmppVCardPhone(const QXmppVCardPhone &other);
     ~QXmppVCardPhone();
 
-    QXmppVCardPhone& operator=(const QXmppVCardPhone &other);
+    QXmppVCardPhone &operator=(const QXmppVCardPhone &other);
 
     QString number() const;
     void setNumber(const QString &number);
@@ -172,8 +171,8 @@ private:
     QSharedDataPointer<QXmppVCardPhonePrivate> d;
 };
 
-QXMPP_EXPORT bool operator==(const QXmppVCardPhone&, const QXmppVCardPhone&);
-QXMPP_EXPORT bool operator!=(const QXmppVCardPhone&, const QXmppVCardPhone&);
+QXMPP_EXPORT bool operator==(const QXmppVCardPhone &, const QXmppVCardPhone &);
+QXMPP_EXPORT bool operator!=(const QXmppVCardPhone &, const QXmppVCardPhone &);
 
 /// \brief Represents organization information in XMPP vCards.
 ///
@@ -187,19 +186,19 @@ public:
     QXmppVCardOrganization(const QXmppVCardOrganization &other);
     ~QXmppVCardOrganization();
 
-    QXmppVCardOrganization& operator=(const QXmppVCardOrganization &other);
+    QXmppVCardOrganization &operator=(const QXmppVCardOrganization &other);
 
     QString organization() const;
-    void setOrganization(const QString&);
+    void setOrganization(const QString &);
 
     QString unit() const;
-    void setUnit(const QString&);
+    void setUnit(const QString &);
 
     QString title() const;
-    void setTitle(const QString&);
+    void setTitle(const QString &);
 
     QString role() const;
-    void setRole(const QString&);
+    void setRole(const QString &);
 
     /// \cond
     void parse(const QDomElement &element);
@@ -210,8 +209,8 @@ private:
     QSharedDataPointer<QXmppVCardOrganizationPrivate> d;
 };
 
-QXMPP_EXPORT bool operator==(const QXmppVCardOrganization&, const QXmppVCardOrganization&);
-QXMPP_EXPORT bool operator!=(const QXmppVCardOrganization&, const QXmppVCardOrganization&);
+QXMPP_EXPORT bool operator==(const QXmppVCardOrganization &, const QXmppVCardOrganization &);
+QXMPP_EXPORT bool operator!=(const QXmppVCardOrganization &, const QXmppVCardOrganization &);
 
 /// \brief Represents the XMPP vCard.
 ///
@@ -226,11 +225,11 @@ QXMPP_EXPORT bool operator!=(const QXmppVCardOrganization&, const QXmppVCardOrga
 class QXMPP_EXPORT QXmppVCardIq : public QXmppIq
 {
 public:
-    QXmppVCardIq(const QString& bareJid = QString());
+    QXmppVCardIq(const QString &bareJid = QString());
     QXmppVCardIq(const QXmppVCardIq &other);
     ~QXmppVCardIq() override;
 
-    QXmppVCardIq& operator=(const QXmppVCardIq &other);
+    QXmppVCardIq &operator=(const QXmppVCardIq &other);
 
     QDate birthday() const;
     void setBirthday(const QDate &birthday);
@@ -239,31 +238,31 @@ public:
     void setDescription(const QString &description);
 
     QString email() const;
-    void setEmail(const QString&);
+    void setEmail(const QString &);
 
     QString firstName() const;
-    void setFirstName(const QString&);
+    void setFirstName(const QString &);
 
     QString fullName() const;
-    void setFullName(const QString&);
+    void setFullName(const QString &);
 
     QString lastName() const;
-    void setLastName(const QString&);
+    void setLastName(const QString &);
 
     QString middleName() const;
-    void setMiddleName(const QString&);
+    void setMiddleName(const QString &);
 
     QString nickName() const;
-    void setNickName(const QString&);
+    void setNickName(const QString &);
 
     QByteArray photo() const;
-    void setPhoto(const QByteArray&);
+    void setPhoto(const QByteArray &);
 
     QString photoType() const;
     void setPhotoType(const QString &type);
 
     QString url() const;
-    void setUrl(const QString&);
+    void setUrl(const QString &);
 
     QList<QXmppVCardAddress> addresses() const;
     void setAddresses(const QList<QXmppVCardAddress> &addresses);
@@ -275,7 +274,7 @@ public:
     void setPhones(const QList<QXmppVCardPhone> &phones);
 
     QXmppVCardOrganization organization() const;
-    void setOrganization(const QXmppVCardOrganization&);
+    void setOrganization(const QXmppVCardOrganization &);
 
     /// \cond
     static bool isVCard(const QDomElement &element);
@@ -283,7 +282,7 @@ public:
 
 protected:
     /// \cond
-    void parseElementFromChild(const QDomElement&) override;
+    void parseElementFromChild(const QDomElement &) override;
     void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 
@@ -291,7 +290,7 @@ private:
     QSharedDataPointer<QXmppVCardIqPrivate> d;
 };
 
-QXMPP_EXPORT bool operator==(const QXmppVCardIq&, const QXmppVCardIq&);
-QXMPP_EXPORT bool operator!=(const QXmppVCardIq&, const QXmppVCardIq&);
+QXMPP_EXPORT bool operator==(const QXmppVCardIq &, const QXmppVCardIq &);
+QXMPP_EXPORT bool operator!=(const QXmppVCardIq &, const QXmppVCardIq &);
 
-#endif // QXMPPVCARDIQ_H
+#endif  // QXMPPVCARDIQ_H

--- a/src/client/QXmppArchiveManager.h
+++ b/src/client/QXmppArchiveManager.h
@@ -70,11 +70,11 @@ public:
 signals:
     /// This signal is emitted when archive list is received
     /// after calling listCollections()
-    void archiveListReceived(const QList<QXmppArchiveChat>&, const QXmppResultSetReply &rsm = QXmppResultSetReply());
+    void archiveListReceived(const QList<QXmppArchiveChat> &, const QXmppResultSetReply &rsm = QXmppResultSetReply());
 
     /// This signal is emitted when archive chat is received
     /// after calling retrieveCollection()
-    void archiveChatReceived(const QXmppArchiveChat&, const QXmppResultSetReply &rsm = QXmppResultSetReply());
+    void archiveChatReceived(const QXmppArchiveChat &, const QXmppResultSetReply &rsm = QXmppResultSetReply());
 };
 
 #endif

--- a/src/client/QXmppBookmarkManager.h
+++ b/src/client/QXmppBookmarkManager.h
@@ -57,7 +57,7 @@ signals:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client) override;
+    void setClient(QXmppClient *client) override;
     /// \endcond
 
 private slots:
@@ -65,7 +65,7 @@ private slots:
     void slotDisconnected();
 
 private:
-    QXmppBookmarkManagerPrivate * const d;
+    QXmppBookmarkManagerPrivate *const d;
 };
 
 #endif

--- a/src/client/QXmppCallManager.h
+++ b/src/client/QXmppCallManager.h
@@ -63,17 +63,17 @@ class QXMPP_EXPORT QXmppCall : public QXmppLoggable
 public:
     /// This enum is used to describe the direction of a call.
     enum Direction {
-        IncomingDirection, ///< The call is incoming.
-        OutgoingDirection  ///< The call is outgoing.
+        IncomingDirection,  ///< The call is incoming.
+        OutgoingDirection   ///< The call is outgoing.
     };
     Q_ENUM(Direction)
 
     /// This enum is used to describe the state of a call.
     enum State {
-        ConnectingState = 0,    ///< The call is being connected.
-        ActiveState = 1,        ///< The call is active.
-        DisconnectingState = 2, ///< The call is being disconnected.
-        FinishedState = 3       ///< The call is finished.
+        ConnectingState = 0,     ///< The call is being connected.
+        ActiveState = 1,         ///< The call is active.
+        DisconnectingState = 2,  ///< The call is being disconnected.
+        FinishedState = 3        ///< The call is finished.
     };
     Q_ENUM(State)
 
@@ -188,7 +188,7 @@ public slots:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client) override;
+    void setClient(QXmppClient *client) override;
     /// \endcond
 
 private slots:

--- a/src/client/QXmppCarbonManager.h
+++ b/src/client/QXmppCarbonManager.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPCARBONMANAGER_H
 #define QXMPPCARBONMANAGER_H
 
@@ -58,14 +57,14 @@ signals:
     /// and directed to another resource.
     /// If you connect this signal to the \s QXmppClient::messageReceived
     /// signal, they will appear as normal messages.
-    void messageReceived(const QXmppMessage&);
+    void messageReceived(const QXmppMessage &);
 
     /// \brief Emitted when another resource sent a message to
     /// someone else
-    void messageSent(const QXmppMessage&);
+    void messageSent(const QXmppMessage &);
 
 private:
     bool m_carbonsEnabled;
 };
 
-#endif // QXMPPCARBONMANAGER_H
+#endif  // QXMPPCARBONMANAGER_H

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -80,17 +80,17 @@ class QXmppVersionManager;
 class QXMPP_EXPORT QXmppClient : public QXmppLoggable
 {
     Q_OBJECT
-    Q_PROPERTY(QXmppLogger* logger READ logger WRITE setLogger NOTIFY loggerChanged)
+    Q_PROPERTY(QXmppLogger *logger READ logger WRITE setLogger NOTIFY loggerChanged)
     Q_PROPERTY(State state READ state NOTIFY stateChanged)
 
 public:
     /// An enumeration for type of error.
     /// Error could come due a TCP socket or XML stream or due to various stanzas.
     enum Error {
-        NoError,            ///< No error.
-        SocketError,        ///< Error due to TCP socket.
-        KeepAliveError,     ///< Error due to no response to a keep alive.
-        XmppStreamError     ///< Error due to XML stream.
+        NoError,         ///< No error.
+        SocketError,     ///< Error due to TCP socket.
+        KeepAliveError,  ///< Error due to no response to a keep alive.
+        XmppStreamError  ///< Error due to XML stream.
     };
     Q_ENUM(Error)
 
@@ -105,11 +105,11 @@ public:
     QXmppClient(QObject *parent = nullptr);
     ~QXmppClient() override;
 
-    bool addExtension(QXmppClientExtension* extension);
-    bool insertExtension(int index, QXmppClientExtension* extension);
-    bool removeExtension(QXmppClientExtension* extension);
+    bool addExtension(QXmppClientExtension *extension);
+    bool insertExtension(int index, QXmppClientExtension *extension);
+    bool removeExtension(QXmppClientExtension *extension);
 
-    QList<QXmppClientExtension*> extensions();
+    QList<QXmppClientExtension *> extensions();
 
     /// \brief Returns the extension which can be cast into type T*, or 0
     /// if there is no such extension.
@@ -124,13 +124,12 @@ public:
     /// \endcode
     ///
     template<typename T>
-    T* findExtension()
+    T *findExtension()
     {
-        const QList<QXmppClientExtension*> list = extensions();
-        for (auto ext : list)
-        {
-            T* extension = qobject_cast<T*>(ext);
-            if(extension)
+        const QList<QXmppClientExtension *> list = extensions();
+        for (auto ext : list) {
+            T *extension = qobject_cast<T *>(ext);
+            if (extension)
                 return extension;
         }
         return nullptr;
@@ -156,13 +155,13 @@ public:
 
 #if QXMPP_DEPRECATED_SINCE(1, 1)
     QT_DEPRECATED_X("Use QXmppClient::findExtension<QXmppRosterManager>() instead")
-    QXmppRosterManager& rosterManager();
+    QXmppRosterManager &rosterManager();
 
     QT_DEPRECATED_X("Use QXmppClient::findExtension<QXmppVCardManager>() instead")
-    QXmppVCardManager& vCardManager();
+    QXmppVCardManager &vCardManager();
 
     QT_DEPRECATED_X("Use QXmppClient::findExtension<QXmppVersionManager>() instead")
-    QXmppVersionManager& versionManager();
+    QXmppVersionManager &versionManager();
 #endif
 
 signals:
@@ -228,14 +227,14 @@ signals:
     void stateChanged(QXmppClient::State state);
 
 public slots:
-    void connectToServer(const QXmppConfiguration&,
-                         const QXmppPresence& initialPresence =
-                         QXmppPresence());
+    void connectToServer(const QXmppConfiguration &,
+                         const QXmppPresence &initialPresence =
+                             QXmppPresence());
     void connectToServer(const QString &jid,
                          const QString &password);
     void disconnectFromServer();
-    bool sendPacket(const QXmppStanza&);
-    void sendMessage(const QString& bareJid, const QString& message);
+    bool sendPacket(const QXmppStanza &);
+    void sendMessage(const QString &bareJid, const QString &message);
 
 private slots:
     void _q_elementReceived(const QDomElement &element, bool &handled);
@@ -246,7 +245,7 @@ private slots:
     void _q_streamError(QXmppClient::Error error);
 
 private:
-    QXmppClientPrivate * const d;
+    QXmppClientPrivate *const d;
 };
 
-#endif // QXMPPCLIENT_H
+#endif  // QXMPPCLIENT_H

--- a/src/client/QXmppClientExtension.h
+++ b/src/client/QXmppClientExtension.h
@@ -68,7 +68,7 @@ protected:
     virtual void setClient(QXmppClient *client);
 
 private:
-    QXmppClientExtensionPrivate * const d;
+    QXmppClientExtensionPrivate *const d;
 
     friend class QXmppClient;
 };

--- a/src/client/QXmppConfiguration.h
+++ b/src/client/QXmppConfiguration.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPCONFIGURATION_H
 #define QXMPPCONFIGURATION_H
 
@@ -51,22 +50,20 @@ public:
     /// An enumeration for type of the Security Mode that is stream is encrypted or not.
     /// The server may or may not have TLS feature. Server may force the encryption.
     /// Depending upon all this user can specify following options.
-    enum StreamSecurityMode
-    {
-        TLSEnabled = 0, ///< Encryption is used if available (default).
-        TLSDisabled,    ///< No encryption even if the server offers it.
-        TLSRequired,    ///< Encryption must be available, otherwise the
-                        ///< connection will not be established.
-        LegacySSL       ///< Use only legacy SSL mode.
+    enum StreamSecurityMode {
+        TLSEnabled = 0,  ///< Encryption is used if available (default).
+        TLSDisabled,     ///< No encryption even if the server offers it.
+        TLSRequired,     ///< Encryption must be available, otherwise the
+                         ///< connection will not be established.
+        LegacySSL        ///< Use only legacy SSL mode.
     };
 
     /// An enumeration for various Non-SASL authentication mechanisms available.
     /// The server may or may not allow QXmppConfiguration::Plain mechanism. So
     /// specifying the mechanism is just a hint to the library.
-    enum NonSASLAuthMechanism
-    {
-        NonSASLPlain = 0,///< Plain
-        NonSASLDigest    ///< Digest (default)
+    enum NonSASLAuthMechanism {
+        NonSASLPlain = 0,  ///< Plain
+        NonSASLDigest      ///< Digest (default)
     };
 
     /// An enumeration for various SASL authentication mechanisms available.
@@ -77,25 +74,25 @@ public:
     QXmppConfiguration();
     QXmppConfiguration(const QXmppConfiguration &other);
     ~QXmppConfiguration();
-    QXmppConfiguration& operator=(const QXmppConfiguration &other);
+    QXmppConfiguration &operator=(const QXmppConfiguration &other);
 
     QString host() const;
-    void setHost(const QString&);
+    void setHost(const QString &);
 
     QString domain() const;
-    void setDomain(const QString&);
+    void setDomain(const QString &);
 
     int port() const;
     void setPort(int);
 
     QString user() const;
-    void setUser(const QString&);
+    void setUser(const QString &);
 
     QString password() const;
-    void setPassword(const QString&);
+    void setPassword(const QString &);
 
     QString resource() const;
-    void setResource(const QString&);
+    void setResource(const QString &);
 
     QString jid() const;
     void setJid(const QString &jid);
@@ -103,10 +100,10 @@ public:
     QString jidBare() const;
 
     QString facebookAccessToken() const;
-    void setFacebookAccessToken(const QString&);
+    void setFacebookAccessToken(const QString &);
 
     QString facebookAppId() const;
-    void setFacebookAppId(const QString&);
+    void setFacebookAppId(const QString &);
 
     QString googleAccessToken() const;
     void setGoogleAccessToken(const QString &accessToken);
@@ -139,7 +136,7 @@ public:
     void setSaslAuthMechanism(const QString &mechanism);
 
     QNetworkProxy networkProxy() const;
-    void setNetworkProxy(const QNetworkProxy& proxy);
+    void setNetworkProxy(const QNetworkProxy &proxy);
 
     int keepAliveInterval() const;
     void setKeepAliveInterval(int secs);
@@ -154,4 +151,4 @@ private:
     QSharedDataPointer<QXmppConfigurationPrivate> d;
 };
 
-#endif // QXMPPCONFIGURATION_H
+#endif  // QXMPPCONFIGURATION_H

--- a/src/client/QXmppDiscoveryManager.h
+++ b/src/client/QXmppDiscoveryManager.h
@@ -62,11 +62,11 @@ public:
     void setClientType(const QString&);
 
     QXmppDataForm clientInfoForm() const;
-    void setClientInfoForm(const QXmppDataForm &form);
+    void setClientInfoForm(const QXmppDataForm& form);
 
     /// \cond
     QStringList discoveryFeatures() const override;
-    bool handleStanza(const QDomElement &element) override;
+    bool handleStanza(const QDomElement& element) override;
     /// \endcond
 
 signals:
@@ -77,7 +77,7 @@ signals:
     void itemsReceived(const QXmppDiscoveryIq&);
 
 private:
-    QXmppDiscoveryManagerPrivate *d;
+    QXmppDiscoveryManagerPrivate* d;
 };
 
-#endif // QXMPPDISCOVERYMANAGER_H
+#endif  // QXMPPDISCOVERYMANAGER_H

--- a/src/client/QXmppEntityTimeManager.h
+++ b/src/client/QXmppEntityTimeManager.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPENTITYTIMEMANAGER_H
 #define QXMPPENTITYTIMEMANAGER_H
 
@@ -43,7 +42,7 @@ public:
 
     /// \cond
     QStringList discoveryFeatures() const override;
-    bool handleStanza(const QDomElement &element) override;
+    bool handleStanza(const QDomElement& element) override;
     /// \endcond
 
 signals:
@@ -51,4 +50,4 @@ signals:
     void timeReceived(const QXmppEntityTimeIq&);
 };
 
-#endif // QXMPPENTITYTIMEMANAGER_H
+#endif  // QXMPPENTITYTIMEMANAGER_H

--- a/src/client/QXmppInvokable.h
+++ b/src/client/QXmppInvokable.h
@@ -39,41 +39,40 @@ This is the base class for all objects that will be invokable via RPC.  All publ
 */
 class QXMPP_EXPORT QXmppInvokable : public QObject
 {
-        Q_OBJECT
+    Q_OBJECT
 public:
-        QXmppInvokable( QObject *parent = nullptr );
+    QXmppInvokable(QObject *parent = nullptr);
 
-        ~QXmppInvokable() override;
+    ~QXmppInvokable() override;
 
-        /**
+    /**
          * Execute a method on an object. with a set of arguments. This method is reentrant, and the method
          * that is invoked will be done in a thread safe manner.  It should be noted that while this method
          * is threadsafe and reentrant the side affects of the methods invoked may not be.
          */
-        QVariant dispatch( const QByteArray &method, const QList<QVariant> &args = QList<QVariant>() );
+    QVariant dispatch(const QByteArray &method, const QList<QVariant> &args = QList<QVariant>());
 
-        /**
+    /**
          * Utility method to convert a QList<QVariant> to a list of types for type
          * checking.
          */
-        static QList<QByteArray> paramTypes( const QList<QVariant> &params );
+    static QList<QByteArray> paramTypes(const QList<QVariant> &params);
 
-        /**
+    /**
           * Reimplement this method to return a true if the invoking JID is allowed to execute the method.
           */
-        virtual bool isAuthorized( const QString &jid ) const = 0;
+    virtual bool isAuthorized(const QString &jid) const = 0;
 
 public slots:
-        /**
+    /**
           * This provides a list of interfaces for introspection of the presented interface.
           */
-        QStringList interfaces() const;
+    QStringList interfaces() const;
 
 private:
-        void buildMethodHash();
-        QHash<QByteArray,int> m_methodHash;
-        QReadWriteLock m_lock;
+    void buildMethodHash();
+    QHash<QByteArray, int> m_methodHash;
+    QReadWriteLock m_lock;
 };
-
 
 #endif

--- a/src/client/QXmppMessageReceiptManager.h
+++ b/src/client/QXmppMessageReceiptManager.h
@@ -51,4 +51,4 @@ signals:
     void messageDelivered(const QString &jid, const QString &id);
 };
 
-#endif // QXMPPMESSAGERECEIPTMANAGER_H
+#endif  // QXMPPMESSAGERECEIPTMANAGER_H

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -59,14 +59,14 @@ class QXmppMucRoomPrivate;
 class QXMPP_EXPORT QXmppMucManager : public QXmppClientExtension
 {
     Q_OBJECT
-    Q_PROPERTY(QList<QXmppMucRoom*> rooms READ rooms NOTIFY roomAdded)
+    Q_PROPERTY(QList<QXmppMucRoom *> rooms READ rooms NOTIFY roomAdded)
 
 public:
     QXmppMucManager();
     ~QXmppMucManager() override;
 
     QXmppMucRoom *addRoom(const QString &roomJid);
-    QList<QXmppMucRoom*> rooms() const;
+    QList<QXmppMucRoom *> rooms() const;
 
     /// \cond
     QStringList discoveryFeatures() const override;
@@ -82,7 +82,7 @@ signals:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client) override;
+    void setClient(QXmppClient *client) override;
     /// \endcond
 
 private slots:
@@ -112,14 +112,13 @@ class QXMPP_EXPORT QXmppMucRoom : public QObject
     Q_PROPERTY(QString subject READ subject WRITE setSubject NOTIFY subjectChanged)
 
 public:
-
     /// This enum is used to describe chat room actions.
     enum Action {
-        NoAction = 0,               ///< no action
-        SubjectAction = 1,          ///< change the room's subject
-        ConfigurationAction = 2,    ///< change the room's configuration
-        PermissionsAction = 4,      ///< change the room's permissions
-        KickAction = 8              ///< kick users from the room
+        NoAction = 0,             ///< no action
+        SubjectAction = 1,        ///< change the room's subject
+        ConfigurationAction = 2,  ///< change the room's configuration
+        PermissionsAction = 4,    ///< change the room's permissions
+        KickAction = 8            ///< kick users from the room
     };
     Q_DECLARE_FLAGS(Actions, Action)
 

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -22,7 +22,6 @@
  *
  */
 
-
 #ifndef QXMPPOUTGOINGCLIENT_H
 #define QXMPPOUTGOINGCLIENT_H
 
@@ -60,7 +59,7 @@ public:
     QSslSocket *socket() const { return QXmppStream::socket(); };
     QXmppStanza::Error::Condition xmppStreamError();
 
-    QXmppConfiguration& configuration();
+    QXmppConfiguration &configuration();
 
 signals:
     /// This signal is emitted when an error is encountered.
@@ -70,13 +69,13 @@ signals:
     void elementReceived(const QDomElement &element, bool &handled);
 
     /// This signal is emitted when a presence is received.
-    void presenceReceived(const QXmppPresence&);
+    void presenceReceived(const QXmppPresence &);
 
     /// This signal is emitted when a message is received.
-    void messageReceived(const QXmppMessage&);
+    void messageReceived(const QXmppMessage &);
 
     /// This signal is emitted when an IQ is received.
-    void iqReceived(const QXmppIq&);
+    void iqReceived(const QXmppIq &);
 
     /// This signal is emitted when SSL errors are encountered.
     void sslErrors(const QList<QSslError> &errors);
@@ -96,7 +95,7 @@ private slots:
     void _q_dnsLookupFinished();
     void _q_socketDisconnected();
     void socketError(QAbstractSocket::SocketError);
-    void socketSslErrors(const QList<QSslError>&);
+    void socketSslErrors(const QList<QSslError> &);
 
     void pingStart();
     void pingStop();
@@ -105,7 +104,7 @@ private slots:
 
 private:
     friend class QXmppOutgoingClientPrivate;
-    QXmppOutgoingClientPrivate * const d;
+    QXmppOutgoingClientPrivate *const d;
 };
 
-#endif // QXMPPOUTGOINGCLIENT_H
+#endif  // QXMPPOUTGOINGCLIENT_H

--- a/src/client/QXmppRemoteMethod.h
+++ b/src/client/QXmppRemoteMethod.h
@@ -32,7 +32,7 @@
 class QXmppClient;
 
 struct QXmppRemoteMethodResult {
-    QXmppRemoteMethodResult() : hasError(false), code(0) { }
+    QXmppRemoteMethodResult() : hasError(false), code(0) {}
     bool hasError;
     int code;
     QString errorMessage;
@@ -44,11 +44,11 @@ class QXMPP_EXPORT QXmppRemoteMethod : public QObject
     Q_OBJECT
 public:
     QXmppRemoteMethod(const QString &jid, const QString &method, const QVariantList &args, QXmppClient *client);
-    QXmppRemoteMethodResult call( );
+    QXmppRemoteMethodResult call();
 
 private slots:
-    void gotError( const QXmppRpcErrorIq &iq );
-    void gotResult( const QXmppRpcResponseIq &iq );
+    void gotError(const QXmppRpcErrorIq &iq);
+    void gotResult(const QXmppRpcResponseIq &iq);
 
 signals:
     void callDone();
@@ -57,7 +57,6 @@ private:
     QXmppRpcInvokeIq m_payload;
     QXmppClient *m_client;
     QXmppRemoteMethodResult m_result;
-
 };
 
-#endif // QXMPPREMOTEMETHOD_H
+#endif  // QXMPPREMOTEMETHOD_H

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -69,18 +69,18 @@ class QXMPP_EXPORT QXmppRosterManager : public QXmppClientExtension
     Q_OBJECT
 
 public:
-    QXmppRosterManager(QXmppClient* stream);
+    QXmppRosterManager(QXmppClient *stream);
     ~QXmppRosterManager() override;
 
     bool isRosterReceived() const;
     QStringList getRosterBareJids() const;
-    QXmppRosterIq::Item getRosterEntry(const QString& bareJid) const;
+    QXmppRosterIq::Item getRosterEntry(const QString &bareJid) const;
 
-    QStringList getResources(const QString& bareJid) const;
+    QStringList getResources(const QString &bareJid) const;
     QMap<QString, QXmppPresence> getAllPresencesForBareJid(
-            const QString& bareJid) const;
-    QXmppPresence getPresence(const QString& bareJid,
-                              const QString& resource) const;
+        const QString &bareJid) const;
+    QXmppPresence getPresence(const QString &bareJid,
+                              const QString &resource) const;
 
     /// \cond
     bool handleStanza(const QDomElement &element) override;
@@ -103,7 +103,7 @@ signals:
     void rosterReceived();
 
     /// This signal is emitted when the presence of a particular bareJid and resource changes.
-    void presenceChanged(const QString& bareJid, const QString& resource);
+    void presenceChanged(const QString &bareJid, const QString &resource);
 
     /// This signal is emitted when a contact asks to subscribe to your presence.
     ///
@@ -112,27 +112,27 @@ signals:
     ///
     /// \note If you set QXmppConfiguration::autoAcceptSubscriptions() to true, this
     /// signal will not be emitted.
-    void subscriptionReceived(const QString& bareJid);
+    void subscriptionReceived(const QString &bareJid);
 
     /// This signal is emitted when the roster entry of a particular bareJid is
     /// added as a result of roster push.
-    void itemAdded(const QString& bareJid);
+    void itemAdded(const QString &bareJid);
 
     /// This signal is emitted when the roster entry of a particular bareJid
     /// changes as a result of roster push.
-    void itemChanged(const QString& bareJid);
+    void itemChanged(const QString &bareJid);
 
     /// This signal is emitted when the roster entry of a particular bareJid is
     /// removed as a result of roster push.
-    void itemRemoved(const QString& bareJid);
+    void itemRemoved(const QString &bareJid);
 
 private slots:
     void _q_connected();
     void _q_disconnected();
-    void _q_presenceReceived(const QXmppPresence&);
+    void _q_presenceReceived(const QXmppPresence &);
 
 private:
     QXmppRosterManagerPrivate *d;
 };
 
-#endif // QXMPPROSTER_H
+#endif  // QXMPPROSTER_H

--- a/src/client/QXmppRpcManager.h
+++ b/src/client/QXmppRpcManager.h
@@ -58,19 +58,19 @@ class QXMPP_EXPORT QXmppRpcManager : public QXmppClientExtension
 public:
     QXmppRpcManager();
 
-    void addInvokableInterface( QXmppInvokable *interface );
-    QXmppRemoteMethodResult callRemoteMethod( const QString &jid,
-                                              const QString &interface,
-                                              const QVariant &arg1 = QVariant(),
-                                              const QVariant &arg2 = QVariant(),
-                                              const QVariant &arg3 = QVariant(),
-                                              const QVariant &arg4 = QVariant(),
-                                              const QVariant &arg5 = QVariant(),
-                                              const QVariant &arg6 = QVariant(),
-                                              const QVariant &arg7 = QVariant(),
-                                              const QVariant &arg8 = QVariant(),
-                                              const QVariant &arg9 = QVariant(),
-                                              const QVariant &arg10 = QVariant() );
+    void addInvokableInterface(QXmppInvokable *interface);
+    QXmppRemoteMethodResult callRemoteMethod(const QString &jid,
+                                             const QString &interface,
+                                             const QVariant &arg1 = QVariant(),
+                                             const QVariant &arg2 = QVariant(),
+                                             const QVariant &arg3 = QVariant(),
+                                             const QVariant &arg4 = QVariant(),
+                                             const QVariant &arg5 = QVariant(),
+                                             const QVariant &arg6 = QVariant(),
+                                             const QVariant &arg7 = QVariant(),
+                                             const QVariant &arg8 = QVariant(),
+                                             const QVariant &arg9 = QVariant(),
+                                             const QVariant &arg10 = QVariant());
 
     /// \cond
     QStringList discoveryFeatures() const override;
@@ -80,14 +80,14 @@ public:
 
 signals:
     /// \cond
-    void rpcCallResponse(const QXmppRpcResponseIq& result);
+    void rpcCallResponse(const QXmppRpcResponseIq &result);
     void rpcCallError(const QXmppRpcErrorIq &err);
     /// \endcond
 
 private:
     void invokeInterfaceMethod(const QXmppRpcInvokeIq &iq);
 
-    QMap<QString,QXmppInvokable*> m_interfaces;
+    QMap<QString, QXmppInvokable *> m_interfaces;
 };
 
 #endif

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -66,7 +66,7 @@ public:
     void setSize(qint64 size);
 
     bool isNull() const;
-    QXmppTransferFileInfo& operator=(const QXmppTransferFileInfo &other);
+    QXmppTransferFileInfo &operator=(const QXmppTransferFileInfo &other);
     bool operator==(const QXmppTransferFileInfo &other) const;
 
     /// \cond
@@ -99,38 +99,37 @@ class QXMPP_EXPORT QXmppTransferJob : public QXmppLoggable
 public:
     /// This enum is used to describe the direction of a transfer job.
     enum Direction {
-        IncomingDirection, ///< The file is being received.
-        OutgoingDirection  ///< The file is being sent.
+        IncomingDirection,  ///< The file is being received.
+        OutgoingDirection   ///< The file is being sent.
     };
     Q_ENUM(Direction)
 
     /// This enum is used to describe the type of error encountered by a transfer job.
     enum Error {
-        NoError = 0,      ///< No error occurred.
-        AbortError,       ///< The file transfer was aborted.
-        FileAccessError,  ///< An error was encountered trying to access a local file.
-        FileCorruptError, ///< The file is corrupt: the file size or hash do not match.
-        ProtocolError     ///< An error was encountered in the file transfer protocol.
+        NoError = 0,       ///< No error occurred.
+        AbortError,        ///< The file transfer was aborted.
+        FileAccessError,   ///< An error was encountered trying to access a local file.
+        FileCorruptError,  ///< The file is corrupt: the file size or hash do not match.
+        ProtocolError      ///< An error was encountered in the file transfer protocol.
     };
     Q_ENUM(Error)
 
     /// This enum is used to describe a transfer method.
     enum Method {
-        NoMethod = 0,     ///< No transfer method.
-        InBandMethod = 1, ///< XEP-0047: In-Band Bytestreams
-        SocksMethod = 2,  ///< XEP-0065: SOCKS5 Bytestreams
-        AnyMethod = 3     ///< Any supported transfer method.
+        NoMethod = 0,      ///< No transfer method.
+        InBandMethod = 1,  ///< XEP-0047: In-Band Bytestreams
+        SocksMethod = 2,   ///< XEP-0065: SOCKS5 Bytestreams
+        AnyMethod = 3      ///< Any supported transfer method.
     };
     Q_ENUM(Method)
     Q_DECLARE_FLAGS(Methods, Method)
 
     /// This enum is used to describe the state of a transfer job.
-    enum State
-    {
-        OfferState = 0,    ///< The transfer is being offered to the remote party.
-        StartState = 1,    ///< The transfer is being connected.
-        TransferState = 2, ///< The transfer is ongoing.
-        FinishedState = 3  ///< The transfer is finished.
+    enum State {
+        OfferState = 0,     ///< The transfer is being offered to the remote party.
+        StartState = 1,     ///< The transfer is being connected.
+        TransferState = 2,  ///< The transfer is ongoing.
+        FinishedState = 3   ///< The transfer is finished.
     };
     Q_ENUM(State)
 
@@ -262,11 +261,11 @@ public slots:
 
 protected:
     /// \cond
-    void setClient(QXmppClient* client) override;
+    void setClient(QXmppClient *client) override;
     /// \endcond
 
 private slots:
-    void _q_iqReceived(const QXmppIq&);
+    void _q_iqReceived(const QXmppIq &);
     void _q_jobDestroyed(QObject *object);
     void _q_jobError(QXmppTransferJob::Error error);
     void _q_jobFinished();
@@ -276,17 +275,17 @@ private slots:
 private:
     QXmppTransferManagerPrivate *d;
 
-    void byteStreamIqReceived(const QXmppByteStreamIq&);
-    void byteStreamResponseReceived(const QXmppIq&);
-    void byteStreamResultReceived(const QXmppByteStreamIq&);
-    void byteStreamSetReceived(const QXmppByteStreamIq&);
-    void ibbCloseIqReceived(const QXmppIbbCloseIq&);
-    void ibbDataIqReceived(const QXmppIbbDataIq&);
-    void ibbOpenIqReceived(const QXmppIbbOpenIq&);
-    void ibbResponseReceived(const QXmppIq&);
-    void streamInitiationIqReceived(const QXmppStreamInitiationIq&);
-    void streamInitiationResultReceived(const QXmppStreamInitiationIq&);
-    void streamInitiationSetReceived(const QXmppStreamInitiationIq&);
+    void byteStreamIqReceived(const QXmppByteStreamIq &);
+    void byteStreamResponseReceived(const QXmppIq &);
+    void byteStreamResultReceived(const QXmppByteStreamIq &);
+    void byteStreamSetReceived(const QXmppByteStreamIq &);
+    void ibbCloseIqReceived(const QXmppIbbCloseIq &);
+    void ibbDataIqReceived(const QXmppIbbDataIq &);
+    void ibbOpenIqReceived(const QXmppIbbOpenIq &);
+    void ibbResponseReceived(const QXmppIq &);
+    void streamInitiationIqReceived(const QXmppStreamInitiationIq &);
+    void streamInitiationResultReceived(const QXmppStreamInitiationIq &);
+    void streamInitiationSetReceived(const QXmppStreamInitiationIq &);
     void socksServerSendOffer(QXmppTransferJob *job);
 
     friend class QXmppTransferManagerPrivate;

--- a/src/client/QXmppUploadRequestManager.h
+++ b/src/client/QXmppUploadRequestManager.h
@@ -137,4 +137,4 @@ private:
     QSharedDataPointer<QXmppUploadRequestManagerPrivate> d;
 };
 
-#endif // QXMPPUPLOADREQUESTMANAGER_H
+#endif  // QXMPPUPLOADREQUESTMANAGER_H

--- a/src/client/QXmppVCardManager.h
+++ b/src/client/QXmppVCardManager.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef QXMPPVCARDMANAGER_H
 #define QXMPPVCARDMANAGER_H
 
@@ -71,7 +70,7 @@ public:
 
     /// \cond
     QStringList discoveryFeatures() const override;
-    bool handleStanza(const QDomElement &element) override;
+    bool handleStanza(const QDomElement& element) override;
     /// \endcond
 
 signals:
@@ -84,7 +83,7 @@ signals:
     void clientVCardReceived();
 
 private:
-    QXmppVCardManagerPrivate *d;
+    QXmppVCardManagerPrivate* d;
 };
 
-#endif // QXMPPVCARDMANAGER_H
+#endif  // QXMPPVCARDMANAGER_H

--- a/src/client/QXmppVersionManager.h
+++ b/src/client/QXmppVersionManager.h
@@ -46,11 +46,11 @@ public:
     QXmppVersionManager();
     ~QXmppVersionManager() override;
 
-    QString requestVersion(const QString& jid);
+    QString requestVersion(const QString &jid);
 
-    void setClientName(const QString&);
-    void setClientVersion(const QString&);
-    void setClientOs(const QString&);
+    void setClientName(const QString &);
+    void setClientVersion(const QString &);
+    void setClientOs(const QString &);
 
     QString clientName() const;
     QString clientVersion() const;
@@ -63,10 +63,10 @@ public:
 
 signals:
     /// \brief This signal is emitted when a version response is received.
-    void versionReceived(const QXmppVersionIq&);
+    void versionReceived(const QXmppVersionIq &);
 
 private:
     QXmppVersionManagerPrivate *d;
 };
 
-#endif // QXMPPVERSIONMANAGER_H
+#endif  // QXMPPVERSIONMANAGER_H

--- a/src/server/QXmppDialback.h
+++ b/src/server/QXmppDialback.h
@@ -36,10 +36,10 @@ class QXMPP_EXPORT QXmppDialback : public QXmppStanza
 public:
     /// This enum is used to describe a dialback command.
     enum Command {
-        Result, ///< A dialback command between the originating server
-                ///< and the receiving server.
-        Verify  ///< A dialback command between the receiving server
-                ///< and the authoritative server.
+        Result,  ///< A dialback command between the originating server
+                 ///< and the receiving server.
+        Verify   ///< A dialback command between the receiving server
+                 ///< and the authoritative server.
     };
 
     QXmppDialback();

--- a/src/server/QXmppIncomingClient.h
+++ b/src/server/QXmppIncomingClient.h
@@ -68,7 +68,7 @@ private slots:
 
 private:
     Q_DISABLE_COPY(QXmppIncomingClient)
-    QXmppIncomingClientPrivate* d;
+    QXmppIncomingClientPrivate *d;
     friend class QXmppIncomingClientPrivate;
 };
 

--- a/src/server/QXmppIncomingServer.h
+++ b/src/server/QXmppIncomingServer.h
@@ -64,7 +64,7 @@ private slots:
 
 private:
     Q_DISABLE_COPY(QXmppIncomingServer)
-    QXmppIncomingServerPrivate* d;
+    QXmppIncomingServerPrivate *d;
     friend class QXmppIncomingServerPrivate;
 };
 

--- a/src/server/QXmppOutgoingServer.h
+++ b/src/server/QXmppOutgoingServer.h
@@ -77,7 +77,7 @@ private slots:
 
 private:
     Q_DISABLE_COPY(QXmppOutgoingServer)
-    QXmppOutgoingServerPrivate* const d;
+    QXmppOutgoingServerPrivate *const d;
 };
 
 #endif

--- a/src/server/QXmppServer.h
+++ b/src/server/QXmppServer.h
@@ -59,14 +59,14 @@ class QXmppStream;
 class QXMPP_EXPORT QXmppServer : public QXmppLoggable
 {
     Q_OBJECT
-    Q_PROPERTY(QXmppLogger* logger READ logger WRITE setLogger NOTIFY loggerChanged)
+    Q_PROPERTY(QXmppLogger *logger READ logger WRITE setLogger NOTIFY loggerChanged)
 
 public:
     QXmppServer(QObject *parent = nullptr);
     ~QXmppServer() override;
 
     void addExtension(QXmppServerExtension *extension);
-    QList<QXmppServerExtension*> extensions();
+    QList<QXmppServerExtension *> extensions();
 
     QString domain() const;
     void setDomain(const QString &domain);
@@ -144,7 +144,7 @@ signals:
 
 private:
     void incomingConnection(qintptr socketDescriptor) override;
-    QXmppSslServerPrivate * const d;
+    QXmppSslServerPrivate *const d;
 };
 
 #endif

--- a/src/server/QXmppServerExtension.h
+++ b/src/server/QXmppServerExtension.h
@@ -69,7 +69,7 @@ protected:
 
 private:
     void setServer(QXmppServer *server);
-    QXmppServerExtensionPrivate * const d;
+    QXmppServerExtensionPrivate *const d;
 
     friend class QXmppServer;
 };

--- a/tests/util.h
+++ b/tests/util.h
@@ -26,7 +26,7 @@
 #include <QtTest>
 #include "QXmppPasswordChecker.h"
 
-template <class T>
+template<class T>
 static void parsePacket(T &packet, const QByteArray &xml)
 {
     //qDebug() << "parsing" << xml;
@@ -36,7 +36,7 @@ static void parsePacket(T &packet, const QByteArray &xml)
     packet.parse(element);
 }
 
-template <class T>
+template<class T>
 static void serializePacket(T &packet, const QByteArray &xml)
 {
     QBuffer buffer;
@@ -59,8 +59,7 @@ public:
     /// Retrieves the password for the given username.
     QXmppPasswordReply::Error getPassword(const QXmppPasswordRequest &request, QString &password) override
     {
-        if (m_credentials.contains(request.username()))
-        {
+        if (m_credentials.contains(request.username())) {
             password = m_credentials.value(request.username());
             return QXmppPasswordReply::NoError;
         } else {


### PR DESCRIPTION
Did somebody ask for a `.clang-format`? :)

I took a few files that seem to be representative of the general project style (namely, `QXmppMessage.*` and `QXmppClient.*`) and fed them to a little program I've been working on lately that tries to find the closest matching style. Here's the result which I expect to be more or less close to the best achievable with `clang-format`.

Turns out, that's still quite a significant change, so that's up for you folks to consider if we want to go this route. Personally, the thing I hate the most is the extra space before `&` when there is no parameter name, like `foo(const Bar &)`, but clang-format doesn't have a handle to control that, and aligning all pointers/references to the left makes this change twice as big.