### PR TITLE
base: Convert to QStringLiteral

### DIFF
--- a/src/base/QXmppArchiveIq.cpp
+++ b/src/base/QXmppArchiveIq.cpp
@@ -88,22 +88,22 @@ QXmppArchiveChat::QXmppArchiveChat()
 /// \cond
 void QXmppArchiveChat::parse(const QDomElement &element)
 {
-    m_with = element.attribute("with");
-    m_start = QXmppUtils::datetimeFromString(element.attribute("start"));
-    m_subject = element.attribute("subject");
-    m_thread = element.attribute("thread");
-    m_version = element.attribute("version").toInt();
+    m_with = element.attribute(QSL("with"));
+    m_start = QXmppUtils::datetimeFromString(element.attribute(QSL("start")));
+    m_subject = element.attribute(QSL("subject"));
+    m_thread = element.attribute(QSL("thread"));
+    m_version = element.attribute(QSL("version")).toInt();
 
     QDateTime timeAccu = m_start;
 
     QDomElement child = element.firstChildElement();
     while (!child.isNull()) {
-        if ((child.tagName() == "from") || (child.tagName() == "to")) {
+        if ((child.tagName() == QSL("from")) || (child.tagName() == QSL("to"))) {
             QXmppArchiveMessage message;
-            message.setBody(child.firstChildElement("body").text());
-            timeAccu = timeAccu.addSecs(child.attribute("secs").toInt());
+            message.setBody(child.firstChildElement(QSL("body")).text());
+            timeAccu = timeAccu.addSecs(child.attribute(QSL("secs")).toInt());
             message.setDate(timeAccu);
-            message.setReceived(child.tagName() == "from");
+            message.setReceived(child.tagName() == QSL("from"));
             m_messages << message;
         }
         child = child.nextSiblingElement();
@@ -112,22 +112,22 @@ void QXmppArchiveChat::parse(const QDomElement &element)
 
 void QXmppArchiveChat::toXml(QXmlStreamWriter *writer, const QXmppResultSetReply &rsm) const
 {
-    writer->writeStartElement("chat");
+    writer->writeStartElement(QSL("chat"));
     writer->writeDefaultNamespace(ns_archive);
-    helperToXmlAddAttribute(writer, "with", m_with);
+    helperToXmlAddAttribute(writer, QSL("with"), m_with);
     if (m_start.isValid())
-        helperToXmlAddAttribute(writer, "start", QXmppUtils::datetimeToString(m_start));
-    helperToXmlAddAttribute(writer, "subject", m_subject);
-    helperToXmlAddAttribute(writer, "thread", m_thread);
+        helperToXmlAddAttribute(writer, QSL("start"), QXmppUtils::datetimeToString(m_start));
+    helperToXmlAddAttribute(writer, QSL("subject"), m_subject);
+    helperToXmlAddAttribute(writer, QSL("thread"), m_thread);
     if (m_version)
-        helperToXmlAddAttribute(writer, "version", QString::number(m_version));
+        helperToXmlAddAttribute(writer, QSL("version"), QString::number(m_version));
 
     QDateTime prevTime = m_start;
 
     for (const QXmppArchiveMessage &message : m_messages) {
-        writer->writeStartElement(message.isReceived() ? "from" : "to");
-        helperToXmlAddAttribute(writer, "secs", QString::number(prevTime.secsTo(message.date())));
-        writer->writeTextElement("body", message.body());
+        writer->writeStartElement(message.isReceived() ? QSL("from") : QSL("to"));
+        helperToXmlAddAttribute(writer, QSL("secs"), QString::number(prevTime.secsTo(message.date())));
+        writer->writeTextElement(QSL("body"), message.body());
         writer->writeEndElement();
         prevTime = message.date();
     }
@@ -256,14 +256,14 @@ void QXmppArchiveChatIq::setResultSetReply(const QXmppResultSetReply &rsm)
 /// \cond
 bool QXmppArchiveChatIq::isArchiveChatIq(const QDomElement &element)
 {
-    QDomElement chatElement = element.firstChildElement("chat");
-    return !chatElement.attribute("with").isEmpty();
+    QDomElement chatElement = element.firstChildElement(QSL("chat"));
+    return !chatElement.attribute(QSL("with")).isEmpty();
     //return (chatElement.namespaceURI() == ns_archive);
 }
 
 void QXmppArchiveChatIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement chatElement = element.firstChildElement("chat");
+    QDomElement chatElement = element.firstChildElement(QSL("chat"));
     m_chat.parse(chatElement);
     m_rsmReply.parse(chatElement);
 }
@@ -385,23 +385,23 @@ void QXmppArchiveListIq::setResultSetReply(const QXmppResultSetReply &rsm)
 /// \cond
 bool QXmppArchiveListIq::isArchiveListIq(const QDomElement &element)
 {
-    QDomElement listElement = element.firstChildElement("list");
+    QDomElement listElement = element.firstChildElement(QSL("list"));
     return (listElement.namespaceURI() == ns_archive);
 }
 
 void QXmppArchiveListIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement listElement = element.firstChildElement("list");
-    m_with = listElement.attribute("with");
-    m_start = QXmppUtils::datetimeFromString(listElement.attribute("start"));
-    m_end = QXmppUtils::datetimeFromString(listElement.attribute("end"));
+    QDomElement listElement = element.firstChildElement(QSL("list"));
+    m_with = listElement.attribute(QSL("with"));
+    m_start = QXmppUtils::datetimeFromString(listElement.attribute(QSL("start")));
+    m_end = QXmppUtils::datetimeFromString(listElement.attribute(QSL("end")));
 
     m_rsmQuery.parse(listElement);
     m_rsmReply.parse(listElement);
 
     QDomElement child = listElement.firstChildElement();
     while (!child.isNull()) {
-        if (child.tagName() == "chat") {
+        if (child.tagName() == QSL("chat")) {
             QXmppArchiveChat chat;
             chat.parse(child);
             m_chats << chat;
@@ -412,14 +412,14 @@ void QXmppArchiveListIq::parseElementFromChild(const QDomElement &element)
 
 void QXmppArchiveListIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("list");
+    writer->writeStartElement(QSL("list"));
     writer->writeDefaultNamespace(ns_archive);
     if (!m_with.isEmpty())
-        helperToXmlAddAttribute(writer, "with", m_with);
+        helperToXmlAddAttribute(writer, QSL("with"), m_with);
     if (m_start.isValid())
-        helperToXmlAddAttribute(writer, "start", QXmppUtils::datetimeToString(m_start));
+        helperToXmlAddAttribute(writer, QSL("start"), QXmppUtils::datetimeToString(m_start));
     if (m_end.isValid())
-        helperToXmlAddAttribute(writer, "end", QXmppUtils::datetimeToString(m_end));
+        helperToXmlAddAttribute(writer, QSL("end"), QXmppUtils::datetimeToString(m_end));
     if (!m_rsmQuery.isNull())
         m_rsmQuery.toXml(writer);
     else if (!m_rsmReply.isNull())
@@ -431,19 +431,19 @@ void QXmppArchiveListIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 
 bool QXmppArchivePrefIq::isArchivePrefIq(const QDomElement &element)
 {
-    QDomElement prefElement = element.firstChildElement("pref");
+    QDomElement prefElement = element.firstChildElement(QSL("pref"));
     return (prefElement.namespaceURI() == ns_archive);
 }
 
 void QXmppArchivePrefIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("pref");
+    QDomElement queryElement = element.firstChildElement(QSL("pref"));
     Q_UNUSED(queryElement);
 }
 
 void QXmppArchivePrefIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("pref");
+    writer->writeStartElement(QSL("pref"));
     writer->writeDefaultNamespace(ns_archive);
     writer->writeEndElement();
 }
@@ -503,28 +503,28 @@ void QXmppArchiveRemoveIq::setEnd(const QDateTime &end)
 /// \cond
 bool QXmppArchiveRemoveIq::isArchiveRemoveIq(const QDomElement &element)
 {
-    QDomElement retrieveElement = element.firstChildElement("remove");
+    QDomElement retrieveElement = element.firstChildElement(QSL("remove"));
     return (retrieveElement.namespaceURI() == ns_archive);
 }
 
 void QXmppArchiveRemoveIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement listElement = element.firstChildElement("remove");
-    m_with = listElement.attribute("with");
-    m_start = QXmppUtils::datetimeFromString(listElement.attribute("start"));
-    m_end = QXmppUtils::datetimeFromString(listElement.attribute("end"));
+    QDomElement listElement = element.firstChildElement(QSL("remove"));
+    m_with = listElement.attribute(QSL("with"));
+    m_start = QXmppUtils::datetimeFromString(listElement.attribute(QSL("start")));
+    m_end = QXmppUtils::datetimeFromString(listElement.attribute(QSL("end")));
 }
 
 void QXmppArchiveRemoveIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("remove");
+    writer->writeStartElement(QSL("remove"));
     writer->writeDefaultNamespace(ns_archive);
     if (!m_with.isEmpty())
-        helperToXmlAddAttribute(writer, "with", m_with);
+        helperToXmlAddAttribute(writer, QSL("with"), m_with);
     if (m_start.isValid())
-        helperToXmlAddAttribute(writer, "start", QXmppUtils::datetimeToString(m_start));
+        helperToXmlAddAttribute(writer, QSL("start"), QXmppUtils::datetimeToString(m_start));
     if (m_end.isValid())
-        helperToXmlAddAttribute(writer, "end", QXmppUtils::datetimeToString(m_end));
+        helperToXmlAddAttribute(writer, QSL("end"), QXmppUtils::datetimeToString(m_end));
     writer->writeEndElement();
 }
 /// \endcond
@@ -589,25 +589,25 @@ void QXmppArchiveRetrieveIq::setResultSetQuery(const QXmppResultSetQuery &rsm)
 /// \cond
 bool QXmppArchiveRetrieveIq::isArchiveRetrieveIq(const QDomElement &element)
 {
-    QDomElement retrieveElement = element.firstChildElement("retrieve");
+    QDomElement retrieveElement = element.firstChildElement(QSL("retrieve"));
     return (retrieveElement.namespaceURI() == ns_archive);
 }
 
 void QXmppArchiveRetrieveIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement retrieveElement = element.firstChildElement("retrieve");
-    m_with = retrieveElement.attribute("with");
-    m_start = QXmppUtils::datetimeFromString(retrieveElement.attribute("start"));
+    QDomElement retrieveElement = element.firstChildElement(QSL("retrieve"));
+    m_with = retrieveElement.attribute(QSL("with"));
+    m_start = QXmppUtils::datetimeFromString(retrieveElement.attribute(QSL("start")));
 
     m_rsmQuery.parse(retrieveElement);
 }
 
 void QXmppArchiveRetrieveIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("retrieve");
+    writer->writeStartElement(QSL("retrieve"));
     writer->writeDefaultNamespace(ns_archive);
-    helperToXmlAddAttribute(writer, "with", m_with);
-    helperToXmlAddAttribute(writer, "start", QXmppUtils::datetimeToString(m_start));
+    helperToXmlAddAttribute(writer, QSL("with"), m_with);
+    helperToXmlAddAttribute(writer, QSL("start"), QXmppUtils::datetimeToString(m_start));
     if (!m_rsmQuery.isNull())
         m_rsmQuery.toXml(writer);
     writer->writeEndElement();

--- a/src/base/QXmppBindIq.cpp
+++ b/src/base/QXmppBindIq.cpp
@@ -68,25 +68,25 @@ void QXmppBindIq::setResource(const QString &resource)
 /// \cond
 bool QXmppBindIq::isBindIq(const QDomElement &element)
 {
-    QDomElement bindElement = element.firstChildElement("bind");
+    QDomElement bindElement = element.firstChildElement(QSL("bind"));
     return (bindElement.namespaceURI() == ns_bind);
 }
 
 void QXmppBindIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement bindElement = element.firstChildElement("bind");
-    m_jid = bindElement.firstChildElement("jid").text();
-    m_resource = bindElement.firstChildElement("resource").text();
+    QDomElement bindElement = element.firstChildElement(QSL("bind"));
+    m_jid = bindElement.firstChildElement(QSL("jid")).text();
+    m_resource = bindElement.firstChildElement(QSL("resource")).text();
 }
 
 void QXmppBindIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("bind");
+    writer->writeStartElement(QSL("bind"));
     writer->writeDefaultNamespace(ns_bind);
     if (!m_jid.isEmpty())
-        helperToXmlAddTextElement(writer, "jid", m_jid);
+        helperToXmlAddTextElement(writer, QSL("jid"), m_jid);
     if (!m_resource.isEmpty())
-        helperToXmlAddTextElement(writer, "resource", m_resource);
+        helperToXmlAddTextElement(writer, QSL("resource"), m_resource);
     writer->writeEndElement();
 }
 /// \endcond

--- a/src/base/QXmppBitsOfBinaryContentId.cpp
+++ b/src/base/QXmppBitsOfBinaryContentId.cpp
@@ -27,25 +27,25 @@
 #include <QSharedData>
 #include <QString>
 
-#define CONTENTID_URL QStringLiteral("cid:")
+#define CONTENTID_URL QSL("cid:")
 #define CONTENTID_URL_LENGTH 4
-#define CONTENTID_POSTFIX QStringLiteral("@bob.xmpp.org")
+#define CONTENTID_POSTFIX QSL("@bob.xmpp.org")
 #define CONTENTID_POSTFIX_LENGTH 13
-#define CONTENTID_HASH_SEPARATOR QStringLiteral("+")
+#define CONTENTID_HASH_SEPARATOR QSL("+")
 
 static const QMap<QCryptographicHash::Algorithm, QString> HASH_ALGORITHMS = {
-    { QCryptographicHash::Sha1, QStringLiteral("sha1") },
+    { QCryptographicHash::Sha1, QSL("sha1") },
 #ifndef QT_CRYPTOGRAPHICHASH_ONLY_SHA1
-    { QCryptographicHash::Md4, QStringLiteral("md4") },
-    { QCryptographicHash::Md5, QStringLiteral("md5") },
-    { QCryptographicHash::Sha224, QStringLiteral("sha224") },
-    { QCryptographicHash::Sha256, QStringLiteral("sha256") },
-    { QCryptographicHash::Sha384, QStringLiteral("sha384") },
-    { QCryptographicHash::Sha512, QStringLiteral("sha512") },
-    { QCryptographicHash::Sha3_224, QStringLiteral("sha3-224") },
-    { QCryptographicHash::Sha3_256, QStringLiteral("sha3-256") },
-    { QCryptographicHash::Sha3_384, QStringLiteral("sha3-384") },
-    { QCryptographicHash::Sha3_512, QStringLiteral("sha3-512") },
+    { QCryptographicHash::Md4, QSL("md4") },
+    { QCryptographicHash::Md5, QSL("md5") },
+    { QCryptographicHash::Sha224, QSL("sha224") },
+    { QCryptographicHash::Sha256, QSL("sha256") },
+    { QCryptographicHash::Sha384, QSL("sha384") },
+    { QCryptographicHash::Sha512, QSL("sha512") },
+    { QCryptographicHash::Sha3_224, QSL("sha3-224") },
+    { QCryptographicHash::Sha3_256, QSL("sha3-256") },
+    { QCryptographicHash::Sha3_384, QSL("sha3-384") },
+    { QCryptographicHash::Sha3_512, QSL("sha3-512") },
 #endif
 };
 

--- a/src/base/QXmppBitsOfBinaryData.cpp
+++ b/src/base/QXmppBitsOfBinaryData.cpp
@@ -133,26 +133,26 @@ void QXmppBitsOfBinaryData::setData(const QByteArray &data)
 
 bool QXmppBitsOfBinaryData::isBitsOfBinaryData(const QDomElement &element)
 {
-    return element.tagName() == QStringLiteral("data") && element.namespaceURI() == ns_bob;
+    return element.tagName() == QSL("data") && element.namespaceURI() == ns_bob;
 }
 
 /// \cond
 void QXmppBitsOfBinaryData::parseElementFromChild(const QDomElement &dataElement)
 {
-    d->cid = QXmppBitsOfBinaryContentId::fromContentId(dataElement.attribute("cid"));
-    d->maxAge = dataElement.attribute("max-age", "-1").toInt();
-    d->contentType = QMimeDatabase().mimeTypeForName(dataElement.attribute("type"));
+    d->cid = QXmppBitsOfBinaryContentId::fromContentId(dataElement.attribute(QSL("cid")));
+    d->maxAge = dataElement.attribute(QSL("max-age"), QSL("-1")).toInt();
+    d->contentType = QMimeDatabase().mimeTypeForName(dataElement.attribute(QSL("type")));
     d->data = QByteArray::fromBase64(dataElement.text().toUtf8());
 }
 
 void QXmppBitsOfBinaryData::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("data");
+    writer->writeStartElement(QSL("data"));
     writer->writeDefaultNamespace(ns_bob);
-    helperToXmlAddAttribute(writer, "cid", d->cid.toContentId());
+    helperToXmlAddAttribute(writer, QSL("cid"), d->cid.toContentId());
     if (d->maxAge > -1)
-        helperToXmlAddAttribute(writer, "max-age", QString::number(d->maxAge));
-    helperToXmlAddAttribute(writer, "type", d->contentType.name());
+        helperToXmlAddAttribute(writer, QSL("max-age"), QString::number(d->maxAge));
+    helperToXmlAddAttribute(writer, QSL("type"), d->contentType.name());
     writer->writeCharacters(d->data.toBase64());
     writer->writeEndElement();
 }

--- a/src/base/QXmppBookmarkSet.cpp
+++ b/src/base/QXmppBookmarkSet.cpp
@@ -178,7 +178,7 @@ void QXmppBookmarkSet::setUrls(const QList<QXmppBookmarkUrl> &urls)
 /// \cond
 bool QXmppBookmarkSet::isBookmarkSet(const QDomElement &element)
 {
-    return element.tagName() == "storage" &&
+    return element.tagName() == QSL("storage") &&
         element.namespaceURI() == ns_bookmarks;
 }
 
@@ -186,17 +186,17 @@ void QXmppBookmarkSet::parse(const QDomElement &element)
 {
     QDomElement childElement = element.firstChildElement();
     while (!childElement.isNull()) {
-        if (childElement.tagName() == "conference") {
+        if (childElement.tagName() == QSL("conference")) {
             QXmppBookmarkConference conference;
-            conference.setAutoJoin(childElement.attribute("autojoin") == "true" || childElement.attribute("autojoin") == "1");
-            conference.setJid(childElement.attribute("jid"));
-            conference.setName(childElement.attribute("name"));
-            conference.setNickName(childElement.firstChildElement("nick").text());
+            conference.setAutoJoin(childElement.attribute(QSL("autojoin")) == QSL("true") || childElement.attribute("autojoin") == "1");
+            conference.setJid(childElement.attribute(QSL("jid")));
+            conference.setName(childElement.attribute(QSL("name")));
+            conference.setNickName(childElement.firstChildElement(QSL("nick")).text());
             m_conferences << conference;
-        } else if (childElement.tagName() == "url") {
+        } else if (childElement.tagName() == QSL("url")) {
             QXmppBookmarkUrl url;
-            url.setName(childElement.attribute("name"));
-            url.setUrl(childElement.attribute("url"));
+            url.setName(childElement.attribute(QSL("name")));
+            url.setUrl(childElement.attribute(QSL("url")));
             m_urls << url;
         }
         childElement = childElement.nextSiblingElement();
@@ -205,22 +205,22 @@ void QXmppBookmarkSet::parse(const QDomElement &element)
 
 void QXmppBookmarkSet::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("storage");
+    writer->writeStartElement(QSL("storage"));
     writer->writeDefaultNamespace(ns_bookmarks);
     for (const auto &conference : m_conferences) {
-        writer->writeStartElement("conference");
+        writer->writeStartElement(QSL("conference"));
         if (conference.autoJoin())
-            helperToXmlAddAttribute(writer, "autojoin", "true");
-        helperToXmlAddAttribute(writer, "jid", conference.jid());
-        helperToXmlAddAttribute(writer, "name", conference.name());
+            helperToXmlAddAttribute(writer, QSL("autojoin"), QSL("true"));
+        helperToXmlAddAttribute(writer, QSL("jid"), conference.jid());
+        helperToXmlAddAttribute(writer, QSL("name"), conference.name());
         if (!conference.nickName().isEmpty())
-            helperToXmlAddTextElement(writer, "nick", conference.nickName());
+            helperToXmlAddTextElement(writer, QSL("nick"), conference.nickName());
         writer->writeEndElement();
     }
     for (const auto &url : m_urls) {
-        writer->writeStartElement("url");
-        helperToXmlAddAttribute(writer, "name", url.name());
-        helperToXmlAddAttribute(writer, "url", url.url().toString());
+        writer->writeStartElement(QSL("url"));
+        helperToXmlAddAttribute(writer, QSL("name"), url.name());
+        helperToXmlAddAttribute(writer, QSL("url"), url.url().toString());
         writer->writeEndElement();
     }
     writer->writeEndElement();

--- a/src/base/QXmppByteStreamIq.cpp
+++ b/src/base/QXmppByteStreamIq.cpp
@@ -121,60 +121,60 @@ void QXmppByteStreamIq::setStreamHostUsed(const QString &jid)
 /// \cond
 bool QXmppByteStreamIq::isByteStreamIq(const QDomElement &element)
 {
-    return element.firstChildElement("query").namespaceURI() == ns_bytestreams;
+    return element.firstChildElement(QSL("query")).namespaceURI() == ns_bytestreams;
 }
 
 void QXmppByteStreamIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    m_sid = queryElement.attribute("sid");
-    const QString modeStr = queryElement.attribute("mode");
-    if (modeStr == "tcp")
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    m_sid = queryElement.attribute(QSL("sid"));
+    const QString modeStr = queryElement.attribute(QSL("mode"));
+    if (modeStr == QSL("tcp"))
         m_mode = Tcp;
-    else if (modeStr == "udp")
+    else if (modeStr == QSL("udp"))
         m_mode = Udp;
     else
         m_mode = None;
 
-    QDomElement hostElement = queryElement.firstChildElement("streamhost");
+    QDomElement hostElement = queryElement.firstChildElement(QSL("streamhost"));
     while (!hostElement.isNull()) {
         StreamHost streamHost;
-        streamHost.setHost(hostElement.attribute("host"));
-        streamHost.setJid(hostElement.attribute("jid"));
-        streamHost.setPort(hostElement.attribute("port").toInt());
-        streamHost.setZeroconf(hostElement.attribute("zeroconf"));
+        streamHost.setHost(hostElement.attribute(QSL("host")));
+        streamHost.setJid(hostElement.attribute(QSL("jid")));
+        streamHost.setPort(hostElement.attribute(QSL("port")).toInt());
+        streamHost.setZeroconf(hostElement.attribute(QSL("zeroconf")));
         m_streamHosts.append(streamHost);
 
-        hostElement = hostElement.nextSiblingElement("streamhost");
+        hostElement = hostElement.nextSiblingElement(QSL("streamhost"));
     }
-    m_activate = queryElement.firstChildElement("activate").text();
-    m_streamHostUsed = queryElement.firstChildElement("streamhost-used").attribute("jid");
+    m_activate = queryElement.firstChildElement(QSL("activate")).text();
+    m_streamHostUsed = queryElement.firstChildElement(QSL("streamhost-used")).attribute(QSL("jid"));
 }
 
 void QXmppByteStreamIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_bytestreams);
-    helperToXmlAddAttribute(writer, "sid", m_sid);
+    helperToXmlAddAttribute(writer, QSL("sid"), m_sid);
     QString modeStr;
     if (m_mode == Tcp)
-        modeStr = "tcp";
+        modeStr = QSL("tcp");
     else if (m_mode == Udp)
-        modeStr = "udp";
-    helperToXmlAddAttribute(writer, "mode", modeStr);
+        modeStr = QSL("udp");
+    helperToXmlAddAttribute(writer, QSL("mode"), modeStr);
     for (const auto &streamHost : m_streamHosts) {
-        writer->writeStartElement("streamhost");
-        helperToXmlAddAttribute(writer, "host", streamHost.host());
-        helperToXmlAddAttribute(writer, "jid", streamHost.jid());
-        helperToXmlAddAttribute(writer, "port", QString::number(streamHost.port()));
-        helperToXmlAddAttribute(writer, "zeroconf", streamHost.zeroconf());
+        writer->writeStartElement(QSL("streamhost"));
+        helperToXmlAddAttribute(writer, QSL("host"), streamHost.host());
+        helperToXmlAddAttribute(writer, QSL("jid"), streamHost.jid());
+        helperToXmlAddAttribute(writer, QSL("port"), QString::number(streamHost.port()));
+        helperToXmlAddAttribute(writer, QSL("zeroconf"), streamHost.zeroconf());
         writer->writeEndElement();
     }
     if (!m_activate.isEmpty())
-        helperToXmlAddTextElement(writer, "activate", m_activate);
+        helperToXmlAddTextElement(writer, QSL("activate"), m_activate);
     if (!m_streamHostUsed.isEmpty()) {
-        writer->writeStartElement("streamhost-used");
-        helperToXmlAddAttribute(writer, "jid", m_streamHostUsed);
+        writer->writeStartElement(QSL("streamhost-used"));
+        helperToXmlAddAttribute(writer, QSL("jid"), m_streamHostUsed);
         writer->writeEndElement();
     }
 

--- a/src/base/QXmppDataForm.cpp
+++ b/src/base/QXmppDataForm.cpp
@@ -694,14 +694,14 @@ void QXmppDataForm::parse(const QDomElement &element)
             field.mediaSize().setHeight(mediaElement.attribute("height", "-1").toInt());
             field.mediaSize().setWidth(mediaElement.attribute("width", "-1").toInt());
 
-            QDomElement uriElement = mediaElement.firstChildElement(QStringLiteral("uri"));
+            QDomElement uriElement = mediaElement.firstChildElement(QSL("uri"));
 
             while (!uriElement.isNull()) {
                 field.mediaSources() << MediaSource(
                     QUrl(uriElement.text()),
                     QMimeDatabase().mimeTypeForName(
-                        uriElement.attribute(QStringLiteral("type"))));
-                uriElement = uriElement.nextSiblingElement(QStringLiteral("uri"));
+                        uriElement.attribute(QSL("type"))));
+                uriElement = uriElement.nextSiblingElement(QSL("uri"));
             }
         }
 
@@ -794,18 +794,18 @@ void QXmppDataForm::toXml(QXmlStreamWriter *writer) const
             if (field.mediaSize().width() > 0)
                 helperToXmlAddAttribute(
                     writer,
-                    QStringLiteral("width"),
+                    QSL("width"),
                     QString::number(field.mediaSize().width()));
             if (field.mediaSize().height() > 0)
                 helperToXmlAddAttribute(
                     writer,
-                    QStringLiteral("height"),
+                    QSL("height"),
                     QString::number(field.mediaSize().height()));
 
             const QVector<MediaSource> &sources = field.mediaSources();
             for (const auto &source : sources) {
-                writer->writeStartElement(QStringLiteral("uri"));
-                helperToXmlAddAttribute(writer, QStringLiteral("type"), source.contentType().name());
+                writer->writeStartElement(QSL("uri"));
+                helperToXmlAddAttribute(writer, QSL("type"), source.contentType().name());
                 writer->writeCharacters(source.uri().toString());
                 writer->writeEndElement();
             }

