### PR TITLE
Make QXmpp work with projects using QT_NO_KEYWORDS

### DIFF
--- a/src/base/QXmppLogger.h
+++ b/src/base/QXmppLogger.h
@@ -100,14 +100,14 @@ public:
     QXmppLogger::MessageTypes messageTypes();
     void setMessageTypes(QXmppLogger::MessageTypes types);
 
-public slots:
+public Q_SLOTS:
     virtual void setGauge(const QString &gauge, double value);
     virtual void updateCounter(const QString &counter, qint64 amount);
 
     void log(QXmppLogger::MessageType type, const QString &text);
     void reopen();
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted whenever a log message is received.
     void message(QXmppLogger::MessageType type, const QString &text);
 
@@ -177,7 +177,7 @@ protected:
         emit logMessage(QXmppLogger::SentMessage, qxmpp_loggable_trace(message));
     }
 
-signals:
+Q_SIGNALS:
     /// Sets the given \a gauge to \a value.
     void setGauge(const QString &gauge, double value);
 

--- a/src/base/QXmppRtpChannel.h
+++ b/src/base/QXmppRtpChannel.h
@@ -109,14 +109,14 @@ public:
     qint64 pos() const override;
     bool seek(qint64 pos) override;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a datagram needs to be sent.
     void sendDatagram(const QByteArray &ba);
 
     /// \brief This signal is emitted to send logging messages.
     void logMessage(QXmppLogger::MessageType type, const QString &msg);
 
-public slots:
+public Q_SLOTS:
     void datagramReceived(const QByteArray &ba);
     void startTone(QXmppRtpAudioChannel::Tone tone);
     void stopTone(QXmppRtpAudioChannel::Tone tone);
@@ -148,7 +148,7 @@ protected:
     qint64 writeData(const char *data, qint64 maxSize) override;
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void emitSignals();
     void writeDatagram();
 
@@ -284,11 +284,11 @@ public:
     void setEncoderFormat(const QXmppVideoFormat &format);
     void writeFrame(const QXmppVideoFrame &frame);
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a datagram needs to be sent.
     void sendDatagram(const QByteArray &ba);
 
-public slots:
+public Q_SLOTS:
     void datagramReceived(const QByteArray &ba);
 
 protected:

--- a/src/base/QXmppSocks.h
+++ b/src/base/QXmppSocks.h
@@ -39,10 +39,10 @@ public:
     QXmppSocksClient(const QString &proxyHost, quint16 proxyPort, QObject *parent = nullptr);
     void connectToHost(const QString &hostName, quint16 hostPort);
 
-signals:
+Q_SIGNALS:
     void ready();
 
-private slots:
+private Q_SLOTS:
     void slotConnected();
     void slotReadyRead();
 
@@ -65,10 +65,10 @@ public:
 
     quint16 serverPort() const;
 
-signals:
+Q_SIGNALS:
     void newConnection(QTcpSocket *socket, QString hostName, quint16 port);
 
-private slots:
+private Q_SLOTS:
     void slotNewConnection();
     void slotReadyRead();
 

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -49,7 +49,7 @@ public:
     virtual bool isConnected() const;
     bool sendPacket(const QXmppStanza &);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the stream is connected.
     void connected();
 
@@ -98,11 +98,11 @@ private:
     /// Sends an acknowledgement request as defined in \xep{0198}.
     void sendAcknowledgementRequest();
 
-public slots:
+public Q_SLOTS:
     virtual void disconnectFromHost();
     virtual bool sendData(const QByteArray &);
 
-private slots:
+private Q_SLOTS:
     void _q_socketConnected();
     void _q_socketEncrypted();
     void _q_socketError(QAbstractSocket::SocketError error);

--- a/src/base/QXmppStun.h
+++ b/src/base/QXmppStun.h
@@ -176,12 +176,12 @@ public:
     static QList<QHostAddress> discoverAddresses();
     static QList<QUdpSocket *> reservePorts(const QList<QHostAddress> &addresses, int count, QObject *parent = nullptr);
 
