### PR TITLE
utils: Generate UUIDs for stanza hashes by default

### DIFF
--- a/src/base/QXmppUtils.cpp
+++ b/src/base/QXmppUtils.cpp
@@ -35,6 +35,7 @@
 #include <QRegExp>
 #include <QString>
 #include <QStringList>
+#include <QUuid>
 #include <QXmlStreamWriter>
 
 // adapted from public domain source by Ross Williams and Eric Durbin
@@ -291,12 +292,40 @@ QByteArray QXmppUtils::generateRandomBytes(int length)
     return bytes;
 }
 
+///
+/// Creates a new stanza id in the UUID format.
+///
+/// \since QXmpp 1.3
+///
+QString QXmppUtils::generateStanzaUuid()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+    return QUuid::createUuid().toString(QUuid::WithoutBraces);
+#else
+    return QUuid::createUuid().toString().mid(1, 36);
+#endif
+}
+
+///
 /// Returns a random alphanumerical string of the specified size.
 ///
+/// Since QXmpp 1.3 this will generate a UUID, if the specified \p length is 36
+/// which is also the new default value. The returned string is still 36
+/// characters long, but will contain dashes (as specified in the UUID format).
+///
+/// \note It is recommended to use UUIDs for cases where IDs must be unique and
+/// are possibly stored permanently. This can be done using
+/// QXmppUtils::generateStanzaUuid(). However, since that function is only
+/// available since QXmpp 1.3, you may also want to continue to use this
+/// function because of compatibility reasons.
+///
 /// \param length
-
+///
 QString QXmppUtils::generateStanzaHash(int length)
 {
+    if (length == 36)
+        return QXmppUtils::generateStanzaUuid();
+
     const QString somechars = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const int N = somechars.size();
     QString hashResult;

--- a/src/base/QXmppUtils.h
+++ b/src/base/QXmppUtils.h
@@ -60,7 +60,8 @@ public:
     static QByteArray generateHmacSha1(const QByteArray& key, const QByteArray& text);
     static int generateRandomInteger(int N);
     static QByteArray generateRandomBytes(int length);
-    static QString generateStanzaHash(int length = 32);
+    static QString generateStanzaUuid();
+    static QString generateStanzaHash(int length = 36);
 };
 
 void helperToXmlAddAttribute(QXmlStreamWriter* stream, const QString& name,

--- a/tests/qxmpputils/tst_qxmpputils.cpp
+++ b/tests/qxmpputils/tst_qxmpputils.cpp
@@ -37,6 +37,7 @@ private slots:
     void testJid();
     void testMime();
     void testTimezoneOffset();
+    void testStanzaHash();
 };
 
 void tst_QXmppUtils::testCrc32()
@@ -125,6 +126,22 @@ void tst_QXmppUtils::testTimezoneOffset()
     QCOMPARE(QXmppUtils::timezoneOffsetToString(0), QLatin1String("Z"));
     QCOMPARE(QXmppUtils::timezoneOffsetToString(5400), QLatin1String("+01:30"));
     QCOMPARE(QXmppUtils::timezoneOffsetToString(-5400), QLatin1String("-01:30"));
+}
+
+void tst_QXmppUtils::testStanzaHash()
+{
+    for (int i = 0; i < 100; i++) {
+        const QString hash = QXmppUtils::generateStanzaHash(i);
+        QCOMPARE(hash.size(), i);
+
+        if (i == 36) {
+            QCOMPARE(hash.count('-'), 4);
+        }
+    }
+
+    const QString hash = QXmppUtils::generateStanzaUuid();
+    QCOMPARE(hash.size(), 36);
+    QCOMPARE(hash.count('-'), 4);
 }
 
 QTEST_MAIN(tst_QXmppUtils)


### PR DESCRIPTION
The QXmppUtils::generateStanzaHash() generates UUIDs by default now.
UUIDs are not generated, if the default parameter is changed to a
different value (!= 36). The behaviour is not changed for other values
than 36.

This way all users of QXmpp will automatically start to use UUIDs, if
they use the generateStanzaHash() method.