--- a/src/base/QXmppDiscoveryIq.h
+++ b/src/base/QXmppDiscoveryIq.h
@@ -83,7 +83,7 @@ public:
         Item();
         Item(const Item &);
         ~Item();
-        
+
         Item &operator=(const Item &);
 
         QString jid() const;

--- a/src/base/QXmppGlobal.h.in
+++ b/src/base/QXmppGlobal.h.in
@@ -62,5 +62,8 @@ inline QLatin1String QXmppVersion()
 // This works exactly like QT_DEPRECATED_SINCE, but checks QXMPP_DISABLE_DEPRECATED_BEFORE instead.
 #define QXMPP_DEPRECATED_SINCE(major, minor) (QT_VERSION_CHECK(major, minor, 0) > QXMPP_DISABLE_DEPRECATED_BEFORE)
 
+#define QSL QStringLiteral
+#define QBL QByteArrayLiteral
+
 #endif //QXMPPGLOBAL_H
 

--- a/src/base/QXmppMamIq.cpp
+++ b/src/base/QXmppMamIq.cpp
@@ -107,8 +107,8 @@ void QXmppMamQueryIq::setQueryId(const QString &id)
 /// \cond
 bool QXmppMamQueryIq::isMamQueryIq(const QDomElement &element)
 {
-    if (element.tagName() == "iq") {
-        QDomElement queryElement = element.firstChildElement("query");
+    if (element.tagName() == QSL("iq")) {
+        QDomElement queryElement = element.firstChildElement(QSL("query"));
         if (!queryElement.isNull() && queryElement.namespaceURI() == ns_mam) {
             return true;
         }
@@ -118,14 +118,14 @@ bool QXmppMamQueryIq::isMamQueryIq(const QDomElement &element)
 
 void QXmppMamQueryIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    d->node = queryElement.attribute("node");
-    d->queryId = queryElement.attribute("queryId");
-    QDomElement resultSetElement = queryElement.firstChildElement("set");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    d->node = queryElement.attribute(QSL("node"));
+    d->queryId = queryElement.attribute(QSL("queryId"));
+    QDomElement resultSetElement = queryElement.firstChildElement(QSL("set"));
     if (!resultSetElement.isNull()) {
         d->resultSetQuery.parse(resultSetElement);
     }
-    QDomElement formElement = queryElement.firstChildElement("x");
+    QDomElement formElement = queryElement.firstChildElement(QSL("x"));
     if (!formElement.isNull()) {
         d->form.parse(formElement);
     }
@@ -133,13 +133,13 @@ void QXmppMamQueryIq::parseElementFromChild(const QDomElement &element)
 
 void QXmppMamQueryIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_mam);
     if (!d->node.isEmpty()) {
-        writer->writeAttribute("node", d->node);
+        writer->writeAttribute(QSL("node"), d->node);
     }
     if (!d->queryId.isEmpty()) {
-        writer->writeAttribute("queryid", d->queryId);
+        writer->writeAttribute(QSL("queryid"), d->queryId);
     }
     d->form.toXml(writer);
     d->resultSetQuery.toXml(writer);
@@ -195,8 +195,8 @@ void QXmppMamResultIq::setComplete(bool complete)
 /// \cond
 bool QXmppMamResultIq::isMamResultIq(const QDomElement &element)
 {
-    if (element.tagName() == "iq") {
-        QDomElement finElement = element.firstChildElement("fin");
+    if (element.tagName() == QSL("iq")) {
+        QDomElement finElement = element.firstChildElement(QSL("fin"));
         if (!finElement.isNull() && finElement.namespaceURI() == ns_mam) {
             return true;
         }
@@ -206,9 +206,9 @@ bool QXmppMamResultIq::isMamResultIq(const QDomElement &element)
 
 void QXmppMamResultIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement finElement = element.firstChildElement("fin");
-    d->complete = finElement.attribute("complete") == QString("true");
-    QDomElement resultSetElement = finElement.firstChildElement("set");
+    QDomElement finElement = element.firstChildElement(QSL("fin"));
+    d->complete = finElement.attribute(QSL("complete")) == QSL("true");
+    QDomElement resultSetElement = finElement.firstChildElement(QSL("set"));
     if (!resultSetElement.isNull()) {
         d->resultSetReply.parse(resultSetElement);
     }
@@ -216,10 +216,10 @@ void QXmppMamResultIq::parseElementFromChild(const QDomElement &element)
 
 void QXmppMamResultIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("fin");
+    writer->writeStartElement(QSL("fin"));
     writer->writeDefaultNamespace(ns_mam);
     if (d->complete) {
-        writer->writeAttribute("complete", "true");
+        writer->writeAttribute(QSL("complete"), QSL("true"));
     }
     d->resultSetReply.toXml(writer);
     writer->writeEndElement();

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -36,26 +36,26 @@
 
 static const QStringList CHAT_STATES = {
     QString(),
-    QStringLiteral("active"),
-    QStringLiteral("inactive"),
-    QStringLiteral("gone"),
-    QStringLiteral("composing"),
-    QStringLiteral("paused")
+    QSL("active"),
+    QSL("inactive"),
+    QSL("gone"),
+    QSL("composing"),
+    QSL("paused")
 };
 
 static const QStringList MESSAGE_TYPES = {
-    QStringLiteral("error"),
-    QStringLiteral("normal"),
-    QStringLiteral("chat"),
-    QStringLiteral("groupchat"),
-    QStringLiteral("headline")
+    QSL("error"),
+    QSL("normal"),
+    QSL("chat"),
+    QSL("groupchat"),
+    QSL("headline")
 };
 
 static const QStringList MARKER_TYPES = {
     QString(),
-    QStringLiteral("received"),
-    QStringLiteral("displayed"),
-    QStringLiteral("acknowledged")
+    QSL("received"),
+    QSL("displayed"),
+    QSL("acknowledged")
 };
 
 static const QStringList ENCRYPTION_NAMESPACES = {
@@ -68,19 +68,19 @@ static const QStringList ENCRYPTION_NAMESPACES = {
 };
 
 static const QStringList HINT_TYPES = {
-    QStringLiteral("no-permanent-store"),
-    QStringLiteral("no-store"),
-    QStringLiteral("no-copy"),
-    QStringLiteral("store")
+    QSL("no-permanent-store"),
+    QSL("no-store"),
+    QSL("no-copy"),
+    QSL("store")
 };
 
 static const QStringList ENCRYPTION_NAMES = {
     QString(),
     QString(),
-    QStringLiteral("OTR"),
-    QStringLiteral("Legacy OpenPGP"),
-    QStringLiteral("OpenPGP for XMPP (OX)"),
-    QStringLiteral("OMEMO")
+    QSL("OTR"),
+    QSL("Legacy OpenPGP"),
+    QSL("OpenPGP for XMPP (OX)"),
+    QSL("OMEMO")
 };
 
 static bool checkElement(const QDomElement &element, const QString &tagName, const QString &xmlns)
@@ -905,7 +905,7 @@ void QXmppMessage::parse(const QDomElement &element)
     QXmppStanza::parse(element);
 
     // message type
-    int messageType = MESSAGE_TYPES.indexOf(element.attribute(QStringLiteral("type")));
+    int messageType = MESSAGE_TYPES.indexOf(element.attribute(QSL("type")));
     if (messageType != -1)
         d->type = static_cast<Type>(messageType);
     else
@@ -914,16 +914,16 @@ void QXmppMessage::parse(const QDomElement &element)
     QXmppElementList extensions;
     QDomElement childElement = element.firstChildElement();
     while (!childElement.isNull()) {
-        if (childElement.tagName() == QStringLiteral("body")) {
+        if (childElement.tagName() == QSL("body")) {
             d->body = childElement.text();
-        } else if (childElement.tagName() == QStringLiteral("subject")) {
+        } else if (childElement.tagName() == QSL("subject")) {
             d->subject = childElement.text();
-        } else if (childElement.tagName() == QStringLiteral("thread")) {
+        } else if (childElement.tagName() == QSL("thread")) {
             d->thread = childElement.text();
             // parse message extensions
             // XEP-0033: Extended Stanza Addressing and errors are parsed by QXmppStanza
-        } else if (!checkElement(childElement, QStringLiteral("addresses"), ns_extended_addressing) &&
-                   childElement.tagName() != QStringLiteral("error")) {
+        } else if (!checkElement(childElement, QSL("addresses"), ns_extended_addressing) &&
+                   childElement.tagName() != QSL("error")) {
             parseExtension(childElement, extensions);
         }
         childElement = childElement.nextSiblingElement();
@@ -933,18 +933,18 @@ void QXmppMessage::parse(const QDomElement &element)
 
 void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
 {
-    xmlWriter->writeStartElement(QStringLiteral("message"));
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("xml:lang"), lang());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("id"), id());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("to"), to());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("from"), from());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("type"), MESSAGE_TYPES.at(d->type));
+    xmlWriter->writeStartElement(QSL("message"));
+    helperToXmlAddAttribute(xmlWriter, QSL("xml:lang"), lang());
+    helperToXmlAddAttribute(xmlWriter, QSL("id"), id());
+    helperToXmlAddAttribute(xmlWriter, QSL("to"), to());
+    helperToXmlAddAttribute(xmlWriter, QSL("from"), from());
+    helperToXmlAddAttribute(xmlWriter, QSL("type"), MESSAGE_TYPES.at(d->type));
     if (!d->subject.isEmpty())
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("subject"), d->subject);
+        helperToXmlAddTextElement(xmlWriter, QSL("subject"), d->subject);
     if (!d->body.isEmpty())
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("body"), d->body);
+        helperToXmlAddTextElement(xmlWriter, QSL("body"), d->body);
     if (!d->thread.isEmpty())
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("thread"), d->thread);
+        helperToXmlAddTextElement(xmlWriter, QSL("thread"), d->thread);
     error().toXml(xmlWriter);
 
     // chat states
@@ -956,11 +956,11 @@ void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
 
     // XEP-0071: XHTML-IM
     if (!d->xhtml.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("html"));
+        xmlWriter->writeStartElement(QSL("html"));
         xmlWriter->writeDefaultNamespace(ns_xhtml_im);
-        xmlWriter->writeStartElement(QStringLiteral("body"));
+        xmlWriter->writeStartElement(QSL("body"));
         xmlWriter->writeDefaultNamespace(ns_xhtml);
-        xmlWriter->writeCharacters(QStringLiteral(""));
+        xmlWriter->writeCharacters(QSL(""));
         xmlWriter->device()->write(d->xhtml.toUtf8());
         xmlWriter->writeEndElement();
         xmlWriter->writeEndElement();
@@ -971,63 +971,63 @@ void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
         QDateTime utcStamp = d->stamp.toUTC();
         if (d->stampType == DelayedDelivery) {
             // XEP-0203: Delayed Delivery
-            xmlWriter->writeStartElement(QStringLiteral("delay"));
+            xmlWriter->writeStartElement(QSL("delay"));
             xmlWriter->writeDefaultNamespace(ns_delayed_delivery);
-            helperToXmlAddAttribute(xmlWriter, QStringLiteral("stamp"), QXmppUtils::datetimeToString(utcStamp));
+            helperToXmlAddAttribute(xmlWriter, QSL("stamp"), QXmppUtils::datetimeToString(utcStamp));
             xmlWriter->writeEndElement();
         } else {
             // XEP-0091: Legacy Delayed Delivery
-            xmlWriter->writeStartElement(QStringLiteral("x"));
+            xmlWriter->writeStartElement(QSL("x"));
             xmlWriter->writeDefaultNamespace(ns_legacy_delayed_delivery);
-            helperToXmlAddAttribute(xmlWriter, QStringLiteral("stamp"), utcStamp.toString(QStringLiteral("yyyyMMddThh:mm:ss")));
+            helperToXmlAddAttribute(xmlWriter, QSL("stamp"), utcStamp.toString(QSL("yyyyMMddThh:mm:ss")));
             xmlWriter->writeEndElement();
         }
     }
 
     // XEP-0184: Message Delivery Receipts
     if (!d->receiptId.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("received"));
+        xmlWriter->writeStartElement(QSL("received"));
         xmlWriter->writeDefaultNamespace(ns_message_receipts);
-        xmlWriter->writeAttribute(QStringLiteral("id"), d->receiptId);
+        xmlWriter->writeAttribute(QSL("id"), d->receiptId);
         xmlWriter->writeEndElement();
     }
     if (d->receiptRequested) {
-        xmlWriter->writeStartElement(QStringLiteral("request"));
+        xmlWriter->writeStartElement(QSL("request"));
         xmlWriter->writeDefaultNamespace(ns_message_receipts);
         xmlWriter->writeEndElement();
     }
 
     // \xep{0224}: Attention
     if (d->attentionRequested) {
-        xmlWriter->writeStartElement(QStringLiteral("attention"));
+        xmlWriter->writeStartElement(QSL("attention"));
         xmlWriter->writeDefaultNamespace(ns_attention);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0249: Direct MUC Invitations
     if (!d->mucInvitationJid.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("x"));
+        xmlWriter->writeStartElement(QSL("x"));
         xmlWriter->writeDefaultNamespace(ns_conference);
-        xmlWriter->writeAttribute(QStringLiteral("jid"), d->mucInvitationJid);
+        xmlWriter->writeAttribute(QSL("jid"), d->mucInvitationJid);
         if (!d->mucInvitationPassword.isEmpty())
-            xmlWriter->writeAttribute(QStringLiteral("password"), d->mucInvitationPassword);
+            xmlWriter->writeAttribute(QSL("password"), d->mucInvitationPassword);
         if (!d->mucInvitationReason.isEmpty())
-            xmlWriter->writeAttribute(QStringLiteral("reason"), d->mucInvitationReason);
+            xmlWriter->writeAttribute(QSL("reason"), d->mucInvitationReason);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0333: Chat Markers
     if (d->markable) {
-        xmlWriter->writeStartElement(QStringLiteral("markable"));
+        xmlWriter->writeStartElement(QSL("markable"));
         xmlWriter->writeDefaultNamespace(ns_chat_markers);
         xmlWriter->writeEndElement();
     }
     if (d->marker != NoMarker) {
         xmlWriter->writeStartElement(MARKER_TYPES.at(d->marker));
         xmlWriter->writeDefaultNamespace(ns_chat_markers);
-        xmlWriter->writeAttribute(QStringLiteral("id"), d->markedId);
+        xmlWriter->writeAttribute(QSL("id"), d->markedId);
         if (!d->markedThread.isNull() && !d->markedThread.isEmpty()) {
-            xmlWriter->writeAttribute(QStringLiteral("thread"), d->markedThread);
+            xmlWriter->writeAttribute(QSL("thread"), d->markedThread);
         }
         xmlWriter->writeEndElement();
     }
@@ -1038,24 +1038,24 @@ void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
 
     // XEP-0280: Message Carbons
     if (d->privatemsg) {
-        xmlWriter->writeStartElement(QStringLiteral("private"));
+        xmlWriter->writeStartElement(QSL("private"));
         xmlWriter->writeDefaultNamespace(ns_carbons);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0066: Out of Band Data
     if (!d->outOfBandUrl.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("x"));
+        xmlWriter->writeStartElement(QSL("x"));
         xmlWriter->writeDefaultNamespace(ns_oob);
-        xmlWriter->writeTextElement(QStringLiteral("url"), d->outOfBandUrl);
+        xmlWriter->writeTextElement(QSL("url"), d->outOfBandUrl);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0308: Last Message Correction
     if (!d->replaceId.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("replace"));
+        xmlWriter->writeStartElement(QSL("replace"));
         xmlWriter->writeDefaultNamespace(ns_message_correct);
-        xmlWriter->writeAttribute(QStringLiteral("id"), d->replaceId);
+        xmlWriter->writeAttribute(QSL("id"), d->replaceId);
         xmlWriter->writeEndElement();
     }
 
@@ -1070,50 +1070,50 @@ void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
 
     // XEP-0359: Unique and Stable Stanza IDs
     if (!d->stanzaId.isNull()) {
-        xmlWriter->writeStartElement(QStringLiteral("stanza-id"));
+        xmlWriter->writeStartElement(QSL("stanza-id"));
         xmlWriter->writeDefaultNamespace(ns_sid);
-        xmlWriter->writeAttribute(QStringLiteral("id"), d->stanzaId);
+        xmlWriter->writeAttribute(QSL("id"), d->stanzaId);
         if (!d->stanzaIdBy.isNull())
-            xmlWriter->writeAttribute(QStringLiteral("by"), d->stanzaIdBy);
+            xmlWriter->writeAttribute(QSL("by"), d->stanzaIdBy);
         xmlWriter->writeEndElement();
     }
 
     if (!d->originId.isNull()) {
-        xmlWriter->writeStartElement(QStringLiteral("origin-id"));
+        xmlWriter->writeStartElement(QSL("origin-id"));
         xmlWriter->writeDefaultNamespace(ns_sid);
-        xmlWriter->writeAttribute(QStringLiteral("id"), d->originId);
+        xmlWriter->writeAttribute(QSL("id"), d->originId);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0367: Message Attaching
     if (!d->attachId.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("attach-to"));
+        xmlWriter->writeStartElement(QSL("attach-to"));
         xmlWriter->writeDefaultNamespace(ns_message_attaching);
-        xmlWriter->writeAttribute(QStringLiteral("id"), d->attachId);
+        xmlWriter->writeAttribute(QSL("id"), d->attachId);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0369: Mediated Information eXchange (MIX)
     if (!d->mixUserJid.isEmpty() || !d->mixUserNick.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("mix"));
+        xmlWriter->writeStartElement(QSL("mix"));
         xmlWriter->writeDefaultNamespace(ns_mix);
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("jid"), d->mixUserJid);
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("nick"), d->mixUserNick);
+        helperToXmlAddTextElement(xmlWriter, QSL("jid"), d->mixUserJid);
+        helperToXmlAddTextElement(xmlWriter, QSL("nick"), d->mixUserNick);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0380: Explicit Message Encryption
     if (!d->encryptionMethod.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("encryption"));
+        xmlWriter->writeStartElement(QSL("encryption"));
         xmlWriter->writeDefaultNamespace(ns_eme);