-public slots:
+public Q_SLOTS:
     void close();
     void connectToHost();
     qint64 sendDatagram(const QByteArray &datagram);
 
-private slots:
+private Q_SLOTS:
     void checkCandidates();
     void handleDatagram(const QByteArray &datagram, const QHostAddress &host, quint16 port);
     void turnConnected();
@@ -189,7 +189,7 @@ private slots:
     void updateGatheringState();
     void writeStun(const QXmppStunMessage &request);
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted once ICE negotiation succeeds.
     void connected();
 
@@ -280,7 +280,7 @@ public:
     /// candidates.
     GatheringState gatheringState() const;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted once ICE negotiation succeeds.
     void connected();
 
@@ -293,11 +293,11 @@ signals:
     /// \brief This signal is emitted when the list of local candidates changes.
     void localCandidatesChanged();
 
-public slots:
+public Q_SLOTS:
     void close();
     void connectToHost();
 
-private slots:
+private Q_SLOTS:
     void slotConnected();
     void slotGatheringStateChanged();
     void slotTimeout();

--- a/src/base/QXmppStun_p.h
+++ b/src/base/QXmppStun_p.h
@@ -55,14 +55,14 @@ public:
     QXmppStunMessage request() const;
     QXmppStunMessage response() const;
 
-signals:
+Q_SIGNALS:
     void finished();
     void writeStun(const QXmppStunMessage &request);
 
-public slots:
+public Q_SLOTS:
     void readStun(const QXmppStunMessage &response);
 
-private slots:
+private Q_SLOTS:
     void retry();
 
 private:
@@ -83,10 +83,10 @@ public:
     virtual QXmppJingleCandidate localCandidate(int component) const = 0;
     virtual qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port) = 0;
 
-public slots:
+public Q_SLOTS:
     virtual void disconnectFromHost() = 0;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a data packet is received.
     void datagramReceived(const QByteArray &data, const QHostAddress &host, quint16 port);
 };
@@ -123,18 +123,18 @@ public:
     QXmppJingleCandidate localCandidate(int component) const override;
     qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port) override;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted once TURN allocation succeeds.
     void connected();
 
     /// \brief This signal is emitted when TURN allocation fails.
     void disconnected();
 
-public slots:
+public Q_SLOTS:
     void connectToHost();
     void disconnectFromHost() override;
 
-private slots:
+private Q_SLOTS:
     void readyRead();
     void refresh();
     void refreshChannels();
@@ -185,10 +185,10 @@ public:
     QXmppJingleCandidate localCandidate(int component) const override;
     qint64 writeDatagram(const QByteArray &data, const QHostAddress &host, quint16 port) override;
 
-public slots:
+public Q_SLOTS:
     void disconnectFromHost() override;
 
-private slots:
+private Q_SLOTS:
     void readyRead();
 
 private:

--- a/src/client/QXmppArchiveManager.h
+++ b/src/client/QXmppArchiveManager.h
@@ -67,7 +67,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when archive list is received
     /// after calling listCollections()
     void archiveListReceived(const QList<QXmppArchiveChat> &, const QXmppResultSetReply &rsm = QXmppResultSetReply());

--- a/src/client/QXmppBookmarkManager.h
+++ b/src/client/QXmppBookmarkManager.h
@@ -51,7 +51,7 @@ public:
     bool handleStanza(const QDomElement &stanza) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when bookmarks are received.
     void bookmarksReceived(const QXmppBookmarkSet &bookmarks);
 
@@ -60,7 +60,7 @@ protected:
     void setClient(QXmppClient *client) override;
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void slotConnected();
     void slotDisconnected();
 

