### PR TITLE
QXmppRegisterIq: Add utility methods to create common requests

### DIFF
--- a/src/base/QXmppRegisterIq.cpp
+++ b/src/base/QXmppRegisterIq.cpp
@@ -65,6 +65,42 @@ QXmppRegisterIq::~QXmppRegisterIq() = default;
 
 QXmppRegisterIq &QXmppRegisterIq::operator=(const QXmppRegisterIq &other) = default;
 
+/// Constructs a regular change password request.
+///
+/// \param username The username of the account of which the password should be
+/// changed.
+/// \param newPassword The new password that should be set.
+/// \param to Optional JID of the registration service. If this is omitted, the
+/// IQ is automatically addressed to the local server.
+///
+/// \since QXmpp 1.2
+
+QXmppRegisterIq QXmppRegisterIq::createChangePasswordRequest(const QString &username, const QString &newPassword, const QString &to)
+{
+    QXmppRegisterIq iq;
+    iq.setType(QXmppIq::Set);
+    iq.setTo(to);
+    iq.setUsername(username);
+    iq.setPassword(newPassword);
+    return iq;
+}
+
+/// Constructs a regular unregistration request.
+///
+/// \param to Optional JID of the registration service. If this is omitted, the
+/// IQ is automatically addressed to the local server.
+///
+/// \since QXmpp 1.2
+
+QXmppRegisterIq QXmppRegisterIq::createUnregistrationRequest(const QString &to)
+{
+    QXmppRegisterIq iq;
+    iq.setType(QXmppIq::Set);
+    iq.setTo(to);
+    iq.setRegisterType(QXmppRegisterIq::Remove);
+    return iq;
+}
+
 /// Returns the email for this registration IQ.
 
 QString QXmppRegisterIq::email() const

--- a/src/base/QXmppRegisterIq.h
+++ b/src/base/QXmppRegisterIq.h
@@ -47,7 +47,7 @@ public:
 
     enum RegisterType {
         None,        ///< No special register IQ.
-        Registered,  ///< Used by the service to indicate that an account is already registered.
+        Registered,  ///< Used by the service to indicate that an account is registered.
         Remove       ///< Used by the client to request account removal.
     };
 
@@ -56,6 +56,9 @@ public:
     ~QXmppRegisterIq();
 
     QXmppRegisterIq &operator=(const QXmppRegisterIq &other);
+
+    static QXmppRegisterIq createChangePasswordRequest(const QString &username, const QString &newPassword, const QString &to = {});
+    static QXmppRegisterIq createUnregistrationRequest(const QString &to = {});
 
     QString email() const;
     void setEmail(const QString &email);

--- a/tests/qxmppregisteriq/tst_qxmppregisteriq.cpp
+++ b/tests/qxmppregisteriq/tst_qxmppregisteriq.cpp
@@ -43,6 +43,8 @@ private slots:
     void testBobData();
     void testRegistered();
     void testRemove();
+    void testChangePassword();
+    void testUnregistration();
 };
 
 void tst_QXmppRegisterIq::testGet()
@@ -341,6 +343,39 @@ void tst_QXmppRegisterIq::testRemove()
     iq.setType(QXmppIq::Result);
     iq.setRegisterType(QXmppRegisterIq::Remove);
     iq.setUsername(QStringLiteral("juliet"));
+    serializePacket(iq, xml);
+}
+
+void tst_QXmppRegisterIq::testChangePassword()
+{
+    const QByteArray xml = QByteArrayLiteral(
+        "<iq id=\"changePassword1\" to=\"shakespeare.lit\" type=\"set\">"
+        "<query xmlns=\"jabber:iq:register\">"
+        "<username>bill</username>"
+        "<password>m1cr0$0ft</password>"
+        "</query>"
+        "</iq>");
+
+    auto iq = QXmppRegisterIq::createChangePasswordRequest(
+        QStringLiteral("bill"),
+        QStringLiteral("m1cr0$0ft"),
+        QStringLiteral("shakespeare.lit")
+    );
+    iq.setId(QStringLiteral("changePassword1"));
+    serializePacket(iq, xml);
+}
+
+void tst_QXmppRegisterIq::testUnregistration()
+{
+    const QByteArray xml = QByteArrayLiteral(
+        "<iq id=\"unreg1\" to=\"shakespeare.lit\" type=\"set\">"
+        "<query xmlns=\"jabber:iq:register\">"
+        "<remove/>"
+        "</query>"
+        "</iq>");
+
+    auto iq = QXmppRegisterIq::createUnregistrationRequest(QStringLiteral("shakespeare.lit"));
+    iq.setId(QStringLiteral("unreg1"));
     serializePacket(iq, xml);
 }
 


### PR DESCRIPTION
This adds utility methods to create an unregistration or a change
password request in one line.