-        xmlWriter->writeAttribute(QStringLiteral("namespace"), d->encryptionMethod);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("name"), d->encryptionName);
+        xmlWriter->writeAttribute(QSL("namespace"), d->encryptionMethod);
+        helperToXmlAddAttribute(xmlWriter, QSL("name"), d->encryptionName);
         xmlWriter->writeEndElement();
     }
 
     // XEP-0382: Spoiler messages
     if (d->isSpoiler) {
-        xmlWriter->writeStartElement(QStringLiteral("spoiler"));
+        xmlWriter->writeStartElement(QSL("spoiler"));
         xmlWriter->writeDefaultNamespace(ns_spoiler);
         xmlWriter->writeCharacters(d->spoilerHint);
         xmlWriter->writeEndElement();
@@ -1121,7 +1121,7 @@ void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
 
     // XEP-0428: Fallback Indication
     if (d->isFallback) {
-        xmlWriter->writeStartElement(QStringLiteral("fallback"));
+        xmlWriter->writeStartElement(QSL("fallback"));
         xmlWriter->writeDefaultNamespace(ns_fallback_indication);
         xmlWriter->writeEndElement();
     }
@@ -1140,20 +1140,20 @@ void QXmppMessage::toXml(QXmlStreamWriter *xmlWriter) const
 
 void QXmppMessage::parseExtension(const QDomElement &element, QXmppElementList &unknownExtensions)
 {
-    if (element.tagName() == QStringLiteral("x")) {
+    if (element.tagName() == QSL("x")) {
         parseXElement(element, unknownExtensions);
         // XEP-0071: XHTML-IM
-    } else if (checkElement(element, QStringLiteral("html"), ns_xhtml_im)) {
-        QDomElement bodyElement = element.firstChildElement(QStringLiteral("body"));
+    } else if (checkElement(element, QSL("html"), ns_xhtml_im)) {
+        QDomElement bodyElement = element.firstChildElement(QSL("body"));
         if (!bodyElement.isNull() && bodyElement.namespaceURI() == ns_xhtml) {
             QTextStream stream(&d->xhtml, QIODevice::WriteOnly);
             bodyElement.save(stream, 0);
 
             d->xhtml = d->xhtml.mid(d->xhtml.indexOf('>') + 1);
             d->xhtml.replace(
-                QStringLiteral(" xmlns=\"http://www.w3.org/1999/xhtml\""),
+                QSL(" xmlns=\"http://www.w3.org/1999/xhtml\""),
                 QString());
-            d->xhtml.replace(QStringLiteral("</body>"), QString());
+            d->xhtml.replace(QSL("</body>"), QString());
             d->xhtml = d->xhtml.trimmed();
         }
         // XEP-0085: Chat State Notifications
@@ -1162,21 +1162,21 @@ void QXmppMessage::parseExtension(const QDomElement &element, QXmppElementList &
         if (i > 0)
             d->state = static_cast<QXmppMessage::State>(i);
         // XEP-0184: Message Delivery Receipts
-    } else if (checkElement(element, QStringLiteral("received"), ns_message_receipts)) {
-        d->receiptId = element.attribute(QStringLiteral("id"));
+    } else if (checkElement(element, QSL("received"), ns_message_receipts)) {
+        d->receiptId = element.attribute(QSL("id"));
 
         // compatibility with old-style XEP
         if (d->receiptId.isEmpty())
             d->receiptId = id();
-    } else if (checkElement(element, QStringLiteral("request"), ns_message_receipts)) {
+    } else if (checkElement(element, QSL("request"), ns_message_receipts)) {
         d->receiptRequested = true;
         // XEP-0203: Delayed Delivery
-    } else if (checkElement(element, QStringLiteral("delay"), ns_delayed_delivery)) {
+    } else if (checkElement(element, QSL("delay"), ns_delayed_delivery)) {
         d->stamp = QXmppUtils::datetimeFromString(
-            element.attribute(QStringLiteral("stamp")));
+            element.attribute(QSL("stamp")));
         d->stampType = DelayedDelivery;
         // \xep{0224}: Attention
-    } else if (checkElement(element, QStringLiteral("attention"), ns_attention)) {
+    } else if (checkElement(element, QSL("attention"), ns_attention)) {
         d->attentionRequested = true;
         // XEP-0231: Bits of Binary
     } else if (QXmppBitsOfBinaryData::isBitsOfBinaryData(element)) {
@@ -1184,49 +1184,49 @@ void QXmppMessage::parseExtension(const QDomElement &element, QXmppElementList &
         data.parseElementFromChild(element);
         d->bitsOfBinaryData << data;
         // XEP-0280: Message Carbons
-    } else if (checkElement(element, QStringLiteral("private"), ns_carbons)) {
+    } else if (checkElement(element, QSL("private"), ns_carbons)) {
         d->privatemsg = true;
         // XEP-0308: Last Message Correction
-    } else if (checkElement(element, QStringLiteral("replace"), ns_message_correct)) {
-        d->replaceId = element.attribute(QStringLiteral("id"));
+    } else if (checkElement(element, QSL("replace"), ns_message_correct)) {
+        d->replaceId = element.attribute(QSL("id"));
         // XEP-0333: Chat Markers
     } else if (element.namespaceURI() == ns_chat_markers) {
-        if (element.tagName() == QStringLiteral("markable")) {
+        if (element.tagName() == QSL("markable")) {
             d->markable = true;
         } else {
             int marker = MARKER_TYPES.indexOf(element.tagName());
             if (marker != -1) {
                 d->marker = static_cast<QXmppMessage::Marker>(marker);
-                d->markedId = element.attribute(QStringLiteral("id"));
-                d->markedThread = element.attribute(QStringLiteral("thread"));
+                d->markedId = element.attribute(QSL("id"));
+                d->markedThread = element.attribute(QSL("thread"));
             }
         }
         // XEP-0334: Message Processing Hints
     } else if (element.namespaceURI() == ns_message_processing_hints &&
                HINT_TYPES.contains(element.tagName())) {
         addHint(Hint(1 << HINT_TYPES.indexOf(element.tagName())));
-    } else if (checkElement(element, QStringLiteral("stanza-id"), ns_sid)) {
+    } else if (checkElement(element, QSL("stanza-id"), ns_sid)) {
         // XEP-0359: Unique and Stable Stanza IDs
-        d->stanzaId = element.attribute(QStringLiteral("id"));
-        d->stanzaIdBy = element.attribute(QStringLiteral("by"));
-    } else if (checkElement(element, QStringLiteral("origin-id"), ns_sid)) {
-        d->originId = element.attribute(QStringLiteral("id"));
-    } else if (checkElement(element, QStringLiteral("attach-to"), ns_message_attaching)) {
+        d->stanzaId = element.attribute(QSL("id"));
+        d->stanzaIdBy = element.attribute(QSL("by"));
+    } else if (checkElement(element, QSL("origin-id"), ns_sid)) {
+        d->originId = element.attribute(QSL("id"));
+    } else if (checkElement(element, QSL("attach-to"), ns_message_attaching)) {
         // XEP-0367: Message Attaching
-        d->attachId = element.attribute(QStringLiteral("id"));
+        d->attachId = element.attribute(QSL("id"));
         // XEP-0369: Mediated Information eXchange (MIX)
-    } else if (checkElement(element, QStringLiteral("mix"), ns_mix)) {
-        d->mixUserJid = element.firstChildElement(QStringLiteral("jid")).text();
-        d->mixUserNick = element.firstChildElement(QStringLiteral("nick")).text();
+    } else if (checkElement(element, QSL("mix"), ns_mix)) {
+        d->mixUserJid = element.firstChildElement(QSL("jid")).text();
+        d->mixUserNick = element.firstChildElement(QSL("nick")).text();
         // XEP-0380: Explicit Message Encryption
-    } else if (checkElement(element, QStringLiteral("encryption"), ns_eme)) {
-        d->encryptionMethod = element.attribute(QStringLiteral("namespace"));
-        d->encryptionName = element.attribute(QStringLiteral("name"));
+    } else if (checkElement(element, QSL("encryption"), ns_eme)) {
+        d->encryptionMethod = element.attribute(QSL("namespace"));
+        d->encryptionName = element.attribute(QSL("name"));
         // XEP-0382: Spoiler messages
-    } else if (checkElement(element, QStringLiteral("spoiler"), ns_spoiler)) {
+    } else if (checkElement(element, QSL("spoiler"), ns_spoiler)) {
         d->isSpoiler = true;
         d->spoilerHint = element.text();
-    } else if (checkElement(element, QStringLiteral("fallback"), ns_fallback_indication)) {
+    } else if (checkElement(element, QSL("fallback"), ns_fallback_indication)) {
         // XEP-0428: Fallback Indication
         d->isFallback = true;
     } else {
@@ -1248,19 +1248,19 @@ void QXmppMessage::parseXElement(const QDomElement &element, QXmppElementList &u
         if (d->stamp.isNull()) {
             // XEP-0091: Legacy Delayed Delivery
             d->stamp = QDateTime::fromString(
-                element.attribute(QStringLiteral("stamp")),
-                QStringLiteral("yyyyMMddThh:mm:ss"));
+                element.attribute(QSL("stamp")),
+                QSL("yyyyMMddThh:mm:ss"));
             d->stamp.setTimeSpec(Qt::UTC);
             d->stampType = LegacyDelayedDelivery;
         }
     } else if (element.namespaceURI() == ns_conference) {
         // XEP-0249: Direct MUC Invitations
-        d->mucInvitationJid = element.attribute(QStringLiteral("jid"));
-        d->mucInvitationPassword = element.attribute(QStringLiteral("password"));
-        d->mucInvitationReason = element.attribute(QStringLiteral("reason"));
+        d->mucInvitationJid = element.attribute(QSL("jid"));
+        d->mucInvitationPassword = element.attribute(QSL("password"));
+        d->mucInvitationReason = element.attribute(QSL("reason"));
     } else if (element.namespaceURI() == ns_oob) {
         // XEP-0066: Out of Band Data
-        d->outOfBandUrl = element.firstChildElement(QStringLiteral("url")).text();
+        d->outOfBandUrl = element.firstChildElement(QSL("url")).text();
     } else {
         unknownExtensions << QXmppElement(element);
     }

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -629,7 +629,7 @@ QString QXmppMessage::stanzaId() const
 ///
 /// \since QXmpp 1.3
 ///
-void QXmppMessage::setStanzaId(const QString& id)
+void QXmppMessage::setStanzaId(const QString &id)
 {
     d->stanzaId = id;
 }

--- a/src/base/QXmppMixIq.cpp
+++ b/src/base/QXmppMixIq.cpp
@@ -32,14 +32,14 @@
 
 static const QStringList MIX_ACTION_TYPES = {
     QString(),
-    QStringLiteral("client-join"),
-    QStringLiteral("client-leave"),
-    QStringLiteral("join"),
-    QStringLiteral("leave"),
-    QStringLiteral("update-subscription"),
-    QStringLiteral("setnick"),
-    QStringLiteral("create"),
-    QStringLiteral("destroy")
+    QSL("client-join"),
+    QSL("client-leave"),
+    QSL("join"),
+    QSL("leave"),
+    QSL("update-subscription"),
+    QSL("setnick"),
+    QSL("create"),
+    QSL("destroy")
 };
 
 class QXmppMixIqPrivate : public QSharedData
@@ -153,23 +153,23 @@ void QXmppMixIq::parseElementFromChild(const QDomElement& element)
     d->actionType = (QXmppMixIq::Type)MIX_ACTION_TYPES.indexOf(child.tagName());
 
     if (child.namespaceURI() == ns_mix_pam) {
-        if (child.hasAttribute("channel"))
-            d->jid = child.attribute("channel");
+        if (child.hasAttribute(QSL("channel")))
+            d->jid = child.attribute(QSL("channel"));
 
         child = child.firstChildElement();
     }
 
     if (!child.isNull() && child.namespaceURI() == ns_mix) {
-        if (child.hasAttribute("jid"))
-            d->jid = child.attribute("jid");
-        if (child.hasAttribute("channel"))
-            d->channelName = child.attribute("channel");
+        if (child.hasAttribute(QSL("jid")))
+            d->jid = child.attribute(QSL("jid"));
+        if (child.hasAttribute(QSL("channel")))
+            d->channelName = child.attribute(QSL("channel"));
 
         QDomElement subChild = child.firstChildElement();
         while (!subChild.isNull()) {
-            if (subChild.tagName() == "subscribe")
-                d->nodes << subChild.attribute("node");
-            else if (subChild.tagName() == "nick")
+            if (subChild.tagName() == QSL("subscribe"))
+                d->nodes << subChild.attribute(QSL("node"));
+            else if (subChild.tagName() == QSL("nick"))
                 d->nick = subChild.text();
 
             subChild = subChild.nextSiblingElement();
@@ -186,26 +186,26 @@ void QXmppMixIq::toXmlElementFromChild(QXmlStreamWriter* writer) const
     if (d->actionType == ClientJoin || d->actionType == ClientLeave) {
         writer->writeDefaultNamespace(ns_mix_pam);
         if (type() == Set)
-            helperToXmlAddAttribute(writer, "channel", d->jid);
+            helperToXmlAddAttribute(writer, QSL("channel"), d->jid);
 
         if (d->actionType == ClientJoin)
-            writer->writeStartElement("join");
+            writer->writeStartElement(QSL("join"));
         else if (d->actionType == ClientLeave)
-            writer->writeStartElement("leave");
+            writer->writeStartElement(QSL("leave"));
     }
 
     writer->writeDefaultNamespace(ns_mix);
-    helperToXmlAddAttribute(writer, "channel", d->channelName);
+    helperToXmlAddAttribute(writer, QSL("channel"), d->channelName);
     if (type() == Result)
-        helperToXmlAddAttribute(writer, "jid", d->jid);
+        helperToXmlAddAttribute(writer, QSL("jid"), d->jid);
 
     for (const auto& node : d->nodes) {
-        writer->writeStartElement("subscribe");
-        writer->writeAttribute("node", node);
+        writer->writeStartElement(QSL("subscribe"));
+        writer->writeAttribute(QSL("node"), node);
         writer->writeEndElement();
     }
     if (!d->nick.isEmpty())
-        writer->writeTextElement("nick", d->nick);
+        writer->writeTextElement(QSL("nick"), d->nick);
 
     writer->writeEndElement();
     if (d->actionType == ClientJoin || d->actionType == ClientLeave)

--- a/src/base/QXmppMixItem.cpp
+++ b/src/base/QXmppMixItem.cpp
@@ -100,7 +100,7 @@ bool QXmppMixInfoItem::isMixChannelInfo(const QDomElement& element)
     QXmppDataForm form;
     form.parse(element);
     for (const auto& field : form.fields()) {
-        if (field.key() == "FORM_TYPE")
+        if (field.key() == QSL("FORM_TYPE"))
             return field.value() == ns_mix;
     }
     return false;
@@ -112,11 +112,11 @@ void QXmppMixInfoItem::parse(const QXmppElement& element)
     form.parse(element.sourceDomElement());
 
     for (auto& field : form.fields()) {
-        if (field.key() == "Name")
+        if (field.key() == QSL("Name"))
             d->name = field.value().toString();
-        else if (field.key() == "Description")
+        else if (field.key() == QSL("Description"))
             d->description = field.value().toString();
-        else if (field.key() == "Contact")
+        else if (field.key() == QSL("Contact"))
             d->contactJids = field.value().toStringList();
     }
 }
@@ -129,22 +129,22 @@ QXmppElement QXmppMixInfoItem::toElement() const
 
     QXmppDataForm::Field formType;
     formType.setType(QXmppDataForm::Field::HiddenField);
-    formType.setKey("FORM_TYPE");
+    formType.setKey(QSL("FORM_TYPE"));
     formType.setValue(ns_mix);
     fields << formType;
 
     QXmppDataForm::Field nameField;
-    nameField.setKey("Name");
+    nameField.setKey(QSL("Name"));
     nameField.setValue(d->name);
     fields << nameField;
 
     QXmppDataForm::Field descriptionField;
-    descriptionField.setKey("Description");
+    descriptionField.setKey(QSL("Description"));
     descriptionField.setValue(d->description);
     fields << descriptionField;
 
     QXmppDataForm::Field contactsField;
-    contactsField.setKey("Contact");
+    contactsField.setKey(QSL("Contact"));
     contactsField.setValue(d->contactJids);
     contactsField.setType(QXmppDataForm::Field::JidMultiField);
     fields << contactsField;
@@ -210,23 +210,23 @@ void QXmppMixParticipantItem::setJid(const QString& jid)
 
 void QXmppMixParticipantItem::parse(const QXmppElement& itemContent)
 {
-    d->nick = itemContent.firstChildElement("nick").value();
-    d->jid = itemContent.firstChildElement("jid").value();
+    d->nick = itemContent.firstChildElement(QSL("nick")).value();
+    d->jid = itemContent.firstChildElement(QSL("jid")).value();
 }
 
 QXmppElement QXmppMixParticipantItem::toElement() const
 {
     QXmppElement element;
-    element.setTagName("participant");
-    element.setAttribute("xmlns", ns_mix);
+    element.setTagName(QSL("participant"));
+    element.setAttribute(QSL("xmlns"), ns_mix);
 
     QXmppElement jid;
-    jid.setTagName("jid");
+    jid.setTagName(QSL("jid"));
     jid.setValue(d->jid);
     element.appendChild(jid);
 
     QXmppElement nick;
-    nick.setTagName("nick");
+    nick.setTagName(QSL("nick"));
     nick.setValue(d->nick);
     element.appendChild(nick);
 
@@ -237,5 +237,5 @@ QXmppElement QXmppMixParticipantItem::toElement() const
 
 bool QXmppMixParticipantItem::isMixParticipantItem(const QDomElement& element)
 {
-    return element.tagName() == "participant" && element.namespaceURI() == ns_mix;
+    return element.tagName() == QSL("participant") && element.namespaceURI() == ns_mix;
 }

--- a/src/base/QXmppMucIq.cpp
+++ b/src/base/QXmppMucIq.cpp
@@ -72,15 +72,15 @@ QXmppMucItem::Affiliation QXmppMucItem::affiliation() const
 /// \cond
 QXmppMucItem::Affiliation QXmppMucItem::affiliationFromString(const QString &affiliationStr)
 {
-    if (affiliationStr == "owner")
+    if (affiliationStr == QSL("owner"))
         return QXmppMucItem::OwnerAffiliation;
-    else if (affiliationStr == "admin")
+    else if (affiliationStr == QSL("admin"))
         return QXmppMucItem::AdminAffiliation;
-    else if (affiliationStr == "member")
+    else if (affiliationStr == QSL("member"))
         return QXmppMucItem::MemberAffiliation;
-    else if (affiliationStr == "outcast")
+    else if (affiliationStr == QSL("outcast"))
         return QXmppMucItem::OutcastAffiliation;
-    else if (affiliationStr == "none")
+    else if (affiliationStr == QSL("none"))
         return QXmppMucItem::NoAffiliation;
     else
         return QXmppMucItem::UnspecifiedAffiliation;
@@ -172,13 +172,13 @@ QXmppMucItem::Role QXmppMucItem::role() const
 /// \cond
 QXmppMucItem::Role QXmppMucItem::roleFromString(const QString &roleStr)
 {
-    if (roleStr == "moderator")
+    if (roleStr == QSL("moderator"))
         return QXmppMucItem::ModeratorRole;
-    else if (roleStr == "participant")
+    else if (roleStr == QSL("participant"))
         return QXmppMucItem::ParticipantRole;
-    else if (roleStr == "visitor")
+    else if (roleStr == QSL("visitor"))
         return QXmppMucItem::VisitorRole;
-    else if (roleStr == "none")
+    else if (roleStr == QSL("none"))
         return QXmppMucItem::NoRole;
     else
         return QXmppMucItem::UnspecifiedRole;
@@ -188,13 +188,13 @@ QString QXmppMucItem::roleToString(Role role)
 {
     switch (role) {
     case QXmppMucItem::ModeratorRole:
-        return "moderator";
+        return QSL("moderator");
     case QXmppMucItem::ParticipantRole:
-        return "participant";
+        return QSL("participant");
     case QXmppMucItem::VisitorRole:
-        return "visitor";
+        return QSL("visitor");
     case QXmppMucItem::NoRole:
-        return "none";
+        return QSL("none");
     default:
         return QString();
     }
@@ -213,28 +213,28 @@ void QXmppMucItem::setRole(Role role)
 /// \cond
 void QXmppMucItem::parse(const QDomElement &element)
 {
-    m_affiliation = QXmppMucItem::affiliationFromString(element.attribute("affiliation").toLower());
-    m_jid = element.attribute("jid");
-    m_nick = element.attribute("nick");
-    m_role = QXmppMucItem::roleFromString(element.attribute("role").toLower());
-    m_actor = element.firstChildElement("actor").attribute("jid");
-    m_reason = element.firstChildElement("reason").text();
+    m_affiliation = QXmppMucItem::affiliationFromString(element.attribute(QSL("affiliation")).toLower());
+    m_jid = element.attribute(QSL("jid"));
+    m_nick = element.attribute(QSL("nick"));
+    m_role = QXmppMucItem::roleFromString(element.attribute(QSL("role")).toLower());
+    m_actor = element.firstChildElement(QSL("actor")).attribute("jid");
+    m_reason = element.firstChildElement(QSL("reason")).text();
 }
 
 void QXmppMucItem::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("item");
-    helperToXmlAddAttribute(writer, "affiliation", affiliationToString(m_affiliation));
-    helperToXmlAddAttribute(writer, "jid", m_jid);
-    helperToXmlAddAttribute(writer, "nick", m_nick);
-    helperToXmlAddAttribute(writer, "role", roleToString(m_role));
+    writer->writeStartElement(QSL("item"));
+    helperToXmlAddAttribute(writer, QSL("affiliation"), affiliationToString(m_affiliation));
+    helperToXmlAddAttribute(writer, QSL("jid"), m_jid);
+    helperToXmlAddAttribute(writer, QSL("nick"), m_nick);
+    helperToXmlAddAttribute(writer, QSL("role"), roleToString(m_role));
     if (!m_actor.isEmpty()) {
-        writer->writeStartElement("actor");
-        helperToXmlAddAttribute(writer, "jid", m_actor);
+        writer->writeStartElement(QSL("actor"));
+        helperToXmlAddAttribute(writer, QSL("jid"), m_actor);
         writer->writeEndElement();
     }
     if (!m_reason.isEmpty())
-        helperToXmlAddTextElement(writer, "reason", m_reason);
+        helperToXmlAddTextElement(writer, QSL("reason"), m_reason);
     writer->writeEndElement();
 }
 /// \endcond
@@ -258,25 +258,25 @@ void QXmppMucAdminIq::setItems(const QList<QXmppMucItem> &items)
 /// \cond
 bool QXmppMucAdminIq::isMucAdminIq(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
     return (queryElement.namespaceURI() == ns_muc_admin);
 }
 
 void QXmppMucAdminIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    QDomElement child = queryElement.firstChildElement("item");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    QDomElement child = queryElement.firstChildElement(QSL("item"));
     while (!child.isNull()) {
         QXmppMucItem item;
         item.parse(child);
         m_items << item;
-        child = child.nextSiblingElement("item");
+        child = child.nextSiblingElement(QSL("item"));
     }
 }
 
 void QXmppMucAdminIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_muc_admin);
     for (const QXmppMucItem &item : m_items)
         item.toXml(writer);
@@ -303,19 +303,19 @@ void QXmppMucOwnerIq::setForm(const QXmppDataForm &form)
 /// \cond
 bool QXmppMucOwnerIq::isMucOwnerIq(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
     return (queryElement.namespaceURI() == ns_muc_owner);
 }
 
 void QXmppMucOwnerIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    m_form.parse(queryElement.firstChildElement("x"));
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    m_form.parse(queryElement.firstChildElement(QSL("x")));
 }
 
 void QXmppMucOwnerIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_muc_owner);
     m_form.toXml(writer);
     writer->writeEndElement();

--- a/src/base/QXmppNonSASLAuth.cpp
+++ b/src/base/QXmppNonSASLAuth.cpp
@@ -78,31 +78,31 @@ void QXmppNonSASLAuthIq::setResource(const QString &resource)
 /// \cond
 bool QXmppNonSASLAuthIq::isNonSASLAuthIq(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
     return queryElement.namespaceURI() == ns_auth;
 }
 
 void QXmppNonSASLAuthIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    m_username = queryElement.firstChildElement("username").text();
-    m_password = queryElement.firstChildElement("password").text();
-    m_digest = QByteArray::fromHex(queryElement.firstChildElement("digest").text().toLatin1());
-    m_resource = queryElement.firstChildElement("resource").text();
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    m_username = queryElement.firstChildElement(QSL("username")).text();
+    m_password = queryElement.firstChildElement(QSL("password")).text();
+    m_digest = QByteArray::fromHex(queryElement.firstChildElement(QSL("digest")).text().toLatin1());
+    m_resource = queryElement.firstChildElement(QSL("resource")).text();
 }
 
 void QXmppNonSASLAuthIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_auth);
     if (!m_username.isEmpty())
-        writer->writeTextElement("username", m_username);
+        writer->writeTextElement(QSL("username"), m_username);
     if (!m_digest.isEmpty())
-        writer->writeTextElement("digest", m_digest.toHex());
+        writer->writeTextElement(QSL("digest"), m_digest.toHex());
     if (!m_password.isEmpty())
-        writer->writeTextElement("password", m_password);
+        writer->writeTextElement(QSL("password"), m_password);
     if (!m_resource.isEmpty())
-        writer->writeTextElement("resource", m_resource);
+        writer->writeTextElement(QSL("resource"), m_resource);
     writer->writeEndElement();
 }
 /// \endcond

--- a/src/base/QXmppPingIq.cpp
+++ b/src/base/QXmppPingIq.cpp
@@ -34,14 +34,14 @@ QXmppPingIq::QXmppPingIq() : QXmppIq(QXmppIq::Get)
 
 bool QXmppPingIq::isPingIq(const QDomElement &element)
 {
-    QDomElement pingElement = element.firstChildElement("ping");
-    return (element.attribute("type") == "get" &&
+    QDomElement pingElement = element.firstChildElement(QSL("ping"));
+    return (element.attribute(QSL("type")) == QSL("get") &&
             pingElement.namespaceURI() == ns_ping);
 }
 
 void QXmppPingIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("ping");
+    writer->writeStartElement(QSL("ping"));
     writer->writeDefaultNamespace(ns_ping);
     writer->writeEndElement();
 }

--- a/src/base/QXmppPresence.cpp
+++ b/src/base/QXmppPresence.cpp
@@ -30,23 +30,23 @@
 #include <QDomElement>
 
 static const QStringList PRESENCE_TYPES = {
-    QStringLiteral("error"),
+    QSL("error"),
     QString(),
-    QStringLiteral("unavailable"),
-    QStringLiteral("subscribe"),
-    QStringLiteral("subscribed"),
-    QStringLiteral("unsubscribe"),
-    QStringLiteral("unsubscribed"),
-    QStringLiteral("probe")
+    QSL("unavailable"),
+    QSL("subscribe"),
+    QSL("subscribed"),
+    QSL("unsubscribe"),
+    QSL("unsubscribed"),
+    QSL("probe")
 };
 
 static const QStringList AVAILABLE_STATUS_TYPES = {
     QString(),
-    QStringLiteral("away"),
-    QStringLiteral("xa"),
-    QStringLiteral("dnd"),
-    QStringLiteral("chat"),
-    QStringLiteral("invisible")
+    QSL("away"),
+    QSL("xa"),
+    QSL("dnd"),
+    QSL("chat"),
+    QSL("invisible")
 };
 
 class QXmppPresencePrivate : public QSharedData
@@ -389,7 +389,7 @@ void QXmppPresence::parse(const QDomElement &element)
     QXmppStanza::parse(element);
 
     // attributes
-    int type = PRESENCE_TYPES.indexOf(element.attribute(QStringLiteral("type")));
+    int type = PRESENCE_TYPES.indexOf(element.attribute(QSL("type")));
     if (type > -1)
         d->type = Type(type);
 
@@ -397,17 +397,17 @@ void QXmppPresence::parse(const QDomElement &element)
     QDomElement childElement = element.firstChildElement();
 
     while (!childElement.isNull()) {
-        if (childElement.tagName() == QStringLiteral("show")) {
+        if (childElement.tagName() == QSL("show")) {
             int availableStatusType = AVAILABLE_STATUS_TYPES.indexOf(childElement.text());
             if (availableStatusType > -1)
                 d->availableStatusType = AvailableStatusType(availableStatusType);
-        } else if (childElement.tagName() == QStringLiteral("status")) {
+        } else if (childElement.tagName() == QSL("status")) {
             d->statusText = childElement.text();
-        } else if (childElement.tagName() == QStringLiteral("priority")) {
+        } else if (childElement.tagName() == QSL("priority")) {
             d->priority = childElement.text().toInt();
             // parse presence extensions
             // XEP-0033: Extended Stanza Addressing and errors are parsed by QXmppStanza
-        } else if (!(childElement.tagName() == QStringLiteral("addresses") && childElement.namespaceURI() == ns_extended_addressing) &&
+        } else if (!(childElement.tagName() == QSL("addresses") && childElement.namespaceURI() == ns_extended_addressing) &&
                    childElement.tagName() != "error") {
             parseExtension(childElement, unknownElements);
         }
@@ -420,28 +420,28 @@ void QXmppPresence::parse(const QDomElement &element)
 void QXmppPresence::parseExtension(const QDomElement &element, QXmppElementList &unknownElements)
 {
     // XEP-0045: Multi-User Chat
-    if (element.tagName() == QStringLiteral("x") && element.namespaceURI() == ns_muc) {
+    if (element.tagName() == QSL("x") && element.namespaceURI() == ns_muc) {
         d->mucSupported = true;
-        d->mucPassword = element.firstChildElement(QStringLiteral("password")).text();
-    } else if (element.tagName() == QStringLiteral("x") && element.namespaceURI() == ns_muc_user) {
-        QDomElement itemElement = element.firstChildElement(QStringLiteral("item"));
+        d->mucPassword = element.firstChildElement(QSL("password")).text();
+    } else if (element.tagName() == QSL("x") && element.namespaceURI() == ns_muc_user) {
+        QDomElement itemElement = element.firstChildElement(QSL("item"));
         d->mucItem.parse(itemElement);
-        QDomElement statusElement = element.firstChildElement(QStringLiteral("status"));
+        QDomElement statusElement = element.firstChildElement(QSL("status"));
         d->mucStatusCodes.clear();
 
         while (!statusElement.isNull()) {
-            d->mucStatusCodes << statusElement.attribute(QStringLiteral("code")).toInt();
-            statusElement = statusElement.nextSiblingElement(QStringLiteral("status"));
+            d->mucStatusCodes << statusElement.attribute(QSL("code")).toInt();
+            statusElement = statusElement.nextSiblingElement(QSL("status"));
         }
         // XEP-0115: Entity Capabilities
-    } else if (element.tagName() == QStringLiteral("c") && element.namespaceURI() == ns_capabilities) {
-        d->capabilityNode = element.attribute(QStringLiteral("node"));
-        d->capabilityVer = QByteArray::fromBase64(element.attribute(QStringLiteral("ver")).toLatin1());
-        d->capabilityHash = element.attribute(QStringLiteral("hash"));
-        d->capabilityExt = element.attribute(QStringLiteral("ext")).split(' ', QString::SkipEmptyParts);
+    } else if (element.tagName() == QSL("c") && element.namespaceURI() == ns_capabilities) {
+        d->capabilityNode = element.attribute(QSL("node"));
+        d->capabilityVer = QByteArray::fromBase64(element.attribute(QSL("ver")).toLatin1());
+        d->capabilityHash = element.attribute(QSL("hash"));
+        d->capabilityExt = element.attribute(QSL("ext")).split(' ', QString::SkipEmptyParts);
         // XEP-0153: vCard-Based Avatars
     } else if (element.namespaceURI() == ns_vcard_update) {
-        QDomElement photoElement = element.firstChildElement(QStringLiteral("photo"));
+        QDomElement photoElement = element.firstChildElement(QSL("photo"));
         if (photoElement.isNull()) {
             d->photoHash = {};
             d->vCardUpdateType = VCardUpdateNotReady;
@@ -453,15 +453,15 @@ void QXmppPresence::parseExtension(const QDomElement &element, QXmppElementList 
                 d->vCardUpdateType = VCardUpdateValidPhoto;
         }
         // XEP-0319: Last User Interaction in Presence
-    } else if (element.tagName() == QStringLiteral("idle") && element.namespaceURI() == ns_idle) {
-        if (element.hasAttribute(QStringLiteral("since"))) {
-            const QString since = element.attribute(QStringLiteral("since"));
+    } else if (element.tagName() == QSL("idle") && element.namespaceURI() == ns_idle) {
+        if (element.hasAttribute(QSL("since"))) {
+            const QString since = element.attribute(QSL("since"));
             d->lastUserInteraction = QXmppUtils::datetimeFromString(since);
         }
         // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    } else if (element.tagName() == QStringLiteral("mix") && element.namespaceURI() == ns_mix_presence) {
-        d->mixUserJid = element.firstChildElement(QStringLiteral("jid")).text();
-        d->mixUserNick = element.firstChildElement(QStringLiteral("nick")).text();
+    } else if (element.tagName() == QSL("mix") && element.namespaceURI() == ns_mix_presence) {
+        d->mixUserJid = element.firstChildElement(QSL("jid")).text();
+        d->mixUserNick = element.firstChildElement(QSL("nick")).text();
     } else {
         unknownElements << element;
     }
@@ -469,40 +469,40 @@ void QXmppPresence::parseExtension(const QDomElement &element, QXmppElementList 
 
 void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
 {
-    xmlWriter->writeStartElement(QStringLiteral("presence"));
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("xml:lang"), lang());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("id"), id());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("to"), to());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("from"), from());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("type"), PRESENCE_TYPES.at(d->type));
+    xmlWriter->writeStartElement(QSL("presence"));
+    helperToXmlAddAttribute(xmlWriter, QSL("xml:lang"), lang());
+    helperToXmlAddAttribute(xmlWriter, QSL("id"), id());
+    helperToXmlAddAttribute(xmlWriter, QSL("to"), to());
+    helperToXmlAddAttribute(xmlWriter, QSL("from"), from());
+    helperToXmlAddAttribute(xmlWriter, QSL("type"), PRESENCE_TYPES.at(d->type));
 
     const QString show = AVAILABLE_STATUS_TYPES.at(d->availableStatusType);
     if (!show.isEmpty())
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("show"), show);
+        helperToXmlAddTextElement(xmlWriter, QSL("show"), show);
     if (!d->statusText.isEmpty())
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("status"), d->statusText);
+        helperToXmlAddTextElement(xmlWriter, QSL("status"), d->statusText);
     if (d->priority != 0)
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("priority"), QString::number(d->priority));
+        helperToXmlAddTextElement(xmlWriter, QSL("priority"), QString::number(d->priority));
 
     error().toXml(xmlWriter);
 
     // XEP-0045: Multi-User Chat
     if (d->mucSupported) {
-        xmlWriter->writeStartElement(QStringLiteral("x"));
+        xmlWriter->writeStartElement(QSL("x"));
         xmlWriter->writeDefaultNamespace(ns_muc);
         if (!d->mucPassword.isEmpty())
-            xmlWriter->writeTextElement(QStringLiteral("password"), d->mucPassword);
+            xmlWriter->writeTextElement(QSL("password"), d->mucPassword);
         xmlWriter->writeEndElement();
     }
 
     if (!d->mucItem.isNull() || !d->mucStatusCodes.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("x"));
+        xmlWriter->writeStartElement(QSL("x"));
         xmlWriter->writeDefaultNamespace(ns_muc_user);
         if (!d->mucItem.isNull())
             d->mucItem.toXml(xmlWriter);
         for (const auto code : d->mucStatusCodes) {
-            xmlWriter->writeStartElement(QStringLiteral("status"));
-            xmlWriter->writeAttribute(QStringLiteral("code"), QString::number(code));
+            xmlWriter->writeStartElement(QSL("status"));
+            xmlWriter->writeAttribute(QSL("code"), QString::number(code));
             xmlWriter->writeEndElement();
         }
         xmlWriter->writeEndElement();
@@ -512,24 +512,24 @@ void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
     if (!d->capabilityNode.isEmpty() &&
         !d->capabilityVer.isEmpty() &&
         !d->capabilityHash.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("c"));
+        xmlWriter->writeStartElement(QSL("c"));
         xmlWriter->writeDefaultNamespace(ns_capabilities);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("hash"), d->capabilityHash);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("node"), d->capabilityNode);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("ver"), d->capabilityVer.toBase64());
