### PR TITLE
Refactor QXmppRegisterIq: Replace registerType by two separate attr.

### DIFF
--- a/src/base/QXmppRegisterIq.h
+++ b/src/base/QXmppRegisterIq.h
@@ -41,16 +41,6 @@ class QXmppRegisterIqPrivate;
 class QXMPP_EXPORT QXmppRegisterIq : public QXmppIq
 {
 public:
-    /// Special type of the registration IQ.
-    ///
-    /// \since QXmpp 1.2
-
-    enum RegisterType {
-        None,        ///< No special register IQ.
-        Registered,  ///< Used by the service to indicate that an account is registered.
-        Remove       ///< Used by the client to request account removal.
-    };
-
     QXmppRegisterIq();
     QXmppRegisterIq(const QXmppRegisterIq &other);
     ~QXmppRegisterIq();
@@ -75,8 +65,11 @@ public:
     QString username() const;
     void setUsername(const QString &username);
 
-    RegisterType registerType() const;
-    void setRegisterType(RegisterType registerType);
+    bool isRegistered() const;
+    void setIsRegistered(bool isRegistered);
+
+    bool isRemove() const;
+    void setIsRemove(bool isRemove);
 
     QXmppBitsOfBinaryDataList bitsOfBinaryData() const;
     QXmppBitsOfBinaryDataList &bitsOfBinaryData();

--- a/tests/qxmppregisteriq/tst_qxmppregisteriq.cpp
+++ b/tests/qxmppregisteriq/tst_qxmppregisteriq.cpp
@@ -61,7 +61,8 @@ void tst_QXmppRegisterIq::testGet()
     QCOMPARE(iq.from(), QString());
     QCOMPARE(iq.type(), QXmppIq::Get);
     QCOMPARE(iq.instructions(), QString());
-    QCOMPARE(iq.registerType(), QXmppRegisterIq::None);
+    QVERIFY(!iq.isRegistered());
+    QVERIFY(!iq.isRemove());
     QVERIFY(iq.username().isNull());
     QVERIFY(iq.password().isNull());
     QVERIFY(iq.email().isNull());
@@ -310,14 +311,14 @@ void tst_QXmppRegisterIq::testRegistered()
 
     QXmppRegisterIq iq;
     parsePacket(iq, xml);
-    QCOMPARE(iq.registerType(), QXmppRegisterIq::Registered);
+    QVERIFY(iq.isRegistered());
     QCOMPARE(iq.username(), QStringLiteral("juliet"));
     serializePacket(iq, xml);
 
     iq = QXmppRegisterIq();
     iq.setId(QStringLiteral(""));
     iq.setType(QXmppIq::Result);
-    iq.setRegisterType(QXmppRegisterIq::Registered);
+    iq.setIsRegistered(true);
     iq.setUsername(QStringLiteral("juliet"));
     serializePacket(iq, xml);
 }
@@ -334,14 +335,14 @@ void tst_QXmppRegisterIq::testRemove()
 
     QXmppRegisterIq iq;
     parsePacket(iq, xml);
-    QCOMPARE(iq.registerType(), QXmppRegisterIq::Remove);
+    QVERIFY(iq.isRemove());
     QCOMPARE(iq.username(), QStringLiteral("juliet"));
     serializePacket(iq, xml);
 
     iq = QXmppRegisterIq();
     iq.setId(QStringLiteral(""));
     iq.setType(QXmppIq::Result);
-    iq.setRegisterType(QXmppRegisterIq::Remove);
+    iq.setIsRemove(true);
     iq.setUsername(QStringLiteral("juliet"));
     serializePacket(iq, xml);
 }

--- a/tests/qxmppregistrationmanager/tst_qxmppregistrationmanager.cpp
+++ b/tests/qxmppregistrationmanager/tst_qxmppregistrationmanager.cpp
@@ -147,7 +147,7 @@ void tst_QXmppRegistrationManager::testDeleteAccount()
         // to address must be the server or empty
         QVERIFY(iq.to() == QStringLiteral("example.org") || iq.to().isEmpty());
         QCOMPARE(iq.type(), QXmppIq::Set);
-        QCOMPARE(iq.registerType(), QXmppRegisterIq::Remove);
+        QVERIFY(iq.isRemove());
 
         delete context;  // disconnects lambda
     });


### PR DESCRIPTION
This can be done without any concerns, because the registerType was not
part of any release yet.