--- a/src/client/QXmppCallManager.h
+++ b/src/client/QXmppCallManager.h
@@ -102,7 +102,7 @@ public:
     /// Returns the video mode.
     QIODevice::OpenMode videoMode() const;
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a call is connected.
     ///
     /// Once this signal is emitted, you can connect a QAudioOutput and
@@ -128,13 +128,13 @@ signals:
     /// \brief This signal is emitted when the video channel changes.
     void videoModeChanged(QIODevice::OpenMode mode);
 
-public slots:
+public Q_SLOTS:
     void accept();
     void hangup();
     void startVideo();
     void stopVideo();
 
-private slots:
+private Q_SLOTS:
     void localCandidatesChanged();
     void terminated();
     void updateOpenMode();
@@ -186,7 +186,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a new incoming call is received.
     ///
     /// To accept the call, invoke the call's QXmppCall::accept() method.
@@ -196,7 +196,7 @@ signals:
     /// This signal is emitted when a call (incoming or outgoing) is started.
     void callStarted(QXmppCall *call);
 
-public slots:
+public Q_SLOTS:
     QXmppCall *call(const QString &jid);
 
 protected:
@@ -204,7 +204,7 @@ protected:
     void setClient(QXmppClient *client) override;
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void _q_callDestroyed(QObject *object);
     void _q_disconnected();
     void _q_iqReceived(const QXmppIq &iq);

--- a/src/client/QXmppCarbonManager.h
+++ b/src/client/QXmppCarbonManager.h
@@ -52,7 +52,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \brief Emitted when a message was received from someone else
     /// and directed to another resource.
     /// If you connect this signal to the \s QXmppClient::messageReceived

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -212,7 +212,7 @@ public:
     QXmppVersionManager &versionManager();
 #endif
 
-signals:
+Q_SIGNALS:
 
     /// This signal is emitted when the client connects successfully to the
     /// XMPP server i.e. when a successful XMPP connection is established.
@@ -274,7 +274,7 @@ signals:
     /// This signal is emitted when the client state changes.
     void stateChanged(QXmppClient::State state);
 
-public slots:
+public Q_SLOTS:
     void connectToServer(const QXmppConfiguration &,
                          const QXmppPresence &initialPresence =
                              QXmppPresence());
@@ -284,7 +284,7 @@ public slots:
     bool sendPacket(const QXmppStanza &);
     void sendMessage(const QString &bareJid, const QString &message);
 
-private slots:
+private Q_SLOTS:
     void _q_elementReceived(const QDomElement &element, bool &handled);
     void _q_reconnect();
     void _q_socketStateChanged(QAbstractSocket::SocketState state);

