### PR TITLE
QXmppClient: Add method to get index of extension

### DIFF
--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -135,6 +135,30 @@ public:
         return nullptr;
     }
 
+    /// \brief Returns the index of an extension
+    ///
+    /// Usage example:
+    /// \code
+    /// int index = client->indexOfExtension<QXmppDiscoveryManager>();
+    /// if (index > 0) {
+    ///     // extension found, do stuff...
+    /// } else {
+    ///     // extension not found
+    /// }
+    /// \endcode
+    ///
+    template<typename T>
+    int indexOfExtension()
+    {
+        int index = -1;
+        auto list = extensions();
+        for (int i = 0; i < list.size(); ++i) {
+            if (qobject_cast<T *>(list.at(i)) != nullptr)
+                index = i;
+        }
+        return index;
+    }
+
     bool isAuthenticated() const;
     bool isConnected() const;
 


### PR DESCRIPTION
This is useful when you need to insert an extension after another or before.