### PR TITLE
Update MAM implementation to v0.6

### DIFF
--- a/doc/xep.doc
+++ b/doc/xep.doc
@@ -39,7 +39,7 @@ Complete:
 - XEP-0237: Roster Versioning (partially)
 - XEP-0280: Message Carbons
 - XEP-0308: Last Message Correction
-- XEP-0313: Message Archive Management
+- XEP-0313: Message Archive Management (v0.6)
 - XEP-0319: Last User Interaction in Presence
 - XEP-0334: Message Processing Hints (v0.3.0)
 - XEP-0352: Client State Indication

--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -130,7 +130,7 @@ const char* ns_forwarding = "urn:xmpp:forward:0";
 // XEP-0308: Last Message Correction
 const char* ns_message_correct = "urn:xmpp:message-correct:0";
 // XEP-0313: Message Archive Management
-const char* ns_mam = "urn:xmpp:mam:1";
+const char* ns_mam = "urn:xmpp:mam:2";
 // XEP-0319: Last User Interaction in Presence
 const char* ns_idle = "urn:xmpp:idle:1";
 // XEP-0333: Chat Markers

--- a/tests/qxmppmammanager/tst_qxmppmammanager.cpp
+++ b/tests/qxmppmammanager/tst_qxmppmammanager.cpp
@@ -82,7 +82,7 @@ void tst_QXmppMamManager::testHandleStanza_data()
 
     QTest::newRow("stanza1")
         << QByteArray("<message id='aeb213' to='juliet@capulet.lit/chamber'>"
-                      "<result xmlns='urn:xmpp:mam:1' queryid='f27' id='28482-98726-73623'>"
+                      "<result xmlns='urn:xmpp:mam:2' queryid='f27' id='28482-98726-73623'>"
                       "<forwarded xmlns='urn:xmpp:forward:0'>"
                       "<delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>"
                       "<message xmlns='jabber:client'"
@@ -124,7 +124,7 @@ void tst_QXmppMamManager::testHandleStanza_data()
 
     QTest::newRow("stanza3")
         << QByteArray(
-               "<message id='aeb214' xmlns='urn:xmpp:mam:1' to='juliet@capulet.lit/chamber'>"
+               "<message id='aeb214' xmlns='urn:xmpp:mam:2' to='juliet@capulet.lit/chamber'>"
                "<forwarded xmlns='urn:xmpp:forward:0'>"
                "<delay xmlns='urn:xmpp:delay' stamp='2010-07-10T23:08:25Z'/>"
                "<message xmlns='jabber:client'"
@@ -172,7 +172,7 @@ void tst_QXmppMamManager::testHandleResultIq_data()
 
     QTest::newRow("stanza1")
         << QByteArray("<iq type='result' id='juliet1'>"
-                      "<fin xmlns='urn:xmpp:mam:1'>"
+                      "<fin xmlns='urn:xmpp:mam:2'>"
                       "<set xmlns='http://jabber.org/protocol/rsm'>"
                       "<first index='0'>28482-98726-73623</first>"
                       "<last>09af3-cc343-b409f</last>"
@@ -188,7 +188,7 @@ void tst_QXmppMamManager::testHandleResultIq_data()
 
     QTest::newRow("stanza2")
         << QByteArray("<iq type='result' id='juliet1'>"
-                      "<fin xmlns='urn:xmpp:mam:1' complete='true'>"
+                      "<fin xmlns='urn:xmpp:mam:2' complete='true'>"
                       "<set xmlns='http://jabber.org/protocol/rsm'>"
                       "<first index='0'>28482-98726-73623</first>"
                       "<last>09af3-cc343-b409f</last>"


### PR DESCRIPTION
This updates the MAM implementation to version 0.6.0. The new namespace
is now used (mam:2). There is no compatibility layer with the old
namespace (mam:1) since both ejabberd and prosody have updated their MAM
implementation to support the mam:2 namespace a while ago.

Closes #254.