--- a/src/client/QXmppDiscoveryManager.h
+++ b/src/client/QXmppDiscoveryManager.h
@@ -69,7 +69,7 @@ public:
     bool handleStanza(const QDomElement& element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an information response is received.
     void infoReceived(const QXmppDiscoveryIq&);
 

--- a/src/client/QXmppEntityTimeManager.h
+++ b/src/client/QXmppEntityTimeManager.h
@@ -45,7 +45,7 @@ public:
     bool handleStanza(const QDomElement& element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a time response is received.
     void timeReceived(const QXmppEntityTimeIq&);
 };

--- a/src/client/QXmppInvokable.h
+++ b/src/client/QXmppInvokable.h
@@ -63,7 +63,7 @@ public:
           */
     virtual bool isAuthorized(const QString &jid) const = 0;
 
-public slots:
+public Q_SLOTS:
     /**
           * This provides a list of interfaces for introspection of the presented interface.
           */

--- a/src/client/QXmppMamManager.h
+++ b/src/client/QXmppMamManager.h
@@ -61,7 +61,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an archived message is received
     void archivedMessageReceived(const QString &queryId,
                                  const QXmppMessage &message);

--- a/src/client/QXmppMessageReceiptManager.h
+++ b/src/client/QXmppMessageReceiptManager.h
@@ -44,7 +44,7 @@ public:
     bool handleStanza(const QDomElement &stanza) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when receipt for the message with the
     /// given id is received. The id could be previously obtained by
     /// calling QXmppMessage::id().

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -76,7 +76,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an invitation to a chat room is received.
     void invitationReceived(const QString &roomJid, const QString &inviter, const QString &reason);
 
@@ -88,7 +88,7 @@ protected:
     void setClient(QXmppClient *client) override;
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void _q_messageReceived(const QXmppMessage &message);
     void _q_roomDestroyed(QObject *object);
 
@@ -182,7 +182,7 @@ public:
     QString subject() const;
     void setSubject(const QString &subject);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the allowed actions change.
     void allowedActionsChanged(QXmppMucRoom::Actions actions) const;
 
@@ -233,7 +233,7 @@ signals:
     /// This signal is emitted when the room's subject changes.
     void subjectChanged(const QString &subject);
 
-public slots:
+public Q_SLOTS:
     bool ban(const QString &jid, const QString &reason);
     bool join();
     bool kick(const QString &jid, const QString &reason);
@@ -245,7 +245,7 @@ public slots:
     bool sendInvitation(const QString &jid, const QString &reason);
     bool sendMessage(const QString &text);
 
-private slots:
+private Q_SLOTS:
     void _q_disconnected();
     void _q_discoveryInfoReceived(const QXmppDiscoveryIq &iq);
     void _q_messageReceived(const QXmppMessage &message);

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -61,7 +61,7 @@ public:
 
     QXmppConfiguration &configuration();
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an error is encountered.
     void error(QXmppClient::Error);
 
@@ -88,10 +88,10 @@ protected:
     void handleStream(const QDomElement &element) override;
     /// \endcond
 
-public slots:
+public Q_SLOTS:
     void disconnectFromHost() override;
 
-private slots:
+private Q_SLOTS:
     void _q_dnsLookupFinished();
     void _q_socketDisconnected();
     void socketError(QAbstractSocket::SocketError);

--- a/src/client/QXmppRegistrationManager.h
+++ b/src/client/QXmppRegistrationManager.h
@@ -160,7 +160,7 @@ class QXmppRegistrationManagerPrivate;
 /// in an error (reported by registrationFailed()) or, if everything went well,
 /// the registration form is reported by registrationFormReceived().
 ///
-/// To handle everything correctly, you need to connect to both signals:
+/// To handle everything correctly, you need to connect to both Q_SIGNALS:
 ///
 /// \code
 /// connect(registrationManager, &QXmppRegistrationManager::registrationFormReceived, [=](const QXmppRegisterIq &iq) {
@@ -282,7 +282,7 @@ public:
     bool handleStanza(const QDomElement &stanza) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     ///
     /// Emitted, when registrationSupported() changed.
     ///
@@ -361,7 +361,7 @@ signals:
 protected:
     void setClient(QXmppClient *client) override;
 
-private slots:
+private Q_SLOTS:
     void handleDiscoInfo(const QXmppDiscoveryIq &iq);
 
 private:

--- a/src/client/QXmppRemoteMethod.h
+++ b/src/client/QXmppRemoteMethod.h
@@ -46,11 +46,11 @@ public:
     QXmppRemoteMethod(const QString &jid, const QString &method, const QVariantList &args, QXmppClient *client);
     QXmppRemoteMethodResult call();
 
-private slots:
+private Q_SLOTS:
     void gotError(const QXmppRpcErrorIq &iq);
     void gotResult(const QXmppRpcResponseIq &iq);
 
-signals:
+Q_SIGNALS:
     void callDone();
 
 private:

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -86,7 +86,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-public slots:
+public Q_SLOTS:
     bool acceptSubscription(const QString &bareJid, const QString &reason = QString());
     bool refuseSubscription(const QString &bareJid, const QString &reason = QString());
     bool addItem(const QString &bareJid, const QString &name = QString(), const QSet<QString> &groups = QSet<QString>());
@@ -95,7 +95,7 @@ public slots:
     bool subscribe(const QString &bareJid, const QString &reason = QString());
     bool unsubscribe(const QString &bareJid, const QString &reason = QString());
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the Roster IQ is received after a successful
     /// connection. That is the roster entries are empty before this signal is emitted.
     /// One should use getRosterBareJids() and getRosterEntry() only after
@@ -126,7 +126,7 @@ signals:
     /// removed as a result of roster push.
     void itemRemoved(const QString &bareJid);
 
-private slots:
+private Q_SLOTS:
     void _q_connected();
     void _q_disconnected();
     void _q_presenceReceived(const QXmppPresence &);

--- a/src/client/QXmppRpcManager.h
+++ b/src/client/QXmppRpcManager.h
@@ -78,7 +78,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \cond
     void rpcCallResponse(const QXmppRpcResponseIq &result);
     void rpcCallError(const QXmppRpcErrorIq &err);

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -170,7 +170,7 @@ public:
     qint64 fileSize() const;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an error is encountered while
     /// processing the transfer job.
     void error(QXmppTransferJob::Error error);
@@ -193,12 +193,12 @@ signals:
     /// This signal is emitted when the transfer job changes state.
     void stateChanged(QXmppTransferJob::State state);
 
-public slots:
+public Q_SLOTS:
     void abort();
     void accept(const QString &filePath);
     void accept(QIODevice *output);
 
-private slots:
+private Q_SLOTS:
     void _q_terminated();
 
 private:
@@ -269,7 +269,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a new file transfer offer is received.
     ///
     /// To accept the transfer job, call the job's QXmppTransferJob::accept() method.
@@ -284,7 +284,7 @@ signals:
     /// \sa QXmppTransferJob::finished()
     void jobFinished(QXmppTransferJob *job);
 
-public slots:
+public Q_SLOTS:
     QXmppTransferJob *sendFile(const QString &jid, const QString &filePath, const QString &description = QString());
     QXmppTransferJob *sendFile(const QString &jid, QIODevice *device, const QXmppTransferFileInfo &fileInfo, const QString &sid = QString());
 
@@ -293,7 +293,7 @@ protected:
     void setClient(QXmppClient *client) override;
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void _q_iqReceived(const QXmppIq &);
     void _q_jobDestroyed(QObject *object);
     void _q_jobError(QXmppTransferJob::Error error);

--- a/src/client/QXmppTransferManager_p.h
+++ b/src/client/QXmppTransferManager_p.h
@@ -51,7 +51,7 @@ public:
     void connectToHosts(const QXmppByteStreamIq &iq);
     bool writeData(const QByteArray &data);
 
-private slots:
+private Q_SLOTS:
     void _q_candidateDisconnected();
     void _q_candidateReady();
     void _q_disconnected();
@@ -77,10 +77,10 @@ public:
     void connectToProxy();
     void startSending();
 
-public slots:
+public Q_SLOTS:
     void _q_disconnected();
 
-private slots:
+private Q_SLOTS:
     void _q_proxyReady();
     void _q_sendData();
 };

