### PR TITLE
Do not include 'ask' attribute when renaming roster item

### DIFF
--- a/src/client/QXmppRosterManager.cpp
+++ b/src/client/QXmppRosterManager.cpp
@@ -282,6 +282,10 @@ bool QXmppRosterManager::renameItem(const QString &bareJid, const QString &name)
     QXmppRosterIq::Item item = d->entries.value(bareJid);
     item.setName(name);
 
+    // If there is a pending subscription, do not include the corresponding attribute in the stanza.
+    if (!item.subscriptionStatus().isEmpty())
+        item.setSubscriptionStatus({});
+
     QXmppRosterIq iq;
     iq.setType(QXmppIq::Set);
     iq.addItem(item);


### PR DESCRIPTION
The *ask* attribute must not be included. See https://tools.ietf.org/html/rfc6121#section-2.1.2.2.