+        helperToXmlAddAttribute(xmlWriter, QSL("hash"), d->capabilityHash);
+        helperToXmlAddAttribute(xmlWriter, QSL("node"), d->capabilityNode);
+        helperToXmlAddAttribute(xmlWriter, QSL("ver"), d->capabilityVer.toBase64());
         xmlWriter->writeEndElement();
     }
 
     // XEP-0153: vCard-Based Avatars
     if (d->vCardUpdateType != VCardUpdateNone) {
-        xmlWriter->writeStartElement(QStringLiteral("x"));
+        xmlWriter->writeStartElement(QSL("x"));
         xmlWriter->writeDefaultNamespace(ns_vcard_update);
         switch (d->vCardUpdateType) {
         case VCardUpdateNoPhoto:
-            xmlWriter->writeEmptyElement(QStringLiteral("photo"));
+            xmlWriter->writeEmptyElement(QSL("photo"));
             break;
         case VCardUpdateValidPhoto:
-            helperToXmlAddTextElement(xmlWriter, QStringLiteral("photo"), d->photoHash.toHex());
+            helperToXmlAddTextElement(xmlWriter, QSL("photo"), d->photoHash.toHex());
             break;
         default:
             break;
@@ -539,20 +539,20 @@ void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
 
     // XEP-0319: Last User Interaction in Presence
     if (!d->lastUserInteraction.isNull() && d->lastUserInteraction.isValid()) {
-        xmlWriter->writeStartElement(QStringLiteral("idle"));
+        xmlWriter->writeStartElement(QSL("idle"));
         xmlWriter->writeDefaultNamespace(ns_idle);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("since"), QXmppUtils::datetimeToString(d->lastUserInteraction));
+        helperToXmlAddAttribute(xmlWriter, QSL("since"), QXmppUtils::datetimeToString(d->lastUserInteraction));
         xmlWriter->writeEndElement();
     }
 
     // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
     if (!d->mixUserJid.isEmpty() || !d->mixUserNick.isEmpty()) {
-        xmlWriter->writeStartElement(QStringLiteral("mix"));
+        xmlWriter->writeStartElement(QSL("mix"));
         xmlWriter->writeDefaultNamespace(ns_mix_presence);
         if (!d->mixUserJid.isEmpty())
-            helperToXmlAddTextElement(xmlWriter, QStringLiteral("jid"), d->mixUserJid);
+            helperToXmlAddTextElement(xmlWriter, QSL("jid"), d->mixUserJid);
         if (!d->mixUserNick.isEmpty())
-            helperToXmlAddTextElement(xmlWriter, QStringLiteral("nick"), d->mixUserNick);
+            helperToXmlAddTextElement(xmlWriter, QSL("nick"), d->mixUserNick);
         xmlWriter->writeEndElement();
     }
 

--- a/src/base/QXmppPubSubIq.cpp
+++ b/src/base/QXmppPubSubIq.cpp
@@ -30,15 +30,15 @@
 #include <QSharedData>
 
 static const QStringList PUBSUB_QUERIES = {
-    QStringLiteral("affiliations"),
-    QStringLiteral("default"),
-    QStringLiteral("items"),
-    QStringLiteral("publish"),
-    QStringLiteral("retract"),
-    QStringLiteral("subscribe"),
-    QStringLiteral("subscription"),
-    QStringLiteral("subscriptions"),
-    QStringLiteral("unsubscribe"),
+    QSL("affiliations"),
+    QSL("default"),
+    QSL("items"),
+    QSL("publish"),
+    QSL("retract"),
+    QSL("subscribe"),
+    QSL("subscription"),
+    QSL("subscriptions"),
+    QSL("unsubscribe"),
 };
 
 class QXmppPubSubIqPrivate : public QSharedData
@@ -153,12 +153,12 @@ void QXmppPubSubIq::setItems(const QList<QXmppPubSubItem> &items)
 /// \cond
 bool QXmppPubSubIq::isPubSubIq(const QDomElement &element)
 {
-    return element.firstChildElement("pubsub").namespaceURI() == ns_pubsub;
+    return element.firstChildElement(QSL("pubsub")).namespaceURI() == ns_pubsub;
 }
 
 void QXmppPubSubIq::parseElementFromChild(const QDomElement &element)
 {
-    const QDomElement pubSubElement = element.firstChildElement("pubsub");
+    const QDomElement pubSubElement = element.firstChildElement(QSL("pubsub"));
 
     const QDomElement queryElement = pubSubElement.firstChildElement();
 
@@ -168,8 +168,8 @@ void QXmppPubSubIq::parseElementFromChild(const QDomElement &element)
     if (queryType > -1)
         d->queryType = QueryType(queryType);
 
-    d->queryJid = queryElement.attribute("jid");
-    d->queryNode = queryElement.attribute("node");
+    d->queryJid = queryElement.attribute(QSL("jid"));
+    d->queryNode = queryElement.attribute(QSL("node"));
 
     // parse contents
     QDomElement childElement;
@@ -177,17 +177,17 @@ void QXmppPubSubIq::parseElementFromChild(const QDomElement &element)
     case QXmppPubSubIq::ItemsQuery:
     case QXmppPubSubIq::PublishQuery:
     case QXmppPubSubIq::RetractQuery:
-        childElement = queryElement.firstChildElement("item");
+        childElement = queryElement.firstChildElement(QSL("item"));
         while (!childElement.isNull()) {
             QXmppPubSubItem item;
             item.parse(childElement);
             d->items << item;
-            childElement = childElement.nextSiblingElement("item");
+            childElement = childElement.nextSiblingElement(QSL("item"));
         }
         break;
     case QXmppPubSubIq::SubscriptionQuery:
-        d->subscriptionId = queryElement.attribute("subid");
-        d->subscriptionType = queryElement.attribute("subscription");
+        d->subscriptionId = queryElement.attribute(QSL("subid"));
+        d->subscriptionType = queryElement.attribute(QSL("subscription"));
         break;
     default:
         break;
@@ -196,13 +196,13 @@ void QXmppPubSubIq::parseElementFromChild(const QDomElement &element)
 
 void QXmppPubSubIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("pubsub");
+    writer->writeStartElement(QSL("pubsub"));
     writer->writeDefaultNamespace(ns_pubsub);
 
     // write query type
     writer->writeStartElement(PUBSUB_QUERIES.at(d->queryType));
-    helperToXmlAddAttribute(writer, "jid", d->queryJid);
-    helperToXmlAddAttribute(writer, "node", d->queryNode);
+    helperToXmlAddAttribute(writer, QSL("jid"), d->queryJid);
+    helperToXmlAddAttribute(writer, QSL("node"), d->queryNode);
 
     // write contents
     switch (d->queryType) {
@@ -213,8 +213,8 @@ void QXmppPubSubIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
             item.toXml(writer);
         break;
     case QXmppPubSubIq::SubscriptionQuery:
-        helperToXmlAddAttribute(writer, "subid", d->subscriptionId);
-        helperToXmlAddAttribute(writer, "subscription", d->subscriptionType);
+        helperToXmlAddAttribute(writer, QSL("subid"), d->subscriptionId);
+        helperToXmlAddAttribute(writer, QSL("subscription"), d->subscriptionType);
         break;
     default:
         break;

--- a/src/base/QXmppPubSubItem.cpp
+++ b/src/base/QXmppPubSubItem.cpp
@@ -81,14 +81,14 @@ void QXmppPubSubItem::setContents(const QXmppElement &contents)
 /// \cond
 void QXmppPubSubItem::parse(const QDomElement &element)
 {
-    d->id = element.attribute("id");
+    d->id = element.attribute(QSL("id"));
     d->contents = QXmppElement(element.firstChildElement());
 }
 
 void QXmppPubSubItem::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("item");
-    helperToXmlAddAttribute(writer, "id", d->id);
+    writer->writeStartElement(QSL("item"));
+    helperToXmlAddAttribute(writer, QSL("id"), d->id);
     d->contents.toXml(writer);
     writer->writeEndElement();
 }

--- a/src/base/QXmppRegisterIq.cpp
+++ b/src/base/QXmppRegisterIq.cpp
@@ -30,8 +30,8 @@
 #include <QDomElement>
 #include <QSharedData>
 
-#define ELEMENT_REGISTERED QStringLiteral("registered")
-#define ELEMENT_REMOVE QStringLiteral("remove")
+#define ELEMENT_REGISTERED QSL("registered")
+#define ELEMENT_REMOVE QSL("remove")
 
 class QXmppRegisterIqPrivate : public QSharedData
 {
@@ -260,17 +260,17 @@ void QXmppRegisterIq::setBitsOfBinaryData(const QXmppBitsOfBinaryDataList &bitsO
 /// \cond
 bool QXmppRegisterIq::isRegisterIq(const QDomElement &element)
 {
-    return (element.firstChildElement("query").namespaceURI() == ns_register);
+    return (element.firstChildElement(QSL("query")).namespaceURI() == ns_register);
 }
 
 void QXmppRegisterIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    d->instructions = queryElement.firstChildElement("instructions").text();
-    d->username = queryElement.firstChildElement("username").text();
-    d->password = queryElement.firstChildElement("password").text();
-    d->email = queryElement.firstChildElement("email").text();
-    d->form.parse(queryElement.firstChildElement("x"));
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    d->instructions = queryElement.firstChildElement(QSL("instructions")).text();
+    d->username = queryElement.firstChildElement(QSL("username")).text();
+    d->password = queryElement.firstChildElement(QSL("password")).text();
+    d->email = queryElement.firstChildElement(QSL("email")).text();
+    d->form.parse(queryElement.firstChildElement(QSL("x")));
     d->isRegistered = !queryElement.firstChildElement(ELEMENT_REGISTERED).isNull();
     d->isRemove = !queryElement.firstChildElement(ELEMENT_REMOVE).isNull();
     d->bitsOfBinaryData.parse(queryElement);
@@ -278,11 +278,11 @@ void QXmppRegisterIq::parseElementFromChild(const QDomElement &element)
 
 void QXmppRegisterIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_register);
 
     if (!d->instructions.isEmpty())
-        writer->writeTextElement("instructions", d->instructions);
+        writer->writeTextElement(QSL("instructions"), d->instructions);
 
     if (d->isRegistered)
         writer->writeEmptyElement(ELEMENT_REGISTERED);
@@ -290,19 +290,19 @@ void QXmppRegisterIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
         writer->writeEmptyElement(ELEMENT_REMOVE);
 
     if (!d->username.isEmpty())
-        writer->writeTextElement("username", d->username);
+        writer->writeTextElement(QSL("username"), d->username);
     else if (!d->username.isNull())
-        writer->writeEmptyElement("username");
+        writer->writeEmptyElement(QSL("username"));
 
     if (!d->password.isEmpty())
-        writer->writeTextElement("password", d->password);
+        writer->writeTextElement(QSL("password"), d->password);
     else if (!d->password.isNull())
-        writer->writeEmptyElement("password");
+        writer->writeEmptyElement(QSL("password"));
 
     if (!d->email.isEmpty())
-        writer->writeTextElement("email", d->email);
+        writer->writeTextElement(QSL("email"), d->email);
     else if (!d->email.isNull())
-        writer->writeEmptyElement("email");
+        writer->writeEmptyElement(QSL("email"));
 
     d->form.toXml(writer);
     d->bitsOfBinaryData.toXml(writer);

--- a/src/base/QXmppResultSet.cpp
+++ b/src/base/QXmppResultSet.cpp
@@ -117,15 +117,15 @@ bool QXmppResultSetQuery::isNull() const
 /// \cond
 void QXmppResultSetQuery::parse(const QDomElement& element)
 {
-    QDomElement setElement = (element.tagName() == "set") ? element : element.firstChildElement("set");
+    QDomElement setElement = (element.tagName() == QSL("set")) ? element : element.firstChildElement(QSL("set"));
     if (setElement.namespaceURI() == ns_rsm) {
         bool ok = false;
-        m_max = setElement.firstChildElement("max").text().toInt(&ok);
+        m_max = setElement.firstChildElement(QSL("max")).text().toInt(&ok);
         if (!ok)
             m_max = -1;
-        m_after = setElement.firstChildElement("after").text();
-        m_before = setElement.firstChildElement("before").text();
-        m_index = setElement.firstChildElement("index").text().toInt(&ok);
+        m_after = setElement.firstChildElement(QSL("after")).text();
+        m_before = setElement.firstChildElement(QSL("before")).text();
+        m_index = setElement.firstChildElement(QSL("index")).text().toInt(&ok);
         if (!ok)
             m_index = -1;
     }
@@ -135,16 +135,16 @@ void QXmppResultSetQuery::toXml(QXmlStreamWriter* writer) const
 {
     if (isNull())
         return;
-    writer->writeStartElement("set");
+    writer->writeStartElement(QSL("set"));
     writer->writeDefaultNamespace(ns_rsm);
     if (m_max >= 0)
-        helperToXmlAddTextElement(writer, "max", QString::number(m_max));
+        helperToXmlAddTextElement(writer, QSL("max"), QString::number(m_max));
     if (!m_after.isNull())
-        helperToXmlAddTextElement(writer, "after", m_after);
+        helperToXmlAddTextElement(writer, QSL("after"), m_after);
     if (!m_before.isNull())
-        helperToXmlAddTextElement(writer, "before", m_before);
+        helperToXmlAddTextElement(writer, QSL("before"), m_before);
     if (m_index >= 0)
-        helperToXmlAddTextElement(writer, "index", QString::number(m_index));
+        helperToXmlAddTextElement(writer, QSL("index"), QString::number(m_index));
     writer->writeEndElement();
 }
 /// \endcond

--- a/src/base/QXmppRosterIq.cpp
+++ b/src/base/QXmppRosterIq.cpp
@@ -112,40 +112,40 @@ void QXmppRosterIq::setMixAnnotate(bool mixAnnotate)
 /// \cond
 bool QXmppRosterIq::isRosterIq(const QDomElement &element)
 {
-    return (element.firstChildElement("query").namespaceURI() == ns_roster);
+    return (element.firstChildElement(QSL("query")).namespaceURI() == ns_roster);
 }
 
 void QXmppRosterIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    setVersion(queryElement.attribute("ver"));
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    setVersion(queryElement.attribute(QSL("ver")));
 
-    QDomElement itemElement = queryElement.firstChildElement("item");
+    QDomElement itemElement = queryElement.firstChildElement(QSL("item"));
     while (!itemElement.isNull()) {
         QXmppRosterIq::Item item;
         item.parse(itemElement);
         d->items.append(item);
-        itemElement = itemElement.nextSiblingElement("item");
+        itemElement = itemElement.nextSiblingElement(QSL("item"));
     }
 
-    QDomElement annotateElement = queryElement.firstChildElement("annotate");
+    QDomElement annotateElement = queryElement.firstChildElement(QSL("annotate"));
     setMixAnnotate(!annotateElement.isNull() && annotateElement.namespaceURI()
                    == ns_mix_roster);
 }
 
 void QXmppRosterIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_roster);
 
     // XEP-0237 roster versioning - If the server does not advertise support for roster versioning, the client MUST NOT include the 'ver' attribute.
     if (!version().isEmpty())
-        writer->writeAttribute("ver", version());
+        writer->writeAttribute(QSL("ver"), version());
 
     // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
     if (d->mixAnnotate) {
-        writer->writeStartElement("annotate");
-        writer->writeAttribute("xmlns", ns_mix_roster);
+        writer->writeStartElement(QSL("annotate"));
+        writer->writeAttribute(QSL("xmlns"), ns_mix_roster);
         writer->writeEndElement();
     }
 
@@ -310,17 +310,17 @@ QString QXmppRosterIq::Item::getSubscriptionTypeStr() const
 
 void QXmppRosterIq::Item::setSubscriptionTypeFromStr(const QString &type)
 {
-    if (type == "")
+    if (type.isEmpty() && !type.isNull()) // TODO CHECK
         setSubscriptionType(NotSet);
-    else if (type == "none")
+    else if (type == QSL("none"))
         setSubscriptionType(None);
-    else if (type == "both")
+    else if (type == QSL("both"))
         setSubscriptionType(Both);
-    else if (type == "from")
+    else if (type == QSL("from"))
         setSubscriptionType(From);
-    else if (type == "to")
+    else if (type == QSL("to"))
         setSubscriptionType(To);
-    else if (type == "remove")
+    else if (type == QSL("remove"))
         setSubscriptionType(Remove);
     else
         qWarning("QXmppRosterIq::Item::setTypeFromStr(): invalid type");
@@ -369,44 +369,44 @@ void QXmppRosterIq::Item::setMixParticipantId(const QString& participantId)
 /// \cond
 void QXmppRosterIq::Item::parse(const QDomElement &element)
 {
-    d->name = element.attribute("name");
-    d->bareJid = element.attribute("jid");
-    setSubscriptionTypeFromStr(element.attribute("subscription"));
-    setSubscriptionStatus(element.attribute("ask"));
+    d->name = element.attribute(QSL("name"));
+    d->bareJid = element.attribute(QSL("jid"));
+    setSubscriptionTypeFromStr(element.attribute(QSL("subscription")));
+    setSubscriptionStatus(element.attribute(QSL("ask")));
 
-    QDomElement groupElement = element.firstChildElement("group");
+    QDomElement groupElement = element.firstChildElement(QSL("group"));
     while (!groupElement.isNull()) {
         d->groups << groupElement.text();
-        groupElement = groupElement.nextSiblingElement("group");
+        groupElement = groupElement.nextSiblingElement(QSL("group"));
     }
 
     // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
-    QDomElement channelElement = element.firstChildElement("channel");
+    QDomElement channelElement = element.firstChildElement(QSL("channel"));
     if (!channelElement.isNull() && channelElement.namespaceURI() == ns_mix_roster) {
         d->isMixChannel = true;
-        d->mixParticipantId = channelElement.attribute("participant-id");
+        d->mixParticipantId = channelElement.attribute(QSL("participant-id"));
     }
 }
 
 void QXmppRosterIq::Item::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("item");
-    helperToXmlAddAttribute(writer, "jid", d->bareJid);
-    helperToXmlAddAttribute(writer, "name", d->name);
-    helperToXmlAddAttribute(writer, "subscription", getSubscriptionTypeStr());
-    helperToXmlAddAttribute(writer, "ask", subscriptionStatus());
+    writer->writeStartElement(QSL("item"));
+    helperToXmlAddAttribute(writer, QSL("jid"), d->bareJid);
+    helperToXmlAddAttribute(writer, QSL("name"), d->name);
+    helperToXmlAddAttribute(writer, QSL("subscription"), getSubscriptionTypeStr());
+    helperToXmlAddAttribute(writer, QSL("ask"), subscriptionStatus());
 
     QSet<QString>::const_iterator i = d->groups.constBegin();
     while (i != d->groups.constEnd()) {
-        helperToXmlAddTextElement(writer, "group", *i);
+        helperToXmlAddTextElement(writer, QSL("group"), *i);
         ++i;
     }
 
     // XEP-0405: Mediated Information eXchange (MIX): Participant Server Requirements
     if (d->isMixChannel) {
-        writer->writeStartElement("channel");
-        writer->writeAttribute("xmlns", ns_mix_roster);
-        helperToXmlAddAttribute(writer, "participant-id", d->mixParticipantId);
+        writer->writeStartElement(QSL("channel"));
+        writer->writeAttribute(QSL("xmlns"), ns_mix_roster);
+        helperToXmlAddAttribute(writer, QSL("participant-id"), d->mixParticipantId);
         writer->writeEndElement();
     }
 

--- a/src/base/QXmppRosterIq.cpp
+++ b/src/base/QXmppRosterIq.cpp
@@ -129,8 +129,7 @@ void QXmppRosterIq::parseElementFromChild(const QDomElement &element)
     }
 
     QDomElement annotateElement = queryElement.firstChildElement(QSL("annotate"));
-    setMixAnnotate(!annotateElement.isNull() && annotateElement.namespaceURI()
-                   == ns_mix_roster);
+    setMixAnnotate(!annotateElement.isNull() && annotateElement.namespaceURI() == ns_mix_roster);
 }
 
 void QXmppRosterIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
@@ -310,7 +309,7 @@ QString QXmppRosterIq::Item::getSubscriptionTypeStr() const
 
 void QXmppRosterIq::Item::setSubscriptionTypeFromStr(const QString &type)
 {
-    if (type.isEmpty() && !type.isNull()) // TODO CHECK
+    if (type.isEmpty() && !type.isNull())  // TODO CHECK
         setSubscriptionType(NotSet);
     else if (type == QSL("none"))
         setSubscriptionType(None);
@@ -361,7 +360,7 @@ QString QXmppRosterIq::Item::mixParticipantId() const
 ///
 /// \since QXmpp 1.3
 ///
-void QXmppRosterIq::Item::setMixParticipantId(const QString& participantId)
+void QXmppRosterIq::Item::setMixParticipantId(const QString &participantId)
 {
     d->mixParticipantId = participantId;
 }

--- a/src/base/QXmppRosterIq.h
+++ b/src/base/QXmppRosterIq.h
@@ -84,7 +84,7 @@ public:
         void setIsMixChannel(bool);
 
         QString mixParticipantId() const;
-        void setMixParticipantId(const QString&);
+        void setMixParticipantId(const QString &);
 
         /// \cond
         void parse(const QDomElement &element);

--- a/src/base/QXmppRpcIq.cpp
+++ b/src/base/QXmppRpcIq.cpp
@@ -35,33 +35,33 @@
 
 void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &value)
 {
-    writer->writeStartElement("value");
+    writer->writeStartElement(QSL("value"));
     switch (value.type()) {
     case QVariant::Int:
     case QVariant::UInt:
     case QVariant::LongLong:
     case QVariant::ULongLong:
-        writer->writeTextElement("i4", value.toString());
+        writer->writeTextElement(QSL("i4"), value.toString());
         break;
     case QVariant::Double:
-        writer->writeTextElement("double", value.toString());
+        writer->writeTextElement(QSL("double"), value.toString());
         break;
     case QVariant::Bool:
-        writer->writeTextElement("boolean", value.toBool() ? "1" : "0");
+        writer->writeTextElement(QSL("boolean"), value.toBool() ? QSL("1") : QSL("0"));
         break;
     case QVariant::Date:
-        writer->writeTextElement("dateTime.iso8601", value.toDate().toString(Qt::ISODate));
+        writer->writeTextElement(QSL("dateTime.iso8601"), value.toDate().toString(Qt::ISODate));
         break;
     case QVariant::DateTime:
-        writer->writeTextElement("dateTime.iso8601", value.toDateTime().toString(Qt::ISODate));
+        writer->writeTextElement(QSL("dateTime.iso8601"), value.toDateTime().toString(Qt::ISODate));
         break;
     case QVariant::Time:
-        writer->writeTextElement("dateTime.iso8601", value.toTime().toString(Qt::ISODate));
+        writer->writeTextElement(QSL("dateTime.iso8601"), value.toTime().toString(Qt::ISODate));
         break;
     case QVariant::StringList:
     case QVariant::List: {
-        writer->writeStartElement("array");
-        writer->writeStartElement("data");
+        writer->writeStartElement(QSL("array"));
+        writer->writeStartElement(QSL("data"));
         for (const auto &item : value.toList())
             marshall(writer, item);
         writer->writeEndElement();
@@ -69,12 +69,12 @@ void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &valu
         break;
     }
     case QVariant::Map: {
-        writer->writeStartElement("struct");
+        writer->writeStartElement(QSL("struct"));
         QMap<QString, QVariant> map = value.toMap();
         QMap<QString, QVariant>::ConstIterator index = map.begin();
         while (index != map.end()) {
-            writer->writeStartElement("member");
-            writer->writeTextElement("name", index.key());
+            writer->writeStartElement(QSL("member"));
+            writer->writeTextElement(QSL("name"), index.key());
             marshall(writer, *index);
             writer->writeEndElement();
             ++index;
@@ -83,14 +83,14 @@ void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &valu
         break;
     }
     case QVariant::ByteArray: {
-        writer->writeTextElement("base64", value.toByteArray().toBase64());
+        writer->writeTextElement(QSL("base64"), value.toByteArray().toBase64());
         break;
     }
     default: {
         if (value.isNull())
-            writer->writeEmptyElement("nil");
+            writer->writeEmptyElement(QSL("nil"));
         else if (value.canConvert(QVariant::String)) {
-            writer->writeTextElement("string", value.toString());
+            writer->writeTextElement(QSL("string"), value.toString());
         }
         break;
     }
@@ -100,7 +100,7 @@ void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &valu
 
 QVariant QXmppRpcMarshaller::demarshall(const QDomElement &elem, QStringList &errors)
 {
-    if (elem.tagName().toLower() != "value") {
+    if (elem.tagName().toLower() != QSL("value")) {
         errors << "Bad param value";
         return QVariant();
     }
@@ -112,54 +112,54 @@ QVariant QXmppRpcMarshaller::demarshall(const QDomElement &elem, QStringList &er
     const QDomElement typeData = elem.firstChild().toElement();
     const QString typeName = typeData.tagName().toLower();
 
-    if (typeName == "nil") {
+    if (typeName == QSL("nil")) {
         return QVariant();
     }
-    if (typeName == "string") {
+    if (typeName == QSL("string")) {
         return QVariant(typeData.text());
-    } else if (typeName == "int" || typeName == "i4") {
+    } else if (typeName == QSL("int") || typeName == QSL("i4")) {
         bool ok = false;
         QVariant val(typeData.text().toInt(&ok));
         if (ok)
             return val;
         errors << "I was looking for an integer but data was courupt";
         return QVariant();
-    } else if (typeName == "double") {
+    } else if (typeName == QSL("double")) {
         bool ok = false;
         QVariant val(typeData.text().toDouble(&ok));
         if (ok)
             return val;
         errors << "I was looking for an double but data was corrupt";
-    } else if (typeName == "boolean")
-        return QVariant(typeData.text() == "1" || typeData.text().toLower() == "true");
-    else if (typeName == "datetime" || typeName == "datetime.iso8601")
+    } else if (typeName == QSL("boolean"))
+        return QVariant(typeData.text() == QSL("1") || typeData.text().toLower() == QSL("true"));
+    else if (typeName == QSL("datetime") || typeName == QSL("datetime.iso8601"))
         return QVariant(QDateTime::fromString(typeData.text(), Qt::ISODate));
-    else if (typeName == "array") {
+    else if (typeName == QSL("array")) {
         QVariantList arr;
-        QDomElement valueNode = typeData.firstChildElement("data").firstChildElement();
+        QDomElement valueNode = typeData.firstChildElement(QSL("data")).firstChildElement();
         while (!valueNode.isNull() && errors.isEmpty()) {
             arr.append(demarshall(valueNode, errors));
             valueNode = valueNode.nextSiblingElement();
         }
         return QVariant(arr);
-    } else if (typeName == "struct") {
+    } else if (typeName == QSL("struct")) {
         QMap<QString, QVariant> stct;
         QDomNode valueNode = typeData.firstChild();
         while (!valueNode.isNull() && errors.isEmpty()) {
-            const QDomElement memberNode = valueNode.toElement().elementsByTagName("name").item(0).toElement();
-            const QDomElement dataNode = valueNode.toElement().elementsByTagName("value").item(0).toElement();
+            const QDomElement memberNode = valueNode.toElement().elementsByTagName(QSL("name")).item(0).toElement();
+            const QDomElement dataNode = valueNode.toElement().elementsByTagName(QSL("value")).item(0).toElement();
             stct[memberNode.text()] = demarshall(dataNode, errors);
             valueNode = valueNode.nextSibling();
         }
         return QVariant(stct);
-    } else if (typeName == "base64") {
+    } else if (typeName == QSL("base64")) {
         QVariant returnVariant;
         QByteArray dest;
         QByteArray src = typeData.text().toLatin1();
         return QVariant(QByteArray::fromBase64(src));
     }
 
-    errors << QString("Cannot handle type %1").arg(typeName);
+    errors << QSL("Cannot handle type %1").arg(typeName);
     return QVariant();
 }
 
@@ -180,10 +180,10 @@ void QXmppRpcErrorIq::setQuery(const QXmppRpcInvokeIq &query)
 /// \cond
 bool QXmppRpcErrorIq::isRpcErrorIq(const QDomElement &element)
 {
-    QString type = element.attribute("type");
-    QDomElement errorElement = element.firstChildElement("error");
-    QDomElement queryElement = element.firstChildElement("query");
-    return (type == "error") &&
+    QString type = element.attribute(QSL("type"));
+    QDomElement errorElement = element.firstChildElement(QSL("error"));
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    return (type == QSL("error")) &&
         !errorElement.isNull() &&
         queryElement.namespaceURI() == ns_rpc;
 }
@@ -259,56 +259,56 @@ void QXmppRpcResponseIq::setValues(const QVariantList &values)
 /// \cond
 bool QXmppRpcResponseIq::isRpcResponseIq(const QDomElement &element)
 {
-    QString type = element.attribute("type");
-    QDomElement dataElement = element.firstChildElement("query");
+    QString type = element.attribute(QSL("type"));
+    QDomElement dataElement = element.firstChildElement(QSL("query"));
     return dataElement.namespaceURI() == ns_rpc &&
-        type == "result";
+        type == QSL("result");
 }
 
 void QXmppRpcResponseIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    QDomElement methodElement = queryElement.firstChildElement("methodResponse");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    QDomElement methodElement = queryElement.firstChildElement(QSL("methodResponse"));
 
     const QDomElement contents = methodElement.firstChildElement();
-    if (contents.tagName().toLower() == "params") {
-        QDomNode param = contents.firstChildElement("param");
+    if (contents.tagName().toLower() == QSL("params")) {
+        QDomNode param = contents.firstChildElement(QSL("param"));
         while (!param.isNull()) {
             QStringList errors;
-            const QVariant value = QXmppRpcMarshaller::demarshall(param.firstChildElement("value"), errors);
+            const QVariant value = QXmppRpcMarshaller::demarshall(param.firstChildElement(QSL("value")), errors);
             if (!errors.isEmpty())
                 break;
             m_values << value;
-            param = param.nextSiblingElement("param");
+            param = param.nextSiblingElement(QSL("param"));
         }
-    } else if (contents.tagName().toLower() == "fault") {
+    } else if (contents.tagName().toLower() == QSL("fault")) {
         QStringList errors;
-        const QDomElement errElement = contents.firstChildElement("value");
+        const QDomElement errElement = contents.firstChildElement(QSL("value"));
         const QVariant error = QXmppRpcMarshaller::demarshall(errElement, errors);
         if (!errors.isEmpty())
             return;
-        m_faultCode = error.toMap()["faultCode"].toInt();
-        m_faultString = error.toMap()["faultString"].toString();
+        m_faultCode = error.toMap()[QSL("faultCode")].toInt();
+        m_faultString = error.toMap()[QSL("faultString")].toString();
     }
 }
 
 void QXmppRpcResponseIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_rpc);
 
-    writer->writeStartElement("methodResponse");
+    writer->writeStartElement(QSL("methodResponse"));
     if (m_faultCode) {
-        writer->writeStartElement("fault");
+        writer->writeStartElement(QSL("fault"));
         QMap<QString, QVariant> fault;
-        fault["faultCode"] = m_faultCode;
-        fault["faultString"] = m_faultString;
+        fault[QSL("faultCode")] = m_faultCode;
+        fault[QSL("faultString")] = m_faultString;
         QXmppRpcMarshaller::marshall(writer, fault);
         writer->writeEndElement();
     } else if (!m_values.isEmpty()) {
-        writer->writeStartElement("params");
+        writer->writeStartElement(QSL("params"));
         for (const auto &arg : m_values) {
-            writer->writeStartElement("param");
+            writer->writeStartElement(QSL("param"));
             QXmppRpcMarshaller::marshall(writer, arg);
             writer->writeEndElement();
         }
@@ -362,45 +362,45 @@ void QXmppRpcInvokeIq::setMethod(const QString &method)
 /// \cond
 bool QXmppRpcInvokeIq::isRpcInvokeIq(const QDomElement &element)
 {
-    QString type = element.attribute("type");
-    QDomElement dataElement = element.firstChildElement("query");
+    QString type = element.attribute(QSL("type"));
+    QDomElement dataElement = element.firstChildElement(QSL("query"));
     return dataElement.namespaceURI() == ns_rpc &&
-        type == "set";
+        type == QSL("set");
 }
 
 void QXmppRpcInvokeIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    QDomElement methodElement = queryElement.firstChildElement("methodCall");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    QDomElement methodElement = queryElement.firstChildElement(QSL("methodCall"));
 
-    m_method = methodElement.firstChildElement("methodName").text();
+    m_method = methodElement.firstChildElement(QSL("methodName")).text();
 
-    const QDomElement methodParams = methodElement.firstChildElement("params");
+    const QDomElement methodParams = methodElement.firstChildElement(QSL("params"));
     m_arguments.clear();
     if (!methodParams.isNull()) {
-        QDomNode param = methodParams.firstChildElement("param");
+        QDomNode param = methodParams.firstChildElement(QSL("param"));
         while (!param.isNull()) {
             QStringList errors;
-            QVariant arg = QXmppRpcMarshaller::demarshall(param.firstChildElement("value"), errors);
+            QVariant arg = QXmppRpcMarshaller::demarshall(param.firstChildElement(QSL("value")), errors);
             if (!errors.isEmpty())
                 break;
             m_arguments << arg;
-            param = param.nextSiblingElement("param");
+            param = param.nextSiblingElement(QSL("param"));
         }
     }
 }
 
 void QXmppRpcInvokeIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_rpc);
 
-    writer->writeStartElement("methodCall");
-    writer->writeTextElement("methodName", m_method);
+    writer->writeStartElement(QSL("methodCall"));
+    writer->writeTextElement(QSL("methodName"), m_method);
     if (!m_arguments.isEmpty()) {
-        writer->writeStartElement("params");
+        writer->writeStartElement(QSL("params"));
         for (const auto &arg : m_arguments) {
-            writer->writeStartElement("param");
+            writer->writeStartElement(QSL("param"));
             QXmppRpcMarshaller::marshall(writer, arg);
             writer->writeEndElement();
         }

--- a/src/base/QXmppSasl.cpp
+++ b/src/base/QXmppSasl.cpp
@@ -27,6 +27,7 @@
 
 #include <cstdlib>
 
+#include <QByteArray>
 #include <QDomElement>
 #include <QMessageAuthenticationCode>
 #include <QStringList>
@@ -130,15 +131,15 @@ void QXmppSaslAuth::setValue(const QByteArray &value)
 
 void QXmppSaslAuth::parse(const QDomElement &element)
 {
-    m_mechanism = element.attribute("mechanism");
+    m_mechanism = element.attribute(QSL("mechanism"));
     m_value = QByteArray::fromBase64(element.text().toLatin1());
 }
 
 void QXmppSaslAuth::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("auth");
+    writer->writeStartElement(QSL("auth"));
     writer->writeDefaultNamespace(ns_xmpp_sasl);
-    writer->writeAttribute("mechanism", m_mechanism);
+    writer->writeAttribute(QSL("mechanism"), m_mechanism);
     if (!m_value.isEmpty())
         writer->writeCharacters(m_value.toBase64());
     writer->writeEndElement();
@@ -166,7 +167,7 @@ void QXmppSaslChallenge::parse(const QDomElement &element)
 
 void QXmppSaslChallenge::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("challenge");
+    writer->writeStartElement(QSL("challenge"));
     writer->writeDefaultNamespace(ns_xmpp_sasl);
     if (!m_value.isEmpty())
         writer->writeCharacters(m_value.toBase64());
@@ -195,7 +196,7 @@ void QXmppSaslFailure::parse(const QDomElement &element)
 
 void QXmppSaslFailure::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("failure");
+    writer->writeStartElement(QSL("failure"));
     writer->writeDefaultNamespace(ns_xmpp_sasl);
     if (!m_condition.isEmpty())
         writer->writeEmptyElement(m_condition);
@@ -224,7 +225,7 @@ void QXmppSaslResponse::parse(const QDomElement &element)
 
 void QXmppSaslResponse::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("response");
+    writer->writeStartElement(QSL("response"));
     writer->writeDefaultNamespace(ns_xmpp_sasl);
     if (!m_value.isEmpty())
         writer->writeCharacters(m_value.toBase64());
@@ -242,7 +243,7 @@ void QXmppSaslSuccess::parse(const QDomElement &element)
 
 void QXmppSaslSuccess::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("success");
+    writer->writeStartElement(QSL("success"));
     writer->writeDefaultNamespace(ns_xmpp_sasl);
     writer->writeEndElement();
 }
@@ -270,35 +271,35 @@ QXmppSaslClient::~QXmppSaslClient()
 
 QStringList QXmppSaslClient::availableMechanisms()
 {
-    return QStringList() << "SCRAM-SHA-256"
-                         << "SCRAM-SHA-1"
-                         << "DIGEST-MD5"
-                         << "PLAIN"
-                         << "ANONYMOUS"
-                         << "X-FACEBOOK-PLATFORM"
-                         << "X-MESSENGER-OAUTH2"
-                         << "X-OAUTH2";
+    return QStringList() << QSL("SCRAM-SHA-256")
+                         << QSL("SCRAM-SHA-1")
+                         << QSL("DIGEST-MD5")
+                         << QSL("PLAIN")
+                         << QSL("ANONYMOUS")
+                         << QSL("X-FACEBOOK-PLATFORM")
+                         << QSL("X-MESSENGER-OAUTH2")
+                         << QSL("X-OAUTH2");
 }
 
 /// Creates an SASL client for the given mechanism.
 
 QXmppSaslClient *QXmppSaslClient::create(const QString &mechanism, QObject *parent)
 {
-    if (mechanism == "PLAIN") {
+    if (mechanism == QSL("PLAIN")) {
         return new QXmppSaslClientPlain(parent);
-    } else if (mechanism == "DIGEST-MD5") {
+    } else if (mechanism == QSL("DIGEST-MD5")) {
         return new QXmppSaslClientDigestMd5(parent);
-    } else if (mechanism == "ANONYMOUS") {
+    } else if (mechanism == QSL("ANONYMOUS")) {
         return new QXmppSaslClientAnonymous(parent);
-    } else if (mechanism == "SCRAM-SHA-1") {
+    } else if (mechanism == QSL("SCRAM-SHA-1")) {
         return new QXmppSaslClientScram(QCryptographicHash::Sha1, parent);
-    } else if (mechanism == "SCRAM-SHA-256") {
+    } else if (mechanism == QSL("SCRAM-SHA-256")) {
         return new QXmppSaslClientScram(QCryptographicHash::Sha256, parent);
-    } else if (mechanism == "X-FACEBOOK-PLATFORM") {
+    } else if (mechanism == QSL("X-FACEBOOK-PLATFORM")) {
         return new QXmppSaslClientFacebook(parent);
-    } else if (mechanism == "X-MESSENGER-OAUTH2") {
+    } else if (mechanism == QSL("X-MESSENGER-OAUTH2")) {
         return new QXmppSaslClientWindowsLive(parent);
-    } else if (mechanism == "X-OAUTH2") {
+    } else if (mechanism == QSL("X-OAUTH2")) {
         return new QXmppSaslClientGoogle(parent);
     } else {
         return nullptr;
@@ -368,7 +369,7 @@ QXmppSaslClientAnonymous::QXmppSaslClientAnonymous(QObject *parent)
 
 QString QXmppSaslClientAnonymous::mechanism() const
 {
-    return "ANONYMOUS";
+    return QSL("ANONYMOUS");
 }
 
 bool QXmppSaslClientAnonymous::respond(const QByteArray &challenge, QByteArray &response)
@@ -379,13 +380,13 @@ bool QXmppSaslClientAnonymous::respond(const QByteArray &challenge, QByteArray &
         m_step++;
         return true;
     } else {
-        warning("QXmppSaslClientAnonymous : Invalid step");
+        warning(QSL("QXmppSaslClientAnonymous : Invalid step"));
         return false;
     }
 }
 
 QXmppSaslClientDigestMd5::QXmppSaslClientDigestMd5(QObject *parent)
-    : QXmppSaslClient(parent), m_nc("00000001"), m_step(0)
+    : QXmppSaslClient(parent), m_nc(QBL("00000001")), m_step(0)
 {
     m_cnonce = generateNonce();
 }
@@ -398,7 +399,7 @@ QString QXmppSaslClientDigestMd5::mechanism() const
 bool QXmppSaslClientDigestMd5::respond(const QByteArray &challenge, QByteArray &response)
 {
     Q_UNUSED(challenge);
-    const QByteArray digestUri = QString("%1/%2").arg(serviceType(), host()).toUtf8();
+    const QByteArray digestUri = QSL("%1/%2").arg(serviceType(), host()).toUtf8();
 
     if (m_step == 0) {
         response = QByteArray();
@@ -407,38 +408,38 @@ bool QXmppSaslClientDigestMd5::respond(const QByteArray &challenge, QByteArray &
     } else if (m_step == 1) {
         const QMap<QByteArray, QByteArray> input = QXmppSaslDigestMd5::parseMessage(challenge);
 
-        if (!input.contains("nonce")) {
-            warning("QXmppSaslClientDigestMd5 : Invalid input on step 1");
+        if (!input.contains(QBL("nonce"))) {
+            warning(QSL("QXmppSaslClientDigestMd5 : Invalid input on step 1"));
             return false;
         }
 
         // determine realm
-        const QByteArray realm = input.value("realm");
+        const QByteArray realm = input.value(QBL("realm"));
 
         // determine quality of protection
-        const QList<QByteArray> qops = input.value("qop", "auth").split(',');
-        if (!qops.contains("auth")) {
-            warning("QXmppSaslClientDigestMd5 : Invalid quality of protection");
+        const QList<QByteArray> qops = input.value(QBL("qop"), QBL("auth")).split(',');
+        if (!qops.contains(QBL("auth"))) {
+            warning(QSL("QXmppSaslClientDigestMd5 : Invalid quality of protection"));
             return false;
         }
 
-        m_nonce = input.value("nonce");
+        m_nonce = input.value(QBL("nonce"));
         m_secret = QCryptographicHash::hash(
-            username().toUtf8() + ":" + realm + ":" + password().toUtf8(),
+            username().toUtf8() + QBL(":") + realm + QBL(":") + password().toUtf8(),
             QCryptographicHash::Md5);
 
         // Build response
         QMap<QByteArray, QByteArray> output;
-        output["username"] = username().toUtf8();
+        output[QBL("username")] = username().toUtf8();
         if (!realm.isEmpty())
-            output["realm"] = realm;
-        output["nonce"] = m_nonce;
-        output["qop"] = "auth";
-        output["cnonce"] = m_cnonce;
-        output["nc"] = m_nc;
-        output["digest-uri"] = digestUri;
-        output["response"] = calculateDigest("AUTHENTICATE", digestUri, m_secret, m_nonce, m_cnonce, m_nc);
-        output["charset"] = "utf-8";
+            output[QBL("realm")] = realm;
+        output[QBL("nonce")] = m_nonce;
+        output[QBL("qop")] = QBL("auth");
+        output[QBL("cnonce")] = m_cnonce;
+        output[QBL("nc")] = m_nc;
+        output[QBL("digest-uri")] = digestUri;
+        output[QBL("response")] = calculateDigest(QBL("AUTHENTICATE"), digestUri, m_secret, m_nonce, m_cnonce, m_nc);
+        output[QBL("charset")] = QBL("utf-8");
 
         response = QXmppSaslDigestMd5::serializeMessage(output);
         m_step++;
@@ -447,8 +448,8 @@ bool QXmppSaslClientDigestMd5::respond(const QByteArray &challenge, QByteArray &
         const QMap<QByteArray, QByteArray> input = QXmppSaslDigestMd5::parseMessage(challenge);
 
         // check new challenge
-        if (input.value("rspauth") != calculateDigest(QByteArray(), digestUri, m_secret, m_nonce, m_cnonce, m_nc)) {
-            warning("QXmppSaslClientDigestMd5 : Invalid challenge on step 2");
+        if (input.value(QBL("rspauth")) != calculateDigest(QByteArray(), digestUri, m_secret, m_nonce, m_cnonce, m_nc)) {
+            warning(QSL("QXmppSaslClientDigestMd5 : Invalid challenge on step 2"));
             return false;
         }
 
@@ -456,7 +457,7 @@ bool QXmppSaslClientDigestMd5::respond(const QByteArray &challenge, QByteArray &
         m_step++;
         return true;
     } else {
-        warning("QXmppSaslClientDigestMd5 : Invalid step");
+        warning(QSL("QXmppSaslClientDigestMd5 : Invalid step"));
         return false;
     }
 }
@@ -468,7 +469,7 @@ QXmppSaslClientFacebook::QXmppSaslClientFacebook(QObject *parent)
 
 QString QXmppSaslClientFacebook::mechanism() const
 {
-    return "X-FACEBOOK-PLATFORM";
+    return QSL("X-FACEBOOK-PLATFORM");
 }
 
 bool QXmppSaslClientFacebook::respond(const QByteArray &challenge, QByteArray &response)
@@ -481,26 +482,26 @@ bool QXmppSaslClientFacebook::respond(const QByteArray &challenge, QByteArray &r
     } else if (m_step == 1) {
         // parse request
         QUrlQuery requestUrl(challenge);
-        if (!requestUrl.hasQueryItem("method") || !requestUrl.hasQueryItem("nonce")) {
-            warning("QXmppSaslClientFacebook : Invalid challenge, nonce or method missing");
+        if (!requestUrl.hasQueryItem(QSL("method")) || !requestUrl.hasQueryItem(QSL("nonce"))) {
+            warning(QSL("QXmppSaslClientFacebook : Invalid challenge, nonce or method missing"));
             return false;
         }
 
         // build response
         QUrlQuery responseUrl;
-        responseUrl.addQueryItem("access_token", password());
-        responseUrl.addQueryItem("api_key", username());
-        responseUrl.addQueryItem("call_id", nullptr);
-        responseUrl.addQueryItem("method", requestUrl.queryItemValue("method"));
-        responseUrl.addQueryItem("nonce", requestUrl.queryItemValue("nonce"));
-        responseUrl.addQueryItem("v", "1.0");
+        responseUrl.addQueryItem(QSL("access_token"), password());
+        responseUrl.addQueryItem(QSL("api_key"), username());
+        responseUrl.addQueryItem(QSL("call_id"), nullptr);
+        responseUrl.addQueryItem(QSL("method"), requestUrl.queryItemValue(QSL("method")));
+        responseUrl.addQueryItem(QSL("nonce"), requestUrl.queryItemValue(QSL("nonce")));
+        responseUrl.addQueryItem(QSL("v"), QSL("1.0"));
 
         response = responseUrl.query().toUtf8();
 
         m_step++;
         return true;
     } else {
-        warning("QXmppSaslClientFacebook : Invalid step");
+        warning(QSL("QXmppSaslClientFacebook : Invalid step"));
         return false;
     }
 }
@@ -512,7 +513,7 @@ QXmppSaslClientGoogle::QXmppSaslClientGoogle(QObject *parent)
 
 QString QXmppSaslClientGoogle::mechanism() const
 {
-    return "X-OAUTH2";
+    return QSL("X-OAUTH2");
 }
 
 bool QXmppSaslClientGoogle::respond(const QByteArray &challenge, QByteArray &response)
@@ -524,7 +525,7 @@ bool QXmppSaslClientGoogle::respond(const QByteArray &challenge, QByteArray &res
         m_step++;
         return true;
     } else {
-        warning("QXmppSaslClientGoogle : Invalid step");
+        warning(QSL("QXmppSaslClientGoogle : Invalid step"));
         return false;
     }
 }
@@ -536,7 +537,7 @@ QXmppSaslClientPlain::QXmppSaslClientPlain(QObject *parent)
 
 QString QXmppSaslClientPlain::mechanism() const
 {
-    return "PLAIN";
+    return QSL("PLAIN");
 }
 
 bool QXmppSaslClientPlain::respond(const QByteArray &challenge, QByteArray &response)
@@ -547,7 +548,7 @@ bool QXmppSaslClientPlain::respond(const QByteArray &challenge, QByteArray &resp
         m_step++;
         return true;
     } else {
-        warning("QXmppSaslClientPlain : Invalid step");
+        warning(QSL("QXmppSaslClientPlain : Invalid step"));
         return false;
     }
 }
@@ -560,10 +561,10 @@ QXmppSaslClientScram::QXmppSaslClientScram(QCryptographicHash::Algorithm algorit
 
     if (m_algorithm == QCryptographicHash::Sha256) {
         m_dklen = 32;
-        m_mechanism = "SCRAM-SHA-256";
+        m_mechanism = QSL("SCRAM-SHA-256");
     } else {
         m_dklen = 20;
-        m_mechanism = "SCRAM-SHA-1";
+        m_mechanism = QSL("SCRAM-SHA-1");
     }
 }
 
@@ -576,8 +577,8 @@ bool QXmppSaslClientScram::respond(const QByteArray &challenge, QByteArray &resp
 {
     Q_UNUSED(challenge);
     if (m_step == 0) {
-        m_gs2Header = "n,,";
-        m_clientFirstMessageBare = "n=" + username().toUtf8() + ",r=" + m_nonce;
+        m_gs2Header = QBL("n,,");
+        m_clientFirstMessageBare = QBL("n=") + username().toUtf8() + QBL(",r=") + m_nonce;
 
         response = m_gs2Header + m_clientFirstMessageBare;
         m_step++;
@@ -593,20 +594,20 @@ bool QXmppSaslClientScram::respond(const QByteArray &challenge, QByteArray &resp
         }
 
         // calculate proofs
-        const QByteArray clientFinalMessageBare = "c=" + m_gs2Header.toBase64() + ",r=" + nonce;
+        const QByteArray clientFinalMessageBare = QBL("c=") + m_gs2Header.toBase64() + QBL(",r=") + nonce;
         const QByteArray saltedPassword = deriveKeyPbkdf2(m_algorithm, password().toUtf8(), salt,
                                                           iterations, m_dklen);
-        const QByteArray clientKey = QMessageAuthenticationCode::hash("Client Key", saltedPassword, m_algorithm);
+        const QByteArray clientKey = QMessageAuthenticationCode::hash(QBL("Client Key"), saltedPassword, m_algorithm);
         const QByteArray storedKey = QCryptographicHash::hash(clientKey, m_algorithm);
-        const QByteArray authMessage = m_clientFirstMessageBare + "," + challenge + "," + clientFinalMessageBare;
+        const QByteArray authMessage = m_clientFirstMessageBare + QBL(",") + challenge + QBL(",") + clientFinalMessageBare;
         QByteArray clientProof = QMessageAuthenticationCode::hash(authMessage, storedKey, m_algorithm);
         std::transform(clientProof.cbegin(), clientProof.cend(), clientKey.cbegin(),
                        clientProof.begin(), std::bit_xor<char>());
 
-        const QByteArray serverKey = QMessageAuthenticationCode::hash("Server Key", saltedPassword, m_algorithm);
+        const QByteArray serverKey = QMessageAuthenticationCode::hash(QBL("Server Key"), saltedPassword, m_algorithm);
         m_serverSignature = QMessageAuthenticationCode::hash(authMessage, serverKey, m_algorithm);
 
-        response = clientFinalMessageBare + ",p=" + clientProof.toBase64();
+        response = clientFinalMessageBare + QBL(",p=") + clientProof.toBase64();
         m_step++;
         return true;
     } else if (m_step == 2) {
@@ -615,7 +616,7 @@ bool QXmppSaslClientScram::respond(const QByteArray &challenge, QByteArray &resp
         m_step++;
         return QByteArray::fromBase64(input.value('v')) == m_serverSignature;
     } else {
-        warning("QXmppSaslClientPlain : Invalid step");
+        warning(QSL("QXmppSaslClientPlain : Invalid step"));
         return false;
     }
 }
@@ -627,7 +628,7 @@ QXmppSaslClientWindowsLive::QXmppSaslClientWindowsLive(QObject *parent)
 
 QString QXmppSaslClientWindowsLive::mechanism() const
 {
-    return "X-MESSENGER-OAUTH2";
+    return QSL("X-MESSENGER-OAUTH2");
 }
 
 bool QXmppSaslClientWindowsLive::respond(const QByteArray &challenge, QByteArray &response)
@@ -639,7 +640,7 @@ bool QXmppSaslClientWindowsLive::respond(const QByteArray &challenge, QByteArray
         m_step++;
         return true;
     } else {
-        warning("QXmppSaslClientWindowsLive : Invalid step");
+        warning(QSL("QXmppSaslClientWindowsLive : Invalid step"));
         return false;
     }
 }
@@ -667,11 +668,11 @@ QXmppSaslServer::~QXmppSaslServer()
 
 QXmppSaslServer *QXmppSaslServer::create(const QString &mechanism, QObject *parent)
 {
-    if (mechanism == "PLAIN") {
+    if (mechanism == QSL("PLAIN")) {
         return new QXmppSaslServerPlain(parent);
-    } else if (mechanism == "DIGEST-MD5") {
+    } else if (mechanism == QSL("DIGEST-MD5")) {
         return new QXmppSaslServerDigestMd5(parent);
-    } else if (mechanism == "ANONYMOUS") {
+    } else if (mechanism == QSL("ANONYMOUS")) {
         return new QXmppSaslServerAnonymous(parent);
     } else {
         return nullptr;
@@ -741,7 +742,7 @@ QXmppSaslServerAnonymous::QXmppSaslServerAnonymous(QObject *parent)
 
 QString QXmppSaslServerAnonymous::mechanism() const
 {
-    return "ANONYMOUS";
+    return QSL("ANONYMOUS");
 }
 
 QXmppSaslServer::Response QXmppSaslServerAnonymous::respond(const QByteArray &request, QByteArray &response)
@@ -752,7 +753,7 @@ QXmppSaslServer::Response QXmppSaslServerAnonymous::respond(const QByteArray &re
         response = QByteArray();
         return Succeeded;
     } else {
-        warning("QXmppSaslServerAnonymous : Invalid step");
+        warning(QSL("QXmppSaslServerAnonymous : Invalid step"));
         return Failed;
     }
 }
@@ -765,52 +766,52 @@ QXmppSaslServerDigestMd5::QXmppSaslServerDigestMd5(QObject *parent)
 
 QString QXmppSaslServerDigestMd5::mechanism() const
 {
-    return "DIGEST-MD5";
+    return QSL("DIGEST-MD5");
 }
 
 QXmppSaslServer::Response QXmppSaslServerDigestMd5::respond(const QByteArray &request, QByteArray &response)
 {
     if (m_step == 0) {
         QMap<QByteArray, QByteArray> output;
-        output["nonce"] = m_nonce;
+        output[QBL("nonce")] = m_nonce;
         if (!realm().isEmpty())
-            output["realm"] = realm().toUtf8();
-        output["qop"] = "auth";
-        output["charset"] = "utf-8";
-        output["algorithm"] = "md5-sess";
+            output[QBL("realm")] = realm().toUtf8();
+        output[QBL("qop")] = QBL("auth");
+        output[QBL("charset")] = QBL("utf-8");
+        output[QBL("algorithm")] = QBL("md5-sess");
 
         m_step++;
         response = QXmppSaslDigestMd5::serializeMessage(output);
         return Challenge;
     } else if (m_step == 1) {
         const QMap<QByteArray, QByteArray> input = QXmppSaslDigestMd5::parseMessage(request);
-        const QByteArray realm = input.value("realm");
-        const QByteArray digestUri = input.value("digest-uri");
+        const QByteArray realm = input.value(QBL("realm"));
+        const QByteArray digestUri = input.value(QBL("digest-uri"));
 
-        if (input.value("qop") != "auth") {
-            warning("QXmppSaslServerDigestMd5 : Invalid quality of protection");
+        if (input.value(QBL("qop")) != QBL("auth")) {
+            warning(QSL("QXmppSaslServerDigestMd5 : Invalid quality of protection"));
             return Failed;
         }
 
-        setUsername(QString::fromUtf8(input.value("username")));
+        setUsername(QString::fromUtf8(input.value(QBL("username"))));
         if (password().isEmpty() && passwordDigest().isEmpty())
             return InputNeeded;
 
-        m_nc = input.value("nc");
-        m_cnonce = input.value("cnonce");
+        m_nc = input.value(QBL("nc"));
+        m_cnonce = input.value(QBL("cnonce"));
         if (!password().isEmpty()) {
             m_secret = QCryptographicHash::hash(
-                username().toUtf8() + ":" + realm + ":" + password().toUtf8(),
+                username().toUtf8() + QBL(":") + realm + QBL(":") + password().toUtf8(),
                 QCryptographicHash::Md5);
         } else {
             m_secret = passwordDigest();
         }
 
-        if (input.value("response") != calculateDigest("AUTHENTICATE", digestUri, m_secret, m_nonce, m_cnonce, m_nc))
+        if (input.value(QBL("response")) != calculateDigest(QBL("AUTHENTICATE"), digestUri, m_secret, m_nonce, m_cnonce, m_nc))
             return Failed;
 
         QMap<QByteArray, QByteArray> output;
-        output["rspauth"] = calculateDigest(QByteArray(), digestUri, m_secret, m_nonce, m_cnonce, m_nc);
+        output[QBL("rspauth")] = calculateDigest(QByteArray(), digestUri, m_secret, m_nonce, m_cnonce, m_nc);
 
         m_step++;
         response = QXmppSaslDigestMd5::serializeMessage(output);
@@ -820,7 +821,7 @@ QXmppSaslServer::Response QXmppSaslServerDigestMd5::respond(const QByteArray &re
         response = QByteArray();
         return Succeeded;
     } else {
-        warning("QXmppSaslServerDigestMd5 : Invalid step");
+        warning(QSL("QXmppSaslServerDigestMd5 : Invalid step"));
         return Failed;
     }
 }
@@ -832,7 +833,7 @@ QXmppSaslServerPlain::QXmppSaslServerPlain(QObject *parent)
 
 QString QXmppSaslServerPlain::mechanism() const
 {
-    return "PLAIN";
+    return QSL("PLAIN");
 }
 
 QXmppSaslServer::Response QXmppSaslServerPlain::respond(const QByteArray &request, QByteArray &response)
@@ -845,7 +846,7 @@ QXmppSaslServer::Response QXmppSaslServerPlain::respond(const QByteArray &reques
 
         QList<QByteArray> auth = request.split('\0');
         if (auth.size() != 3) {
-            warning("QXmppSaslServerPlain : Invalid input");
+            warning(QSL("QXmppSaslServerPlain : Invalid input"));
             return Failed;
         }
         setUsername(QString::fromUtf8(auth[1]));
@@ -855,7 +856,7 @@ QXmppSaslServer::Response QXmppSaslServerPlain::respond(const QByteArray &reques
         response = QByteArray();
         return InputNeeded;
     } else {
-        warning("QXmppSaslServerPlain : Invalid step");
+        warning(QSL("QXmppSaslServerPlain : Invalid step"));
         return Failed;
     }
 }
@@ -870,7 +871,7 @@ QMap<QByteArray, QByteArray> QXmppSaslDigestMd5::parseMessage(const QByteArray &
     QMap<QByteArray, QByteArray> map;
     int startIndex = 0;
     int pos = 0;
-    while ((pos = ba.indexOf("=", startIndex)) >= 0) {
+    while ((pos = ba.indexOf(QSL("="), startIndex)) >= 0) {
         // key get name and skip equals
         const QByteArray key = ba.mid(startIndex, pos - startIndex).trimmed();
         pos++;
@@ -913,7 +914,7 @@ QByteArray QXmppSaslDigestMd5::serializeMessage(const QMap<QByteArray, QByteArra
     for (const auto &key : map.keys()) {
         if (!ba.isEmpty())
             ba.append(',');
-        ba.append(key + "=");
+        ba.append(key + QBL("="));
         QByteArray value = map[key];
         const char *separators = "()<>@,;:\\\"/[]?={} \t";
         bool quote = false;
@@ -924,9 +925,9 @@ QByteArray QXmppSaslDigestMd5::serializeMessage(const QMap<QByteArray, QByteArra
             }
         }
         if (quote) {
-            value.replace("\\", "\\\\");
-            value.replace("\"", "\\\"");
-            ba.append("\"" + value + "\"");
+            value.replace(QBL("\\"), QBL("\\\\"));
+            value.replace(QBL("\""), QBL("\\\""));
+            ba.append(QSL("\"") + value + QSL("\""));
         } else
             ba.append(value);
     }

--- a/src/base/QXmppSessionIq.cpp
+++ b/src/base/QXmppSessionIq.cpp
@@ -33,13 +33,13 @@
 /// \cond
 bool QXmppSessionIq::isSessionIq(const QDomElement &element)
 {
-    QDomElement sessionElement = element.firstChildElement("session");
+    QDomElement sessionElement = element.firstChildElement(QSL("session"));
     return (sessionElement.namespaceURI() == ns_session);
 }
 
 void QXmppSessionIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("session");
+    writer->writeStartElement(QSL("session"));
     ;
     writer->writeDefaultNamespace(ns_session);
     writer->writeEndElement();

--- a/src/base/QXmppStanza.cpp
+++ b/src/base/QXmppStanza.cpp
@@ -137,21 +137,21 @@ bool QXmppExtendedAddress::isValid() const
 /// \cond
 void QXmppExtendedAddress::parse(const QDomElement &element)
 {
-    d->delivered = element.attribute("delivered") == "true";
-    d->description = element.attribute("desc");
-    d->jid = element.attribute("jid");
-    d->type = element.attribute("type");
+    d->delivered = element.attribute(QSL("delivered")) == QSL("true");
+    d->description = element.attribute(QSL("desc"));
+    d->jid = element.attribute(QSL("jid"));
+    d->type = element.attribute(QSL("type"));
 }
 
 void QXmppExtendedAddress::toXml(QXmlStreamWriter *xmlWriter) const
 {
-    xmlWriter->writeStartElement("address");
+    xmlWriter->writeStartElement(QSL("address"));
     if (d->delivered)
-        xmlWriter->writeAttribute("delivered", "true");
+        xmlWriter->writeAttribute(QSL("delivered"), QSL("true"));
     if (!d->description.isEmpty())
-        xmlWriter->writeAttribute("desc", d->description);
-    xmlWriter->writeAttribute("jid", d->jid);
-    xmlWriter->writeAttribute("type", d->type);
+        xmlWriter->writeAttribute(QSL("desc"), d->description);
+    xmlWriter->writeAttribute(QSL("jid"), d->jid);
+    xmlWriter->writeAttribute(QSL("type"), d->type);
     xmlWriter->writeEndElement();
 }
 /// \endcond
@@ -347,15 +347,15 @@ QString QXmppStanza::Error::getTypeStr() const
 {
     switch (d->type) {
     case Cancel:
-        return "cancel";
+        return QSL("cancel");
     case Continue:
-        return "continue";
+        return QSL("continue");
     case Modify:
-        return "modify";
+        return QSL("modify");
     case Auth:
-        return "auth";
+        return QSL("auth");
     case Wait:
-        return "wait";
+        return QSL("wait");
     default:
         return {};
     }
@@ -368,15 +368,15 @@ QString QXmppStanza::Error::getConditionStr() const
 
 void QXmppStanza::Error::setTypeFromStr(const QString &type)
 {
-    if (type == "cancel")
+    if (type == QSL("cancel"))
         setType(Cancel);
-    else if (type == "continue")
+    else if (type == QSL("continue"))
         setType(Continue);
-    else if (type == "modify")
+    else if (type == QSL("modify"))
         setType(Modify);
-    else if (type == "auth")
+    else if (type == QSL("auth"))
         setType(Auth);
-    else if (type == "wait")
+    else if (type == QSL("wait"))
         setType(Wait);
     else
         setType(static_cast<QXmppStanza::Error::Type>(-1));
@@ -389,28 +389,28 @@ void QXmppStanza::Error::setConditionFromStr(const QString &type)
 
 void QXmppStanza::Error::parse(const QDomElement &errorElement)
 {
-    setCode(errorElement.attribute("code").toInt());
-    setTypeFromStr(errorElement.attribute("type"));
+    setCode(errorElement.attribute(QSL("code")).toInt());
+    setTypeFromStr(errorElement.attribute(QSL("type")));
 
     QDomElement element = errorElement.firstChildElement();
     while (!element.isNull()) {
         if (element.namespaceURI() == ns_stanza) {
-            if (element.tagName() == "text")
+            if (element.tagName() == QSL("text"))
                 setText(element.text());
             else
                 setConditionFromStr(element.tagName());
             // XEP-0363: HTTP File Upload
         } else if (element.namespaceURI() == ns_http_upload) {
             // file is too large
-            if (element.tagName() == "file-too-large") {
+            if (element.tagName() == QSL("file-too-large")) {
                 d->fileTooLarge = true;
-                d->maxFileSize = element.firstChildElement("max-file-size")
+                d->maxFileSize = element.firstChildElement(QSL("max-file-size"))
                                      .text()
                                      .toLongLong();
                 // retry later
-            } else if (element.tagName() == "retry") {
+            } else if (element.tagName() == QSL("retry")) {
                 d->retryDate = QXmppUtils::datetimeFromString(
-                    element.attribute("stamp"));
+                    element.attribute(QSL("stamp")));
             }
         }
         element = element.nextSiblingElement();
@@ -425,11 +425,11 @@ void QXmppStanza::Error::toXml(QXmlStreamWriter *writer) const
     if (cond.isEmpty() && type.isEmpty())
         return;
 
-    writer->writeStartElement("error");
-    helperToXmlAddAttribute(writer, "type", type);
+    writer->writeStartElement(QSL("error"));
+    helperToXmlAddAttribute(writer, QSL("type"), type);
 
     if (d->code > 0)
-        helperToXmlAddAttribute(writer, "code", QString::number(d->code));
+        helperToXmlAddAttribute(writer, QSL("code"), QString::number(d->code));
 
     if (!cond.isEmpty()) {
         writer->writeStartElement(cond);
@@ -437,8 +437,8 @@ void QXmppStanza::Error::toXml(QXmlStreamWriter *writer) const
         writer->writeEndElement();
     }
     if (!d->text.isEmpty()) {
-        writer->writeStartElement("text");
-        writer->writeAttribute("xml:lang", "en");
+        writer->writeStartElement(QSL("text"));
+        writer->writeAttribute(QSL("xml:lang"), QSL("en"));
         writer->writeDefaultNamespace(ns_stanza);
         writer->writeCharacters(d->text);
         writer->writeEndElement();
@@ -446,15 +446,15 @@ void QXmppStanza::Error::toXml(QXmlStreamWriter *writer) const
 
     // XEP-0363: HTTP File Upload
     if (d->fileTooLarge) {
-        writer->writeStartElement("file-too-large");
+        writer->writeStartElement(QSL("file-too-large"));
         writer->writeDefaultNamespace(ns_http_upload);
-        helperToXmlAddTextElement(writer, "max-file-size",
+        helperToXmlAddTextElement(writer, QSL("max-file-size"),
                                   QString::number(d->maxFileSize));
         writer->writeEndElement();
     } else if (!d->retryDate.isNull() && d->retryDate.isValid()) {
-        writer->writeStartElement("retry");
+        writer->writeStartElement(QSL("retry"));
         writer->writeDefaultNamespace(ns_http_upload);
-        writer->writeAttribute("stamp",
+        writer->writeAttribute(QSL("stamp"),
                                QXmppUtils::datetimeToString(d->retryDate));
         writer->writeEndElement();
     }

--- a/src/base/QXmppStanza.h
+++ b/src/base/QXmppStanza.h
@@ -110,37 +110,37 @@ public:
         /// The error descriptions are not detailed in here. The exact meaning
         /// can be found in the particular protocols using them.
         enum Type {
-            Cancel,   ///< The error is not temporary.
-            Continue, ///< The error was only a warning.
-            Modify,   ///< The request needs to be changed and resent.
-            Auth,     ///< The request needs to be resent after authentication.
-            Wait      ///< The error is temporary, you should wait and resend.
+            Cancel,    ///< The error is not temporary.
+            Continue,  ///< The error was only a warning.
+            Modify,    ///< The request needs to be changed and resent.
+            Auth,      ///< The request needs to be resent after authentication.
+            Wait       ///< The error is temporary, you should wait and resend.
         };
 
         /// A detailed condition of the error
         enum Condition {
-            BadRequest,            ///< The request does not contain a valid schema.
-            Conflict,              ///< The request conflicts with another.
-            FeatureNotImplemented, ///< The feature is not implemented.
-            Forbidden,             ///< The requesting entity does not posses the necessary privileges to perform the request.
-            Gone,                  ///< The user or server can not be contacted at the address.
-            InternalServerError,   ///< The server has expierienced an internal error and can not process the request.
-            ItemNotFound,          ///< The requested item could not be found.
-            JidMalformed,          ///< The given JID is not valid.
-            NotAcceptable,         ///< The request does not meet the defined critera.
-            NotAllowed,            ///< No entity is allowed to perform the request.
-            NotAuthorized,         ///< The request should be resent after authentication.
-            PaymentRequired,       ///< Payment is required to perform the request.
-            RecipientUnavailable,  ///< The recipient is unavailable.
-            Redirect,              ///< The requested resource is available elsewhere.
-            RegistrationRequired,  ///< The requesting entity needs to register first.
-            RemoteServerNotFound,  ///< The remote server could not be found.
-            RemoteServerTimeout,   ///< The connection to the server could not be established or timed out.
-            ResourceConstraint,    ///< The recipient lacks system resources to perform the request.
-            ServiceUnavailable,    ///< The service is currently not available.
-            SubscriptionRequired,  ///< The requester needs to subscribe first.
-            UndefinedCondition,    ///< An undefined condition was hit.
-            UnexpectedRequest      ///< The request was unexpected.
+            BadRequest,             ///< The request does not contain a valid schema.
+            Conflict,               ///< The request conflicts with another.
+            FeatureNotImplemented,  ///< The feature is not implemented.
+            Forbidden,              ///< The requesting entity does not posses the necessary privileges to perform the request.
+            Gone,                   ///< The user or server can not be contacted at the address.
+            InternalServerError,    ///< The server has expierienced an internal error and can not process the request.
+            ItemNotFound,           ///< The requested item could not be found.
+            JidMalformed,           ///< The given JID is not valid.
+            NotAcceptable,          ///< The request does not meet the defined critera.
+            NotAllowed,             ///< No entity is allowed to perform the request.
+            NotAuthorized,          ///< The request should be resent after authentication.
+            PaymentRequired,        ///< Payment is required to perform the request.
+            RecipientUnavailable,   ///< The recipient is unavailable.
+            Redirect,               ///< The requested resource is available elsewhere.
+            RegistrationRequired,   ///< The requesting entity needs to register first.
+            RemoteServerNotFound,   ///< The remote server could not be found.
+            RemoteServerTimeout,    ///< The connection to the server could not be established or timed out.
+            ResourceConstraint,     ///< The recipient lacks system resources to perform the request.
+            ServiceUnavailable,     ///< The service is currently not available.
+            SubscriptionRequired,   ///< The requester needs to subscribe first.
+            UndefinedCondition,     ///< An undefined condition was hit.
+            UnexpectedRequest       ///< The request was unexpected.
         };
 
         Error();

--- a/src/base/QXmppStartTlsPacket.cpp
+++ b/src/base/QXmppStartTlsPacket.cpp
@@ -29,9 +29,9 @@
 #include <QXmlStreamWriter>
 
 const static QStringList STARTTLS_TYPES = {
-    QStringLiteral("starttls"),
-    QStringLiteral("proceed"),
-    QStringLiteral("failure")
+    QSL("starttls"),
+    QSL("proceed"),
+    QSL("failure")
 };
 
 /// Constructs a new QXmppStartTlsPacket

--- a/src/base/QXmppStream.cpp
+++ b/src/base/QXmppStream.cpp
@@ -41,7 +41,7 @@
 #include <QXmlStreamWriter>
 
 static bool randomSeeded = false;
-static const QByteArray streamRootElementEnd = "</stream:stream>";
+static const QByteArray streamRootElementEnd = QBL("</stream:stream>");
 
 class QXmppStreamPrivate
 {
@@ -190,7 +190,7 @@ void QXmppStream::setSocket(QSslSocket *socket)
 
 void QXmppStream::_q_socketConnected()
 {
-    info(QString("Socket connected to %1 %2").arg(d->socket->peerAddress().toString(), QString::number(d->socket->peerPort())));
+    info(QSL("Socket connected to %1 %2").arg(d->socket->peerAddress().toString(), QString::number(d->socket->peerPort())));
     handleStart();
 }
 
@@ -203,7 +203,7 @@ void QXmppStream::_q_socketEncrypted()
 void QXmppStream::_q_socketError(QAbstractSocket::SocketError socketError)
 {
     Q_UNUSED(socketError);
-    warning(QString("Socket error: " + socket()->errorString()));
+    warning(QSL("Socket error: ") + socket()->errorString());
 }
 
 void QXmppStream::_q_socketReadyRead()

--- a/src/base/QXmppStreamFeatures.cpp
+++ b/src/base/QXmppStreamFeatures.cpp
@@ -188,7 +188,7 @@ void QXmppStreamFeatures::setRegisterMode(const QXmppStreamFeatures::Mode &regis
 bool QXmppStreamFeatures::isStreamFeatures(const QDomElement &element)
 {
     return element.namespaceURI() == ns_stream &&
-        element.tagName() == "features";
+        element.tagName() == QSL("features");
 }
 
 static QXmppStreamFeatures::Mode readFeature(const QDomElement &element, const char *tagName, const char *tagNs)
@@ -197,7 +197,7 @@ static QXmppStreamFeatures::Mode readFeature(const QDomElement &element, const c
     QXmppStreamFeatures::Mode mode = QXmppStreamFeatures::Disabled;
     while (!subElement.isNull()) {
         if (subElement.namespaceURI() == tagNs) {
-            if (!subElement.firstChildElement("required").isNull())
+            if (!subElement.firstChildElement(QSL("required")).isNull())
                 mode = QXmppStreamFeatures::Required;
             else if (mode != QXmppStreamFeatures::Required)
                 mode = QXmppStreamFeatures::Enabled;
@@ -218,22 +218,22 @@ void QXmppStreamFeatures::parse(const QDomElement &element)
     d->registerMode = readFeature(element, "register", ns_register_feature);
 
     // parse advertised compression methods
-    QDomElement compression = element.firstChildElement("compression");
+    QDomElement compression = element.firstChildElement(QSL("compression"));
     if (compression.namespaceURI() == ns_compressFeature) {
-        QDomElement subElement = compression.firstChildElement("method");
+        QDomElement subElement = compression.firstChildElement(QSL("method"));
         while (!subElement.isNull()) {
             d->compressionMethods << subElement.text();
-            subElement = subElement.nextSiblingElement("method");
+            subElement = subElement.nextSiblingElement(QSL("method"));
         }
     }
 
     // parse advertised SASL Authentication mechanisms
-    QDomElement mechs = element.firstChildElement("mechanisms");
+    QDomElement mechs = element.firstChildElement(QSL("mechanisms"));
     if (mechs.namespaceURI() == ns_sasl) {
-        QDomElement subElement = mechs.firstChildElement("mechanism");
+        QDomElement subElement = mechs.firstChildElement(QSL("mechanism"));
         while (!subElement.isNull()) {
             d->authMechanisms << subElement.text();
-            subElement = subElement.nextSiblingElement("mechanism");
+            subElement = subElement.nextSiblingElement(QSL("mechanism"));
         }
     }
 }
@@ -244,14 +244,14 @@ static void writeFeature(QXmlStreamWriter *writer, const char *tagName, const ch
         writer->writeStartElement(tagName);
         writer->writeDefaultNamespace(tagNs);
         if (mode == QXmppStreamFeatures::Required)
-            writer->writeEmptyElement("required");
+            writer->writeEmptyElement(QSL("required"));
         writer->writeEndElement();
     }
 }
 
 void QXmppStreamFeatures::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("stream:features");
+    writer->writeStartElement(QSL("stream:features"));
     writeFeature(writer, "bind", ns_bind, d->bindMode);
     writeFeature(writer, "session", ns_session, d->sessionMode);
     writeFeature(writer, "auth", ns_authFeature, d->nonSaslAuthMode);
@@ -261,17 +261,17 @@ void QXmppStreamFeatures::toXml(QXmlStreamWriter *writer) const
     writeFeature(writer, "register", ns_register_feature, d->registerMode);
 
     if (!d->compressionMethods.isEmpty()) {
-        writer->writeStartElement("compression");
+        writer->writeStartElement(QSL("compression"));
         writer->writeDefaultNamespace(ns_compressFeature);
         for (const auto &method : d->compressionMethods)
-            writer->writeTextElement("method", method);
+            writer->writeTextElement(QSL("method"), method);
         writer->writeEndElement();
     }
     if (!d->authMechanisms.isEmpty()) {
-        writer->writeStartElement("mechanisms");
+        writer->writeStartElement(QSL("mechanisms"));
         writer->writeDefaultNamespace(ns_sasl);
         for (const auto &mechanism : d->authMechanisms)
-            writer->writeTextElement("mechanism", mechanism);
+            writer->writeTextElement(QSL("mechanism"), mechanism);
         writer->writeEndElement();
     }
     writer->writeEndElement();

--- a/src/base/QXmppStreamInitiationIq.cpp
+++ b/src/base/QXmppStreamInitiationIq.cpp
@@ -80,25 +80,25 @@ void QXmppStreamInitiationIq::setSiId(const QString &id)
 /// \cond
 bool QXmppStreamInitiationIq::isStreamInitiationIq(const QDomElement &element)
 {
-    QDomElement siElement = element.firstChildElement("si");
+    QDomElement siElement = element.firstChildElement(QSL("si"));
     return (siElement.namespaceURI() == ns_stream_initiation);
 }
 
 void QXmppStreamInitiationIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement siElement = element.firstChildElement("si");
-    m_siId = siElement.attribute("id");
-    m_mimeType = siElement.attribute("mime-type");
-    if (siElement.attribute("profile") == ns_stream_initiation_file_transfer)
+    QDomElement siElement = element.firstChildElement(QSL("si"));
+    m_siId = siElement.attribute(QSL("id"));
+    m_mimeType = siElement.attribute(QSL("mime-type"));
+    if (siElement.attribute(QSL("profile")) == ns_stream_initiation_file_transfer)
         m_profile = FileTransfer;
     else
         m_profile = None;
 
     QDomElement itemElement = siElement.firstChildElement();
     while (!itemElement.isNull()) {
-        if (itemElement.tagName() == "feature" && itemElement.namespaceURI() == ns_feature_negotiation) {
+        if (itemElement.tagName() == QSL("feature") && itemElement.namespaceURI() == ns_feature_negotiation) {
             m_featureForm.parse(itemElement.firstChildElement());
-        } else if (itemElement.tagName() == "file" && itemElement.namespaceURI() == ns_stream_initiation_file_transfer) {
+        } else if (itemElement.tagName() == QSL("file") && itemElement.namespaceURI() == ns_stream_initiation_file_transfer) {
             m_fileInfo.parse(itemElement);
         }
         itemElement = itemElement.nextSiblingElement();
@@ -107,16 +107,16 @@ void QXmppStreamInitiationIq::parseElementFromChild(const QDomElement &element)
 
 void QXmppStreamInitiationIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("si");
+    writer->writeStartElement(QSL("si"));
     writer->writeDefaultNamespace(ns_stream_initiation);
-    helperToXmlAddAttribute(writer, "id", m_siId);
-    helperToXmlAddAttribute(writer, "mime-type", m_mimeType);
+    helperToXmlAddAttribute(writer, QSL("id"), m_siId);
+    helperToXmlAddAttribute(writer, QSL("mime-type"), m_mimeType);
     if (m_profile == FileTransfer)
-        helperToXmlAddAttribute(writer, "profile", ns_stream_initiation_file_transfer);
+        helperToXmlAddAttribute(writer, QSL("profile"), ns_stream_initiation_file_transfer);
     if (!m_fileInfo.isNull())
         m_fileInfo.toXml(writer);
     if (!m_featureForm.isNull()) {
-        writer->writeStartElement("feature");
+        writer->writeStartElement(QSL("feature"));
         writer->writeDefaultNamespace(ns_feature_negotiation);
         m_featureForm.toXml(writer);
         writer->writeEndElement();

--- a/src/base/QXmppStreamManagement.cpp
+++ b/src/base/QXmppStreamManagement.cpp
@@ -25,6 +25,8 @@
 #include "QXmppStanza_p.h"
 #include "QXmppStreamManagement_p.h"
 
+#include "QXmppGlobal.h"
+
 QXmppStreamManagementEnable::QXmppStreamManagementEnable(const bool resume, const unsigned max)
     : m_resume(resume), m_max(max)
 {
@@ -58,19 +60,19 @@ bool QXmppStreamManagementEnable::isStreamManagementEnable(const QDomElement &el
 
 void QXmppStreamManagementEnable::parse(const QDomElement &element)
 {
-    QString resume = element.attribute("resume");
-    m_resume = resume == QString("true") || resume == QString("1");
-    m_max = element.attribute("max").toUInt();
+    QString resume = element.attribute(QSL("resume"));
+    m_resume = resume == QSL("true") || resume == QSL("1");
+    m_max = element.attribute(QSL("max")).toUInt();
 }
 
 void QXmppStreamManagementEnable::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("enable");
+    writer->writeStartElement(QSL("enable"));
     writer->writeDefaultNamespace(ns_stream_management);
     if (m_resume)
-        writer->writeAttribute("resume", "true");
+        writer->writeAttribute(QSL("resume"), QSL("true"));
     if (m_max > 0)
-        writer->writeAttribute("max", QString::number(m_max));
+        writer->writeAttribute(QSL("max"), QString::number(m_max));
     writer->writeEndElement();
 }
 
@@ -127,22 +129,22 @@ bool QXmppStreamManagementEnabled::isStreamManagementEnabled(const QDomElement &
 
 void QXmppStreamManagementEnabled::parse(const QDomElement &element)
 {
-    QString resume = element.attribute("resume");
-    m_resume = resume == QString("true") || resume == QString("1");
-    m_max = element.attribute("max").toUInt();
-    m_location = element.attribute("location");
+    QString resume = element.attribute(QSL("resume"));
+    m_resume = resume == QSL("true") || resume == QSL("1");
+    m_max = element.attribute(QSL("max")).toUInt();
+    m_location = element.attribute(QSL("location"));
 }
 
 void QXmppStreamManagementEnabled::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("enable");
+    writer->writeStartElement(QSL("enable"));
     writer->writeDefaultNamespace(ns_stream_management);
     if (m_resume)
-        writer->writeAttribute("resume", "true");
+        writer->writeAttribute(QSL("resume"), QSL("true"));
     if (m_max > 0)
-        writer->writeAttribute("max", QString::number(m_max));
+        writer->writeAttribute(QSL("max"), QString::number(m_max));
     if (!m_location.isEmpty())
-        writer->writeAttribute("location", m_location);
+        writer->writeAttribute(QSL("location"), m_location);
     writer->writeEndElement();
 }
 
@@ -179,15 +181,15 @@ bool QXmppStreamManagementResume::isStreamManagementResume(const QDomElement &el
 
 void QXmppStreamManagementResume::parse(const QDomElement &element)
 {
-    m_h = element.attribute("h").toUInt();
-    m_previd = element.attribute("previd");
+    m_h = element.attribute(QSL("h")).toUInt();
+    m_previd = element.attribute(QSL("previd"));
 }
 
 void QXmppStreamManagementResume::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("resume");
-    writer->writeAttribute("h", QString::number(m_h));
-    writer->writeAttribute("previd", m_previd);
+    writer->writeStartElement(QSL("resume"));
+    writer->writeAttribute(QSL("h"), QString::number(m_h));
+    writer->writeAttribute(QSL("previd"), m_previd);
     writer->writeEndElement();
 }
 
@@ -224,15 +226,15 @@ bool QXmppStreamManagementResumed::isStreamManagementResumed(const QDomElement &
 
 void QXmppStreamManagementResumed::parse(const QDomElement &element)
 {
-    m_h = element.attribute("h").toUInt();
-    m_previd = element.attribute("previd");
+    m_h = element.attribute(QSL("h")).toUInt();
+    m_previd = element.attribute(QSL("previd"));
 }
 
 void QXmppStreamManagementResumed::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("resumed");
-    writer->writeAttribute("h", QString::number(m_h));
-    writer->writeAttribute("previd", m_previd);
+    writer->writeStartElement(QSL("resumed"));
+    writer->writeAttribute(QSL("h"), QString::number(m_h));
+    writer->writeAttribute(QSL("previd"), m_previd);
     writer->writeEndElement();
 }
 
@@ -269,7 +271,7 @@ void QXmppStreamManagementFailed::toXml(QXmlStreamWriter *writer) const
 {
     QString errorString = strFromCondition(m_error);
 
-    writer->writeStartElement("failed");
+    writer->writeStartElement(QSL("failed"));
     writer->writeDefaultNamespace(ns_stream_management);
     writer->writeStartElement(errorString, ns_stanza);
     writer->writeEndElement();
@@ -293,14 +295,14 @@ void QXmppStreamManagementAck::setSeqNo(const unsigned seqNo)
 
 void QXmppStreamManagementAck::parse(const QDomElement &element)
 {
-    m_seqNo = element.attribute("h").toUInt();
+    m_seqNo = element.attribute(QSL("h")).toUInt();
 }
 
 void QXmppStreamManagementAck::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("a");
+    writer->writeStartElement(QSL("a"));
     writer->writeDefaultNamespace(ns_stream_management);
-    writer->writeAttribute("h", QString::number(m_seqNo));
+    writer->writeAttribute(QSL("h"), QString::number(m_seqNo));
     writer->writeEndElement();
 }
 

--- a/src/base/QXmppStreamManagement.cpp
+++ b/src/base/QXmppStreamManagement.cpp
@@ -22,10 +22,9 @@
  */
 
 #include "QXmppConstants_p.h"
+#include "QXmppGlobal.h"
 #include "QXmppStanza_p.h"
 #include "QXmppStreamManagement_p.h"
-
-#include "QXmppGlobal.h"
 
 QXmppStreamManagementEnable::QXmppStreamManagementEnable(const bool resume, const unsigned max)
     : m_resume(resume), m_max(max)

--- a/src/base/QXmppStun.cpp
+++ b/src/base/QXmppStun.cpp
@@ -773,7 +773,7 @@ bool QXmppStunMessage::decode(const QByteArray &buffer, const QByteArray &key, Q
 
             // Unknown attribute
             stream.skipRawData(a_length);
-            *errors << QString("Skipping unknown attribute %1").arg(QString::number(a_type));
+            *errors << QSL("Skipping unknown attribute %1").arg(QString::number(a_type));
         }
         stream.skipRawData(pad_length);
         done += 4 + a_length + pad_length;
@@ -988,108 +988,108 @@ QString QXmppStunMessage::toString() const
     QString typeName;
     switch (messageMethod()) {
     case Binding:
-        typeName = "Binding";
+        typeName = QSL("Binding");
         break;
     case SharedSecret:
-        typeName = "Shared Secret";
+        typeName = QSL("Shared Secret");
         break;
     case Allocate:
-        typeName = "Allocate";
+        typeName = QSL("Allocate");
         break;
     case Refresh:
-        typeName = "Refresh";
+        typeName = QSL("Refresh");
         break;
     case Send:
-        typeName = "Send";
+        typeName = QSL("Send");
         break;
     case Data:
-        typeName = "Data";
+        typeName = QSL("Data");
         break;
     case CreatePermission:
-        typeName = "CreatePermission";
+        typeName = QSL("CreatePermission");
         break;
     case ChannelBind:
-        typeName = "ChannelBind";
+        typeName = QSL("ChannelBind");
         break;
     default:
-        typeName = "Unknown";
+        typeName = QSL("Unknown");
         break;
     }
     switch (messageClass()) {
     case Request:
-        typeName += " Request";
+        typeName += QSL(" Request");
         break;
     case Indication:
-        typeName += " Indication";
+        typeName += QSL(" Indication");
         break;
     case Response:
-        typeName += " Response";
+        typeName += QSL(" Response");
         break;
     case Error:
-        typeName += " Error";
+        typeName += QSL(" Error");
         break;
     default:
         break;
     }
-    dumpLines << QString(" type %1 (%2)")
+    dumpLines << QSL(" type %1 (%2)")
                      .arg(typeName)
                      .arg(QString::number(m_type));
-    dumpLines << QString(" id %1").arg(QString::fromLatin1(m_id.toHex()));
+    dumpLines << QSL(" id %1").arg(QString::fromLatin1(m_id.toHex()));
 
     // attributes
     if (m_attributes.contains(ChannelNumber))
-        dumpLines << QString(" * CHANNEL-NUMBER %1").arg(QString::number(m_channelNumber));
+        dumpLines << QSL(" * CHANNEL-NUMBER %1").arg(QString::number(m_channelNumber));
     if (errorCode)
-        dumpLines << QString(" * ERROR-CODE %1 %2")
+        dumpLines << QSL(" * ERROR-CODE %1 %2")
                          .arg(QString::number(errorCode), errorPhrase);
     if (m_attributes.contains(Lifetime))
-        dumpLines << QString(" * LIFETIME %1").arg(QString::number(m_lifetime));
+        dumpLines << QSL(" * LIFETIME %1").arg(QString::number(m_lifetime));
     if (m_attributes.contains(Nonce))
-        dumpLines << QString(" * NONCE %1").arg(QString::fromLatin1(m_nonce));
+        dumpLines << QSL(" * NONCE %1").arg(QString::fromLatin1(m_nonce));
     if (m_attributes.contains(Realm))
-        dumpLines << QString(" * REALM %1").arg(m_realm);
+        dumpLines << QSL(" * REALM %1").arg(m_realm);
     if (m_attributes.contains(RequestedTransport))
-        dumpLines << QString(" * REQUESTED-TRANSPORT 0x%1").arg(QString::number(m_requestedTransport, 16));
+        dumpLines << QSL(" * REQUESTED-TRANSPORT 0x%1").arg(QString::number(m_requestedTransport, 16));
     if (m_attributes.contains(ReservationToken))
-        dumpLines << QString(" * RESERVATION-TOKEN %1").arg(QString::fromLatin1(m_reservationToken.toHex()));
+        dumpLines << QSL(" * RESERVATION-TOKEN %1").arg(QString::fromLatin1(m_reservationToken.toHex()));
     if (m_attributes.contains(Software))
-        dumpLines << QString(" * SOFTWARE %1").arg(m_software);
+        dumpLines << QSL(" * SOFTWARE %1").arg(m_software);
     if (m_attributes.contains(Username))
-        dumpLines << QString(" * USERNAME %1").arg(m_username);
+        dumpLines << QSL(" * USERNAME %1").arg(m_username);
     if (mappedPort)
-        dumpLines << QString(" * MAPPED-ADDRESS %1 %2")
+        dumpLines << QSL(" * MAPPED-ADDRESS %1 %2")
                          .arg(mappedHost.toString(), QString::number(mappedPort));
     if (m_attributes.contains(ChangeRequest))
-        dumpLines << QString(" * CHANGE-REQUEST %1")
+        dumpLines << QSL(" * CHANGE-REQUEST %1")
                          .arg(QString::number(m_changeRequest));
     if (sourcePort)
-        dumpLines << QString(" * SOURCE-ADDRESS %1 %2")
+        dumpLines << QSL(" * SOURCE-ADDRESS %1 %2")
                          .arg(sourceHost.toString(), QString::number(sourcePort));
     if (changedPort)
-        dumpLines << QString(" * CHANGED-ADDRESS %1 %2")
+        dumpLines << QSL(" * CHANGED-ADDRESS %1 %2")
                          .arg(changedHost.toString(), QString::number(changedPort));
     if (otherPort)
-        dumpLines << QString(" * OTHER-ADDRESS %1 %2")
+        dumpLines << QSL(" * OTHER-ADDRESS %1 %2")
                          .arg(otherHost.toString(), QString::number(otherPort));
     if (xorMappedPort)
-        dumpLines << QString(" * XOR-MAPPED-ADDRESS %1 %2")
+        dumpLines << QSL(" * XOR-MAPPED-ADDRESS %1 %2")
                          .arg(xorMappedHost.toString(), QString::number(xorMappedPort));
     if (xorPeerPort)
-        dumpLines << QString(" * XOR-PEER-ADDRESS %1 %2")
+        dumpLines << QSL(" * XOR-PEER-ADDRESS %1 %2")
                          .arg(xorPeerHost.toString(), QString::number(xorPeerPort));
     if (xorRelayedPort)
-        dumpLines << QString(" * XOR-RELAYED-ADDRESS %1 %2")
+        dumpLines << QSL(" * XOR-RELAYED-ADDRESS %1 %2")
                          .arg(xorRelayedHost.toString(), QString::number(xorRelayedPort));
     if (m_attributes.contains(Priority))
-        dumpLines << QString(" * PRIORITY %1").arg(QString::number(m_priority));
+        dumpLines << QSL(" * PRIORITY %1").arg(QString::number(m_priority));
     if (!iceControlling.isEmpty())
-        dumpLines << QString(" * ICE-CONTROLLING %1")
+        dumpLines << QSL(" * ICE-CONTROLLING %1")
                          .arg(QString::fromLatin1(iceControlling.toHex()));
     if (!iceControlled.isEmpty())
-        dumpLines << QString(" * ICE-CONTROLLED %1")
+        dumpLines << QSL(" * ICE-CONTROLLED %1")
                          .arg(QString::fromLatin1(iceControlled.toHex()));
     if (useCandidate)
-        dumpLines << QString(" * USE-CANDIDATE");
+        dumpLines << QSL(" * USE-CANDIDATE");
 
     return dumpLines.join("\n");
 }
@@ -1212,7 +1212,7 @@ void QXmppTurnAllocation::connectToHost()
     // start listening for UDP
     if (socket->state() == QAbstractSocket::UnconnectedState) {
         if (!socket->bind()) {
-            warning("Could not start listening for TURN");
+            warning(QSL("Could not start listening for TURN"));
             return;
         }
     }
@@ -1314,7 +1314,7 @@ void QXmppTurnAllocation::handleDatagram(const QByteArray &buffer, const QHostAd
     }
 
 #ifdef QXMPP_DEBUG_STUN
-    logReceived(QString("TURN packet from %1 port %2\n%3").arg(remoteHost.toString(), QString::number(remotePort), message.toString()));
+    logReceived(QSL("TURN packet from %1 port %2\n%3").arg(remoteHost.toString(), QString::number(remotePort), message.toString()));
 #endif
 
     // find transaction
@@ -1457,7 +1457,7 @@ void QXmppTurnAllocation::transactionFinished()
     if (method == QXmppStunMessage::Allocate) {
 
         if (reply.messageClass() == QXmppStunMessage::Error) {
-            warning(QString("Allocation failed: %1 %2").arg(QString::number(reply.errorCode), reply.errorPhrase));
+            warning(QSL("Allocation failed: %1 %2").arg(QString::number(reply.errorCode), reply.errorPhrase));
             setState(UnconnectedState);
             return;
         }
@@ -1482,7 +1482,7 @@ void QXmppTurnAllocation::transactionFinished()
     } else if (method == QXmppStunMessage::ChannelBind) {
 
         if (reply.messageClass() == QXmppStunMessage::Error) {
-            warning(QString("ChannelBind failed: %1 %2").arg(QString::number(reply.errorCode), reply.errorPhrase));
+            warning(QSL("ChannelBind failed: %1 %2").arg(QString::number(reply.errorCode), reply.errorPhrase));
 
             // remove channel
             m_channels.remove(transaction->request().channelNumber());
@@ -1494,7 +1494,7 @@ void QXmppTurnAllocation::transactionFinished()
     } else if (method == QXmppStunMessage::Refresh) {
 
         if (reply.messageClass() == QXmppStunMessage::Error) {
-            warning(QString("Refresh failed: %1 %2").arg(QString::number(reply.errorCode), reply.errorPhrase));
+            warning(QSL("Refresh failed: %1 %2").arg(QString::number(reply.errorCode), reply.errorPhrase));
             setState(UnconnectedState);
             return;
         }
@@ -1556,7 +1556,7 @@ void QXmppTurnAllocation::writeStun(const QXmppStunMessage &message)
 {
     socket->writeDatagram(message.encode(m_key), m_turnHost, m_turnPort);
 #ifdef QXMPP_DEBUG_STUN
-    logSent(QString("TURN packet to %1 port %2\n%3").arg(m_turnHost.toString(), QString::number(m_turnPort), message.toString()));
+    logSent(QSL("TURN packet to %1 port %2\n%3").arg(m_turnHost.toString(), QString::number(m_turnPort), message.toString()));
 #endif
 }
 
@@ -1589,7 +1589,7 @@ QXmppJingleCandidate QXmppUdpTransport::localCandidate(int component) const
     candidate.setHost(addr);
     candidate.setId(QXmppUtils::generateStanzaHash(10));
     candidate.setPort(m_socket->localPort());
-    candidate.setProtocol("udp");
+    candidate.setProtocol(QSL("udp"));
     candidate.setType(QXmppJingleCandidate::HostType);
     candidate.setPriority(candidatePriority(candidate));
     candidate.setFoundation(computeFoundation(
@@ -1677,19 +1677,19 @@ CandidatePair::State CandidatePair::state() const
 void CandidatePair::setState(CandidatePair::State state)
 {
     m_state = state;
-    info(QString("ICE pair changed to state %1 %2").arg(QLatin1String(pair_states[state]), toString()));
+    info(QSL("ICE pair changed to state %1 %2").arg(QLatin1String(pair_states[state]), toString()));
 }
 
 QString CandidatePair::toString() const
 {
     const QXmppJingleCandidate candidate = transport->localCandidate(m_component);
-    QString str = QString("%1 port %2").arg(remote.host().toString(), QString::number(remote.port()));
+    QString str = QSL("%1 port %2").arg(remote.host().toString(), QString::number(remote.port()));
     if (candidate.type() == QXmppJingleCandidate::HostType)
-        str += QString(" (local %1 port %2)").arg(candidate.host().toString(), QString::number(candidate.port()));
+        str += QSL(" (local %1 port %2)").arg(candidate.host().toString(), QString::number(candidate.port()));
     else
-        str += QString(" (relayed)");
+        str += QSL(" (relayed)");
     if (!reflexive.host().isNull() && reflexive.port())
-        str += QString(" (reflexive %1 port %2)").arg(reflexive.host().toString(), QString::number(reflexive.port()));
+        str += QSL(" (reflexive %1 port %2)").arg(reflexive.host().toString(), QString::number(reflexive.port()));
     return str;
 }
 
@@ -1773,7 +1773,7 @@ bool QXmppIceComponentPrivate::addRemoteCandidate(const QXmppJingleCandidate &ca
         (candidate.type() != QXmppJingleCandidate::HostType &&
          candidate.type() != QXmppJingleCandidate::RelayedType &&
          candidate.type() != QXmppJingleCandidate::ServerReflexiveType) ||
-        candidate.protocol() != "udp" ||
+        candidate.protocol() != QSL("udp") ||
         (candidate.host().protocol() != QAbstractSocket::IPv4Protocol &&
          candidate.host().protocol() != QAbstractSocket::IPv6Protocol))
         return false;
@@ -1818,7 +1818,7 @@ void QXmppIceComponentPrivate::performCheck(CandidatePair *pair, bool nominate)
     message.setId(QXmppUtils::generateRandomBytes(STUN_ID_SIZE));
     message.setType(QXmppStunMessage::Binding | QXmppStunMessage::Request);
     message.setPriority(peerReflexivePriority);
-    message.setUsername(QString("%1:%2").arg(config->remoteUser, config->localUser));
+    message.setUsername(QSL("%1:%2").arg(config->remoteUser, config->localUser));
     if (config->iceControlling) {
         message.iceControlling = config->tieBreaker;
         message.useCandidate = true;
@@ -1903,7 +1903,7 @@ void QXmppIceComponentPrivate::writeStun(const QXmppStunMessage &message, QXmppI
     const QByteArray data = message.encode(messagePassword.toUtf8());
     transport->writeDatagram(data, address, port);
 #ifdef QXMPP_DEBUG_STUN
-    q->logSent(QString("STUN packet to %1 port %2\n%3").arg(address.toString(), QString::number(port), message.toString()));
+    q->logSent(QSL("STUN packet to %1 port %2\n%3").arg(address.toString(), QString::number(port), message.toString()));
 #endif
 }
 
@@ -1937,7 +1937,7 @@ QXmppIceComponent::QXmppIceComponent(int component, QXmppIcePrivate *config, QOb
     reflexive.setType(QXmppJingleCandidate::PeerReflexiveType);
     d->peerReflexivePriority = candidatePriority(reflexive);
 
-    setObjectName(QString("STUN(%1)").arg(QString::number(d->component)));
+    setObjectName(QSL("STUN(%1)").arg(QString::number(d->component)));
 }
 
 /// Destroys the QXmppIceComponent.
@@ -1960,7 +1960,7 @@ void QXmppIceComponent::checkCandidates()
 {
     if (d->config->remoteUser.isEmpty())
         return;
-    debug("Checking remote candidates");
+    debug(QSL("Checking remote candidates"));
 
     for (auto *pair : d->pairs) {
         if (pair->state() == CandidatePair::WaitingState) {
@@ -2056,7 +2056,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
         return;
     }
 #ifdef QXMPP_DEBUG_STUN
-    logReceived(QString("STUN packet from %1 port %2\n%3").arg(remoteHost.toString(), QString::number(remotePort), message.toString()));
+    logReceived(QSL("STUN packet from %1 port %2\n%3").arg(remoteHost.toString(), QString::number(remotePort), message.toString()));
 #endif
 
     // we only want binding requests and responses
@@ -2074,10 +2074,10 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
     if (message.messageClass() == QXmppStunMessage::Request) {
         // check for role conflict
         if (d->config->iceControlling && (!message.iceControlling.isEmpty() || message.useCandidate)) {
-            warning("Role conflict, expected to be controlling");
+            warning(QSL("Role conflict, expected to be controlling"));
             return;
         } else if (!d->config->iceControlling && !message.iceControlled.isEmpty()) {
-            warning("Role conflict, expected to be controlled");
+            warning(QSL("Role conflict, expected to be controlled"));
             return;
         }
 
@@ -2106,7 +2106,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
             remoteCandidate.setId(QXmppUtils::generateStanzaHash(10));
             remoteCandidate.setPort(remotePort);
             remoteCandidate.setPriority(message.priority());
-            remoteCandidate.setProtocol("udp");
+            remoteCandidate.setProtocol(QSL("udp"));
             remoteCandidate.setType(QXmppJingleCandidate::PeerReflexiveType);
             remoteCandidate.setFoundation(QXmppUtils::generateStanzaHash(32));
 
@@ -2163,7 +2163,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
         if (remoteHost != pair->remote.host() || remotePort != pair->remote.port()) {
             QXmppStunMessage error;
             error.setType(QXmppStunMessage::Error);
-            error.errorPhrase = QString("Received response from unexpected %1:%1").arg(remoteHost.toString(), QString::number(remotePort));
+            error.errorPhrase = QSL("Received response from unexpected %1:%1").arg(remoteHost.toString(), QString::number(remotePort));
             pair->transaction->readStun(error);
             return;
         }
@@ -2175,7 +2175,7 @@ void QXmppIceComponent::handleDatagram(const QByteArray &buffer, const QHostAddr
     if (pair && pair->nominated) {
         d->timer->stop();
         if (!d->activePair || pair->priority() > d->activePair->priority()) {
-            info(QString("ICE pair selected %1 (priority: %2)").arg(pair->toString(), QString::number(pair->priority())));
+            info(QSL("ICE pair selected %1 (priority: %2)").arg(pair->toString(), QString::number(pair->priority())));
             const bool wasConnected = (d->activePair != nullptr);
             d->activePair = pair;
             if (!wasConnected)
@@ -2206,7 +2206,7 @@ void QXmppIceComponent::transactionFinished()
                 pair->nominated = true;
             }
         } else {
-            debug(QString("ICE forward check failed %1 (error %2)").arg(pair->toString(), transaction->response().errorPhrase));
+            debug(QSL("ICE forward check failed %1 (error %2)").arg(pair->toString(), transaction->response().errorPhrase));
             pair->setState(CandidatePair::FailedState);
         }
         pair->transaction = nullptr;
@@ -2228,7 +2228,7 @@ void QXmppIceComponent::transactionFinished()
                 reflexiveHost = response.mappedHost;
                 reflexivePort = response.mappedPort;
             } else {
-                warning("STUN server did not provide a reflexive address");
+                warning(QSL("STUN server did not provide a reflexive address"));
                 return;
             }
 
@@ -2241,7 +2241,7 @@ void QXmppIceComponent::transactionFinished()
             }
 
             // add the new local candidate
-            debug(QString("Adding server-reflexive candidate %1 port %2").arg(reflexiveHost.toString(), QString::number(reflexivePort)));
+            debug(QSL("Adding server-reflexive candidate %1 port %2").arg(reflexiveHost.toString(), QString::number(reflexivePort)));
             QXmppJingleCandidate candidate;
             candidate.setComponent(d->component);
             candidate.setHost(reflexiveHost);
@@ -2259,7 +2259,7 @@ void QXmppIceComponent::transactionFinished()
 
             emit localCandidatesChanged();
         } else {
-            debug(QString("STUN test failed (error %1)").arg(transaction->response().errorPhrase));
+            debug(QSL("STUN test failed (error %1)").arg(transaction->response().errorPhrase));
         }
         d->stunTransactions.remove(transaction);
         updateGatheringState();
@@ -2272,7 +2272,7 @@ void QXmppIceComponent::turnConnected()
     const QXmppJingleCandidate candidate = d->turnAllocation->localCandidate(d->component);
 
     // add the new local candidate
-    debug(QString("Adding relayed candidate %1 port %2").arg(candidate.host().toString(), QString::number(candidate.port())));
+    debug(QSL("Adding relayed candidate %1 port %2").arg(candidate.host().toString(), QString::number(candidate.port())));
     d->localCandidates << candidate;
 
     emit localCandidatesChanged();
@@ -2422,7 +2422,7 @@ void QXmppIceComponent::writeStun(const QXmppStunMessage &message)
     if (transport) {
         transport->writeDatagram(message.encode(), transportDetails.stunHost, transportDetails.stunPort);
 #ifdef QXMPP_DEBUG_STUN
-        logSent(QString("STUN packet to %1 port %2\n%3").arg(transportDetails.stunHost.toString(), QString::number(transportDetails.stunPort), message.toString()));
+        logSent(QSL("STUN packet to %1 port %2\n%3").arg(transportDetails.stunHost.toString(), QString::number(transportDetails.stunPort), message.toString()));
 #endif
         return;
     }
@@ -2488,7 +2488,7 @@ void QXmppIceConnection::addComponent(int component)
 {
 
     if (d->components.contains(component)) {
-        warning(QString("Already have component %1").arg(QString::number(component)));
+        warning(QSL("Already have component %1").arg(QString::number(component)));
         return;
     }
 
@@ -2517,7 +2517,7 @@ void QXmppIceConnection::addRemoteCandidate(const QXmppJingleCandidate &candidat
 {
     QXmppIceComponent *socket = d->components.value(candidate.component());
     if (!socket) {
-        warning(QString("Not adding candidate for unknown component %1").arg(QString::number(candidate.component())));
+        warning(QSL("Not adding candidate for unknown component %1").arg(QString::number(candidate.component())));
         return;
     }
     socket->d->addRemoteCandidate(candidate);
@@ -2709,7 +2709,7 @@ void QXmppIceConnection::slotConnected()
     for (auto *socket : d->components.values())
         if (!socket->isConnected())
             return;
-    info(QString("ICE negotiation completed"));
+    info(QSL("ICE negotiation completed"));
     d->connectTimer->stop();
     emit connected();
 }
@@ -2733,7 +2733,7 @@ void QXmppIceConnection::slotGatheringStateChanged()
         newGatheringState = BusyGatheringState;
 
     if (newGatheringState != d->gatheringState) {
-        info(QString("ICE gathering state changed from '%1' to '%2'").arg(gathering_states[d->gatheringState], gathering_states[newGatheringState]));
+        info(QSL("ICE gathering state changed from '%1' to '%2'").arg(gathering_states[d->gatheringState], gathering_states[newGatheringState]));
         d->gatheringState = newGatheringState;
         emit gatheringStateChanged();
     }
@@ -2741,7 +2741,7 @@ void QXmppIceConnection::slotGatheringStateChanged()
 
 void QXmppIceConnection::slotTimeout()
 {
-    warning(QString("ICE negotiation timed out"));
+    warning(QSL("ICE negotiation timed out"));
     for (auto *socket : d->components.values())
         socket->close();
     emit disconnected();

--- a/src/base/QXmppStun.cpp
+++ b/src/base/QXmppStun.cpp
@@ -1715,8 +1715,7 @@ QXmppIcePrivate::QXmppIcePrivate()
     tieBreaker = QXmppUtils::generateRandomBytes(8);
 }
 
-struct QXmppIceTransportDetails
-{
+struct QXmppIceTransportDetails {
     QXmppIceTransport *transport;
     QHostAddress stunHost;
     quint16 stunPort;
@@ -1868,7 +1867,7 @@ void QXmppIceComponentPrivate::setSockets(QList<QUdpSocket *> sockets)
 
             request.setId(QXmppUtils::generateRandomBytes(STUN_ID_SIZE));
             auto *transaction = new QXmppStunTransaction(request, q);
-            stunTransactions.insert(transaction, {transport, stunServer.first, stunServer.second});
+            stunTransactions.insert(transaction, { transport, stunServer.first, stunServer.second });
         }
     }
 

--- a/src/base/QXmppUtils.cpp
+++ b/src/base/QXmppUtils.cpp
@@ -280,7 +280,8 @@ int QXmppUtils::generateRandomInteger(int N)
 {
     Q_ASSERT(N > 0 && N <= RAND_MAX);
     int val;
-    while (N <= (val = qrand() / (RAND_MAX / N))) { };
+    while (N <= (val = qrand() / (RAND_MAX / N))) {
+    };
     return val;
 }
 

--- a/src/base/QXmppUtils.cpp
+++ b/src/base/QXmppUtils.cpp
@@ -113,25 +113,25 @@ static quint32 crctable[256] = {
 ///
 QDateTime QXmppUtils::datetimeFromString(const QString &str)
 {
-    QRegExp tzRe("(Z|([+-])([0-9]{2}):([0-9]{2}))");
+    QRegExp tzRe(QSL("(Z|([+-])([0-9]{2}):([0-9]{2}))"));
     int tzPos = tzRe.indexIn(str, 19);
     if (str.size() < 20 || tzPos < 0)
         return QDateTime();
 
     // process date and time
-    QDateTime dt = QDateTime::fromString(str.left(19), "yyyy-MM-ddThh:mm:ss");
+    QDateTime dt = QDateTime::fromString(str.left(19), QSL("yyyy-MM-ddThh:mm:ss"));
     dt.setTimeSpec(Qt::UTC);
 
     // process milliseconds
     if (tzPos > 20 && str.at(19) == '.') {
-        QString millis = (str.mid(20, tzPos - 20) + "000").left(3);
+        QString millis = (str.mid(20, tzPos - 20) + QSL("000")).left(3);
         dt = dt.addMSecs(millis.toInt());
     }
 
     // process time zone
-    if (tzRe.cap(1) != "Z") {
+    if (tzRe.cap(1) != QSL("Z")) {
         int offset = tzRe.cap(3).toInt() * 3600 + tzRe.cap(4).toInt() * 60;
-        if (tzRe.cap(2) == "+")
+        if (tzRe.cap(2) == QSL("+"))
             dt = dt.addSecs(-offset);
         else
             dt = dt.addSecs(offset);
@@ -147,9 +147,9 @@ QString QXmppUtils::datetimeToString(const QDateTime &dt)
 {
     QDateTime utc = dt.toUTC();
     if (utc.time().msec())
-        return utc.toString("yyyy-MM-ddThh:mm:ss.zzzZ");
+        return utc.toString(QSL("yyyy-MM-ddThh:mm:ss.zzzZ"));
     else
-        return utc.toString("yyyy-MM-ddThh:mm:ssZ");
+        return utc.toString(QSL("yyyy-MM-ddThh:mm:ssZ"));
 }
 
 ///
@@ -158,18 +158,18 @@ QString QXmppUtils::datetimeToString(const QDateTime &dt)
 ///
 int QXmppUtils::timezoneOffsetFromString(const QString &str)
 {
-    QRegExp tzRe("(Z|([+-])([0-9]{2}):([0-9]{2}))");
+    QRegExp tzRe(QSL("(Z|([+-])([0-9]{2}):([0-9]{2}))"));
     if (!tzRe.exactMatch(str))
         return 0;
 
     // No offset from UTC
-    if (tzRe.cap(1) == "Z")
+    if (tzRe.cap(1) == QSL("Z"))
         return 0;
 
     // Calculate offset
     const int offset = tzRe.cap(3).toInt() * 3600 +
         tzRe.cap(4).toInt() * 60;
-    if (tzRe.cap(2) == "-")
+    if (tzRe.cap(2) == QSL("-"))
         return -offset;
     else
         return offset;
@@ -182,17 +182,17 @@ int QXmppUtils::timezoneOffsetFromString(const QString &str)
 QString QXmppUtils::timezoneOffsetToString(int secs)
 {
     if (!secs)
-        return QString::fromLatin1("Z");
+        return QSL("Z");
 
     const QTime tzoTime = QTime(0, 0, 0).addSecs(qAbs(secs));
-    return (secs < 0 ? "-" : "+") + tzoTime.toString("hh:mm");
+    return (secs < 0 ? QSL("-") : QSL("+")) + tzoTime.toString(QSL("hh:mm"));
 }
 
 /// Returns the domain for the given \a jid.
 
 QString QXmppUtils::jidToDomain(const QString &jid)
 {
-    return jidToBareJid(jid).split("@").last();
+    return jidToBareJid(jid).split(QSL("@")).last();
 }
 
 /// Returns the resource for the given \a jid.
@@ -330,7 +330,7 @@ QString QXmppUtils::generateStanzaHash(int length)
     if (length == 36)
         return QXmppUtils::generateStanzaUuid();
 
-    const QString somechars = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const QString somechars = QSL("1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ");
     const int N = somechars.size();
     QString hashResult;
     for (int idx = 0; idx < length; ++idx)

--- a/src/base/QXmppVCardIq.cpp
+++ b/src/base/QXmppVCardIq.cpp
@@ -32,20 +32,20 @@
 static QString getImageType(const QByteArray &contents)
 {
     if (contents.startsWith("\x89PNG\x0d\x0a\x1a\x0a"))
-        return "image/png";
+        return QSL("image/png");
     else if (contents.startsWith("\x8aMNG"))
-        return "video/x-mng";
+        return QSL("video/x-mng");
     else if (contents.startsWith("GIF8"))
-        return "image/gif";
+        return QSL("image/gif");
     else if (contents.startsWith("BM"))
-        return "image/bmp";
+        return QSL("image/bmp");
     else if (contents.contains("/* XPM */"))
-        return "image/x-xpm";
+        return QSL("image/x-xpm");
     else if (contents.contains("<?xml") && contents.contains("<svg"))
-        return "image/svg+xml";
+        return QSL("image/svg+xml");
     else if (contents.startsWith("\xFF\xD8\xFF\xE0"))
-        return "image/jpeg";
-    return "image/unknown";
+        return QSL("image/jpeg");
+    return QSL("image/unknown");
 }
 
 class QXmppVCardAddressPrivate : public QSharedData
@@ -192,44 +192,44 @@ void QXmppVCardAddress::setType(QXmppVCardAddress::Type type)
 /// \cond
 void QXmppVCardAddress::parse(const QDomElement &element)
 {
-    if (!element.firstChildElement("HOME").isNull())
+    if (!element.firstChildElement(QSL("HOME")).isNull())
         d->type |= Home;
-    if (!element.firstChildElement("WORK").isNull())
+    if (!element.firstChildElement(QSL("WORK")).isNull())
         d->type |= Work;
-    if (!element.firstChildElement("POSTAL").isNull())
+    if (!element.firstChildElement(QSL("POSTAL")).isNull())
         d->type |= Postal;
-    if (!element.firstChildElement("PREF").isNull())
+    if (!element.firstChildElement(QSL("PREF")).isNull())
         d->type |= Preferred;
 
-    d->country = element.firstChildElement("CTRY").text();
-    d->locality = element.firstChildElement("LOCALITY").text();
-    d->postcode = element.firstChildElement("PCODE").text();
-    d->region = element.firstChildElement("REGION").text();
-    d->street = element.firstChildElement("STREET").text();
+    d->country = element.firstChildElement(QSL("CTRY")).text();
+    d->locality = element.firstChildElement(QSL("LOCALITY")).text();
+    d->postcode = element.firstChildElement(QSL("PCODE")).text();
+    d->region = element.firstChildElement(QSL("REGION")).text();
+    d->street = element.firstChildElement(QSL("STREET")).text();
 }
 
 void QXmppVCardAddress::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("ADR");
+    writer->writeStartElement(QSL("ADR"));
     if (d->type & Home)
-        writer->writeEmptyElement("HOME");
+        writer->writeEmptyElement(QSL("HOME"));
     if (d->type & Work)
-        writer->writeEmptyElement("WORK");
+        writer->writeEmptyElement(QSL("WORK"));
     if (d->type & Postal)
-        writer->writeEmptyElement("POSTAL");
+        writer->writeEmptyElement(QSL("POSTAL"));
     if (d->type & Preferred)
-        writer->writeEmptyElement("PREF");
+        writer->writeEmptyElement(QSL("PREF"));
 
     if (!d->country.isEmpty())
-        writer->writeTextElement("CTRY", d->country);
+        writer->writeTextElement(QSL("CTRY"), d->country);
     if (!d->locality.isEmpty())
-        writer->writeTextElement("LOCALITY", d->locality);
+        writer->writeTextElement(QSL("LOCALITY"), d->locality);
     if (!d->postcode.isEmpty())
-        writer->writeTextElement("PCODE", d->postcode);
+        writer->writeTextElement(QSL("PCODE"), d->postcode);
     if (!d->region.isEmpty())
-        writer->writeTextElement("REGION", d->region);
+        writer->writeTextElement(QSL("REGION"), d->region);
     if (!d->street.isEmpty())
-        writer->writeTextElement("STREET", d->street);
+        writer->writeTextElement(QSL("STREET"), d->street);
 
     writer->writeEndElement();
 }
@@ -315,33 +315,33 @@ void QXmppVCardEmail::setType(QXmppVCardEmail::Type type)
 /// \cond
 void QXmppVCardEmail::parse(const QDomElement &element)
 {
-    if (!element.firstChildElement("HOME").isNull())
+    if (!element.firstChildElement(QSL("HOME")).isNull())
         d->type |= Home;
-    if (!element.firstChildElement("WORK").isNull())
+    if (!element.firstChildElement(QSL("WORK")).isNull())
         d->type |= Work;
-    if (!element.firstChildElement("INTERNET").isNull())
+    if (!element.firstChildElement(QSL("INTERNET")).isNull())
         d->type |= Internet;
-    if (!element.firstChildElement("PREF").isNull())
+    if (!element.firstChildElement(QSL("PREF")).isNull())
         d->type |= Preferred;
-    if (!element.firstChildElement("X400").isNull())
+    if (!element.firstChildElement(QSL("X400")).isNull())
         d->type |= X400;
-    d->address = element.firstChildElement("USERID").text();
+    d->address = element.firstChildElement(QSL("USERID")).text();
 }
 
 void QXmppVCardEmail::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("EMAIL");
+    writer->writeStartElement(QSL("EMAIL"));
     if (d->type & Home)
-        writer->writeEmptyElement("HOME");
+        writer->writeEmptyElement(QSL("HOME"));
     if (d->type & Work)
-        writer->writeEmptyElement("WORK");
+        writer->writeEmptyElement(QSL("WORK"));
     if (d->type & Internet)
-        writer->writeEmptyElement("INTERNET");
+        writer->writeEmptyElement(QSL("INTERNET"));
     if (d->type & Preferred)
-        writer->writeEmptyElement("PREF");
+        writer->writeEmptyElement(QSL("PREF"));
     if (d->type & X400)
-        writer->writeEmptyElement("X400");
-    writer->writeTextElement("USERID", d->address);
+        writer->writeEmptyElement(QSL("X400"));
+    writer->writeTextElement(QSL("USERID"), d->address);
     writer->writeEndElement();
 }
 /// \endcond
@@ -426,65 +426,65 @@ void QXmppVCardPhone::setType(QXmppVCardPhone::Type type)
 /// \cond
 void QXmppVCardPhone::parse(const QDomElement &element)
 {
-    if (!element.firstChildElement("HOME").isNull())
+    if (!element.firstChildElement(QSL("HOME")).isNull())
         d->type |= Home;
-    if (!element.firstChildElement("WORK").isNull())
+    if (!element.firstChildElement(QSL("WORK")).isNull())
         d->type |= Work;
-    if (!element.firstChildElement("VOICE").isNull())
+    if (!element.firstChildElement(QSL("VOICE")).isNull())
         d->type |= Voice;
-    if (!element.firstChildElement("FAX").isNull())
+    if (!element.firstChildElement(QSL("FAX")).isNull())
         d->type |= Fax;
-    if (!element.firstChildElement("PAGER").isNull())
+    if (!element.firstChildElement(QSL("PAGER")).isNull())
         d->type |= Pager;
-    if (!element.firstChildElement("MSG").isNull())
+    if (!element.firstChildElement(QSL("MSG")).isNull())
         d->type |= Messaging;
-    if (!element.firstChildElement("CELL").isNull())
+    if (!element.firstChildElement(QSL("CELL")).isNull())
         d->type |= Cell;
-    if (!element.firstChildElement("VIDEO").isNull())
+    if (!element.firstChildElement(QSL("VIDEO")).isNull())
         d->type |= Video;
-    if (!element.firstChildElement("BBS").isNull())
+    if (!element.firstChildElement(QSL("BBS")).isNull())
         d->type |= BBS;
-    if (!element.firstChildElement("MODEM").isNull())
+    if (!element.firstChildElement(QSL("MODEM")).isNull())
         d->type |= Modem;
-    if (!element.firstChildElement("ISDN").isNull())
+    if (!element.firstChildElement(QSL("ISDN")).isNull())
         d->type |= ISDN;
-    if (!element.firstChildElement("PCS").isNull())
+    if (!element.firstChildElement(QSL("PCS")).isNull())
         d->type |= PCS;
-    if (!element.firstChildElement("PREF").isNull())
+    if (!element.firstChildElement(QSL("PREF")).isNull())
         d->type |= Preferred;
-    d->number = element.firstChildElement("NUMBER").text();
+    d->number = element.firstChildElement(QSL("NUMBER")).text();
 }
 
 void QXmppVCardPhone::toXml(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("TEL");
+    writer->writeStartElement(QSL("TEL"));
     if (d->type & Home)
-        writer->writeEmptyElement("HOME");
+        writer->writeEmptyElement(QSL("HOME"));
     if (d->type & Work)
-        writer->writeEmptyElement("WORK");
+        writer->writeEmptyElement(QSL("WORK"));
     if (d->type & Voice)
-        writer->writeEmptyElement("VOICE");
+        writer->writeEmptyElement(QSL("VOICE"));
     if (d->type & Fax)
-        writer->writeEmptyElement("FAX");
+        writer->writeEmptyElement(QSL("FAX"));
     if (d->type & Pager)
-        writer->writeEmptyElement("PAGER");
+        writer->writeEmptyElement(QSL("PAGER"));
     if (d->type & Messaging)
-        writer->writeEmptyElement("MSG");
+        writer->writeEmptyElement(QSL("MSG"));
     if (d->type & Cell)
-        writer->writeEmptyElement("CELL");
+        writer->writeEmptyElement(QSL("CELL"));
     if (d->type & Video)
-        writer->writeEmptyElement("VIDEO");
+        writer->writeEmptyElement(QSL("VIDEO"));
     if (d->type & BBS)
-        writer->writeEmptyElement("BBS");
+        writer->writeEmptyElement(QSL("BBS"));
     if (d->type & Modem)
-        writer->writeEmptyElement("MODEM");
+        writer->writeEmptyElement(QSL("MODEM"));
     if (d->type & ISDN)
-        writer->writeEmptyElement("ISDN");
+        writer->writeEmptyElement(QSL("ISDN"));
     if (d->type & PCS)
-        writer->writeEmptyElement("PCS");
+        writer->writeEmptyElement(QSL("PCS"));
     if (d->type & Preferred)
-        writer->writeEmptyElement("PREF");
-    writer->writeTextElement("NUMBER", d->number);
+        writer->writeEmptyElement(QSL("PREF"));
+    writer->writeTextElement(QSL("NUMBER"), d->number);
     writer->writeEndElement();
 }
 /// \endcond
@@ -600,25 +600,25 @@ void QXmppVCardOrganization::setTitle(const QString &title)
 /// \cond
 void QXmppVCardOrganization::parse(const QDomElement &cardElem)
 {
-    d->title = cardElem.firstChildElement("TITLE").text();
-    d->role = cardElem.firstChildElement("ROLE").text();
+    d->title = cardElem.firstChildElement(QSL("TITLE")).text();
+    d->role = cardElem.firstChildElement(QSL("ROLE")).text();
 
-    const QDomElement &orgElem = cardElem.firstChildElement("ORG");
-    d->organization = orgElem.firstChildElement("ORGNAME").text();
-    d->unit = orgElem.firstChildElement("ORGUNIT").text();
+    const QDomElement &orgElem = cardElem.firstChildElement(QSL("ORG"));
+    d->organization = orgElem.firstChildElement(QSL("ORGNAME")).text();
+    d->unit = orgElem.firstChildElement(QSL("ORGUNIT")).text();
 }
 
 void QXmppVCardOrganization::toXml(QXmlStreamWriter *stream) const
 {
     if (!d->unit.isEmpty() || !d->organization.isEmpty()) {
-        stream->writeStartElement("ORG");
-        stream->writeTextElement("ORGNAME", d->organization);
-        stream->writeTextElement("ORGUNIT", d->unit);
+        stream->writeStartElement(QSL("ORG"));
+        stream->writeTextElement(QSL("ORGNAME"), d->organization);
+        stream->writeTextElement(QSL("ORGUNIT"), d->unit);
         stream->writeEndElement();
     }
 
-    helperToXmlAddTextElement(stream, "TITLE", d->title);
-    helperToXmlAddTextElement(stream, "ROLE", d->role);
+    helperToXmlAddTextElement(stream, QSL("TITLE"), d->title);
+    helperToXmlAddTextElement(stream, QSL("ROLE"), d->role);
 }
 /// \endcond
 
@@ -959,38 +959,38 @@ void QXmppVCardIq::setOrganization(const QXmppVCardOrganization &org)
 /// \cond
 bool QXmppVCardIq::isVCard(const QDomElement &nodeRecv)
 {
-    return nodeRecv.firstChildElement("vCard").namespaceURI() == ns_vcard;
+    return nodeRecv.firstChildElement(QSL("vCard")).namespaceURI() == ns_vcard;
 }
 
 void QXmppVCardIq::parseElementFromChild(const QDomElement &nodeRecv)
 {
     // vCard
-    QDomElement cardElement = nodeRecv.firstChildElement("vCard");
-    d->birthday = QDate::fromString(cardElement.firstChildElement("BDAY").text(), "yyyy-MM-dd");
-    d->description = cardElement.firstChildElement("DESC").text();
-    d->fullName = cardElement.firstChildElement("FN").text();
-    d->nickName = cardElement.firstChildElement("NICKNAME").text();
-    QDomElement nameElement = cardElement.firstChildElement("N");
-    d->firstName = nameElement.firstChildElement("GIVEN").text();
-    d->lastName = nameElement.firstChildElement("FAMILY").text();
-    d->middleName = nameElement.firstChildElement("MIDDLE").text();
-    d->url = cardElement.firstChildElement("URL").text();
-    QDomElement photoElement = cardElement.firstChildElement("PHOTO");
-    QByteArray base64data = photoElement.firstChildElement("BINVAL").text().toLatin1();
+    QDomElement cardElement = nodeRecv.firstChildElement(QSL("vCard"));
+    d->birthday = QDate::fromString(cardElement.firstChildElement(QSL("BDAY")).text(), QSL("yyyy-MM-dd"));
+    d->description = cardElement.firstChildElement(QSL("DESC")).text();
+    d->fullName = cardElement.firstChildElement(QSL("FN")).text();
+    d->nickName = cardElement.firstChildElement(QSL("NICKNAME")).text();
+    QDomElement nameElement = cardElement.firstChildElement(QSL("N"));
+    d->firstName = nameElement.firstChildElement(QSL("GIVEN")).text();
+    d->lastName = nameElement.firstChildElement(QSL("FAMILY")).text();
+    d->middleName = nameElement.firstChildElement(QSL("MIDDLE")).text();
+    d->url = cardElement.firstChildElement(QSL("URL")).text();
+    QDomElement photoElement = cardElement.firstChildElement(QSL("PHOTO"));
+    QByteArray base64data = photoElement.firstChildElement(QSL("BINVAL")).text().toLatin1();
     d->photo = QByteArray::fromBase64(base64data);
-    d->photoType = photoElement.firstChildElement("TYPE").text();
+    d->photoType = photoElement.firstChildElement(QSL("TYPE")).text();
 
     QDomElement child = cardElement.firstChildElement();
     while (!child.isNull()) {
-        if (child.tagName() == "ADR") {
+        if (child.tagName() == QSL("ADR")) {
             QXmppVCardAddress address;
             address.parse(child);
             d->addresses << address;
-        } else if (child.tagName() == "EMAIL") {
+        } else if (child.tagName() == QSL("EMAIL")) {
             QXmppVCardEmail email;
             email.parse(child);
             d->emails << email;
-        } else if (child.tagName() == "TEL") {
+        } else if (child.tagName() == QSL("TEL")) {
             QXmppVCardPhone phone;
             phone.parse(child);
             d->phones << phone;
@@ -1003,46 +1003,46 @@ void QXmppVCardIq::parseElementFromChild(const QDomElement &nodeRecv)
 
 void QXmppVCardIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("vCard");
+    writer->writeStartElement(QSL("vCard"));
     writer->writeDefaultNamespace(ns_vcard);
     for (const QXmppVCardAddress &address : d->addresses)
         address.toXml(writer);
     if (d->birthday.isValid())
-        helperToXmlAddTextElement(writer, "BDAY", d->birthday.toString("yyyy-MM-dd"));
+        helperToXmlAddTextElement(writer, QSL("BDAY"), d->birthday.toString(QSL("yyyy-MM-dd")));
     if (!d->description.isEmpty())
-        helperToXmlAddTextElement(writer, "DESC", d->description);
+        helperToXmlAddTextElement(writer, QSL("DESC"), d->description);
     for (const QXmppVCardEmail &email : d->emails)
         email.toXml(writer);
     if (!d->fullName.isEmpty())
-        helperToXmlAddTextElement(writer, "FN", d->fullName);
+        helperToXmlAddTextElement(writer, QSL("FN"), d->fullName);
     if (!d->nickName.isEmpty())
-        helperToXmlAddTextElement(writer, "NICKNAME", d->nickName);
+        helperToXmlAddTextElement(writer, QSL("NICKNAME"), d->nickName);
     if (!d->firstName.isEmpty() ||
         !d->lastName.isEmpty() ||
         !d->middleName.isEmpty()) {
         writer->writeStartElement("N");
         if (!d->firstName.isEmpty())
-            helperToXmlAddTextElement(writer, "GIVEN", d->firstName);
+            helperToXmlAddTextElement(writer, QSL("GIVEN"), d->firstName);
         if (!d->lastName.isEmpty())
-            helperToXmlAddTextElement(writer, "FAMILY", d->lastName);
+            helperToXmlAddTextElement(writer, QSL("FAMILY"), d->lastName);
         if (!d->middleName.isEmpty())
-            helperToXmlAddTextElement(writer, "MIDDLE", d->middleName);
+            helperToXmlAddTextElement(writer, QSL("MIDDLE"), d->middleName);
         writer->writeEndElement();
     }
 
     for (const QXmppVCardPhone &phone : d->phones)
         phone.toXml(writer);
     if (!photo().isEmpty()) {
-        writer->writeStartElement("PHOTO");
+        writer->writeStartElement(QSL("PHOTO"));
         QString photoType = d->photoType;
         if (photoType.isEmpty())
             photoType = getImageType(d->photo);
-        helperToXmlAddTextElement(writer, "TYPE", photoType);
-        helperToXmlAddTextElement(writer, "BINVAL", d->photo.toBase64());
+        helperToXmlAddTextElement(writer, QSL("TYPE"), photoType);
+        helperToXmlAddTextElement(writer, QSL("BINVAL"), d->photo.toBase64());
         writer->writeEndElement();
     }
     if (!d->url.isEmpty())
-        helperToXmlAddTextElement(writer, "URL", d->url);
+        helperToXmlAddTextElement(writer, QSL("URL"), d->url);
 
     d->organization.toXml(writer);
 

--- a/src/base/QXmppVersionIq.cpp
+++ b/src/base/QXmppVersionIq.cpp
@@ -82,31 +82,31 @@ void QXmppVersionIq::setVersion(const QString &version)
 /// \cond
 bool QXmppVersionIq::isVersionIq(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
     return queryElement.namespaceURI() == ns_version;
 }
 
 void QXmppVersionIq::parseElementFromChild(const QDomElement &element)
 {
-    QDomElement queryElement = element.firstChildElement("query");
-    m_name = queryElement.firstChildElement("name").text();
-    m_os = queryElement.firstChildElement("os").text();
-    m_version = queryElement.firstChildElement("version").text();
+    QDomElement queryElement = element.firstChildElement(QSL("query"));
+    m_name = queryElement.firstChildElement(QSL("name")).text();
+    m_os = queryElement.firstChildElement(QSL("os")).text();
+    m_version = queryElement.firstChildElement(QSL("version")).text();
 }
 
 void QXmppVersionIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
-    writer->writeStartElement("query");
+    writer->writeStartElement(QSL("query"));
     writer->writeDefaultNamespace(ns_version);
 
     if (!m_name.isEmpty())
-        helperToXmlAddTextElement(writer, "name", m_name);
+        helperToXmlAddTextElement(writer, QSL("name"), m_name);
 
     if (!m_os.isEmpty())
-        helperToXmlAddTextElement(writer, "os", m_os);
+        helperToXmlAddTextElement(writer, QSL("os"), m_os);
 
     if (!m_version.isEmpty())
-        helperToXmlAddTextElement(writer, "version", m_version);
+        helperToXmlAddTextElement(writer, QSL("version"), m_version);
 
     writer->writeEndElement();
 }


### PR DESCRIPTION
Added two short forms as defines:
```
QStringLiteral -> QSL
QByteArrayLiteral -> QBL
```

This was necessary to make this amount of work bearable, but it should be easy to expand them if you like that better.