--- a/src/client/QXmppUploadRequestManager.h
+++ b/src/client/QXmppUploadRequestManager.h
@@ -118,7 +118,7 @@ public:
 
     bool handleStanza(const QDomElement &stanza) override;
 
-signals:
+Q_SIGNALS:
     /// Emitted when an upload slot was received.
     void slotReceived(const QXmppHttpUploadSlotIq &slot);
 

--- a/src/client/QXmppVCardManager.h
+++ b/src/client/QXmppVCardManager.h
@@ -74,7 +74,7 @@ public:
     bool handleStanza(const QDomElement& element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the requested vCard is received
     /// after calling the requestVCard() function.
     void vCardReceived(const QXmppVCardIq&);

--- a/src/client/QXmppVersionManager.h
+++ b/src/client/QXmppVersionManager.h
@@ -62,7 +62,7 @@ public:
     bool handleStanza(const QDomElement &element) override;
     /// \endcond
 
-signals:
+Q_SIGNALS:
     /// \brief This signal is emitted when a version response is received.
     void versionReceived(const QXmppVersionIq &);
 

--- a/src/server/QXmppIncomingClient.h
+++ b/src/server/QXmppIncomingClient.h
@@ -50,7 +50,7 @@ public:
     void setInactivityTimeout(int secs);
     void setPasswordChecker(QXmppPasswordChecker *checker);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when an element is received.
     void elementReceived(const QDomElement &element);
 
@@ -60,7 +60,7 @@ protected:
     void handleStanza(const QDomElement &element) override;
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void onDigestReply();
     void onPasswordReply();
     void onSocketDisconnected();

--- a/src/server/QXmppIncomingServer.h
+++ b/src/server/QXmppIncomingServer.h
@@ -45,7 +45,7 @@ public:
     bool isConnected() const override;
     QString localStreamId() const;
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a dialback verify request is received.
     void dialbackRequestReceived(const QXmppDialback &result);
 
@@ -58,7 +58,7 @@ protected:
     void handleStream(const QDomElement &streamElement) override;
     /// \endcond
 
-private slots:
+private Q_SLOTS:
     void slotDialbackResponseReceived(const QXmppDialback &dialback);
     void slotSocketDisconnected();
 

--- a/src/server/QXmppOutgoingServer.h
+++ b/src/server/QXmppOutgoingServer.h
@@ -53,7 +53,7 @@ public:
 
     QString remoteDomain() const;
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a dialback verify response is received.
     void dialbackResponseReceived(const QXmppDialback &response);
 
@@ -64,11 +64,11 @@ protected:
     void handleStanza(const QDomElement &stanzaElement) override;
     /// \endcond
 
-public slots:
+public Q_SLOTS:
     void connectToHost(const QString &domain);
     void queueData(const QByteArray &data);
 
-private slots:
+private Q_SLOTS:
     void _q_dnsLookupFinished();
     void _q_socketDisconnected();
     void sendDialback();

--- a/src/server/QXmppPasswordChecker.h
+++ b/src/server/QXmppPasswordChecker.h
@@ -80,11 +80,11 @@ public:
 
     bool isFinished() const;
 
-public slots:
+public Q_SLOTS:
     void finish();
     void finishLater();
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when the reply has finished.
     void finished();
 

--- a/src/server/QXmppServer.h
+++ b/src/server/QXmppServer.h
@@ -97,7 +97,7 @@ public:
 
     void addIncomingClient(QXmppIncomingClient *stream);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a client has connected.
     void clientConnected(const QString &jid);
 
@@ -107,10 +107,10 @@ signals:
     /// This signal is emitted when the logger changes.
     void loggerChanged(QXmppLogger *logger);
 
-public slots:
+public Q_SLOTS:
     void handleElement(const QDomElement &element);
 
-private slots:
+private Q_SLOTS:
     void _q_clientConnection(QSslSocket *socket);
     void _q_clientConnected();
     void _q_clientDisconnected();
@@ -141,7 +141,7 @@ public:
     void setLocalCertificate(const QSslCertificate &certificate);
     void setPrivateKey(const QSslKey &key);
 
-signals:
+Q_SIGNALS:
     /// This signal is emitted when a new connection is established.
     void newConnection(QSslSocket *socket);
 


### PR DESCRIPTION
This replaces all occurencies of 'slots' and 'signals' with 'Q_SLOTS'
and 'Q_SIGNALS'. This allows for smooth integration with software
projects that need QT_NO_KEYWORDS, such as those ones that rely on
boost libraries.

Closes #115.

Co-authored-by: Tommaso Cucinotta <tommaso.cucinotta@santannapisa.it>


Replaces #115.