### PR TITLE
Bug/receipt manager

### DIFF
--- a/src/client/QXmppMessageReceiptManager.cpp
+++ b/src/client/QXmppMessageReceiptManager.cpp
@@ -64,11 +64,7 @@ bool QXmppMessageReceiptManager::handleStanza(const QDomElement &stanza)
     }
 
     // If requested, send a receipt.
-    if (message.isReceiptRequested() 
-        && !message.from().isEmpty() 
-        && !message.id().isEmpty() 
-        && message.type() != QXmppMessage::Error
-    ) {
+    if (message.isReceiptRequested() && !message.from().isEmpty() && !message.id().isEmpty() && message.type() != QXmppMessage::Error) {
         QXmppMessage receipt;
         receipt.setTo(message.from());
         receipt.setReceiptId(message.id());

--- a/src/client/QXmppMessageReceiptManager.cpp
+++ b/src/client/QXmppMessageReceiptManager.cpp
@@ -64,7 +64,11 @@ bool QXmppMessageReceiptManager::handleStanza(const QDomElement &stanza)
     }
 
     // If requested, send a receipt.
-    if (message.isReceiptRequested() && !message.from().isEmpty() && !message.id().isEmpty()) {
+    if (message.isReceiptRequested() 
+        && !message.from().isEmpty() 
+        && !message.id().isEmpty() 
+        && message.type() != QXmppMessage::Error
+    ) {
         QXmppMessage receipt;
         receipt.setTo(message.from());
         receipt.setReceiptId(message.id());

--- a/tests/qxmppmessagereceiptmanager/tst_qxmppmessagereceiptmanager.cpp
+++ b/tests/qxmppmessagereceiptmanager/tst_qxmppmessagereceiptmanager.cpp
@@ -41,7 +41,7 @@ private slots:
     {
         m_messageDelivered = true;
     }
-    void onLoggerMessage(QXmppLogger::MessageType type, const QString& text) 
+    void onLoggerMessage(QXmppLogger::MessageType type, const QString& text)
     {
         m_receiptSent = true;
     }
@@ -58,14 +58,14 @@ void tst_QXmppMessageReceiptManager::initTestCase()
 {
     m_manager = new QXmppMessageReceiptManager();
     m_logger = new QXmppLogger();
-    
+
     m_client.addExtension(m_manager);
     m_logger->setLoggingType(QXmppLogger::SignalLogging);
     m_client.setLogger(m_logger);
-    
-    connect(m_logger, &QXmppLogger::message, 
+
+    connect(m_logger, &QXmppLogger::message,
             this, &tst_QXmppMessageReceiptManager::onLoggerMessage);
-    
+
     connect(m_manager, &QXmppMessageReceiptManager::messageDelivered,
             this, &tst_QXmppMessageReceiptManager::handleMessageDelivered);
 }
@@ -101,53 +101,53 @@ void tst_QXmppMessageReceiptManager::testReceipt_data()
         << true;
     QTest::newRow("error")
         << QByteArray(
-            "<message xml:lang=\"en\" "
-                "to=\"northumberland@shakespeare.lit/westminster\" "
-                "from=\"kingrichard@royalty.england.lit/throne\" "
-                "type=\"error\" id=\"bi29sg183b4v\" "
-            "> "
-                "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
-                "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
-                "<delay xmlns=\"urn:xmpp:delay\" stamp=\"2020-03-26T20:30:41.678Z\"/> "
-                "<request xmlns=\"urn:xmpp:receipts\"/> "
-                "<error code=\"500\" type=\"wait\"> "
-                    "<resource-constraint xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/> "
-                    "<text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" xml:lang=\"en\">"
-                        "Your contact offline message queue is full. The message has been discarded."
-                    "</text>"
-                "</error>"
-                "<body>1</body> "
-            "</message>")
+               "<message xml:lang=\"en\" "
+               "to=\"northumberland@shakespeare.lit/westminster\" "
+               "from=\"kingrichard@royalty.england.lit/throne\" "
+               "type=\"error\" id=\"bi29sg183b4v\" "
+               "> "
+               "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+               "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+               "<delay xmlns=\"urn:xmpp:delay\" stamp=\"2020-03-26T20:30:41.678Z\"/> "
+               "<request xmlns=\"urn:xmpp:receipts\"/> "
+               "<error code=\"500\" type=\"wait\"> "
+               "<resource-constraint xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/> "
+               "<text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" xml:lang=\"en\">"
+               "Your contact offline message queue is full. The message has been discarded."
+               "</text>"
+               "</error>"
+               "<body>1</body> "
+               "</message>")
         << false
         << false
         << false;
     QTest::newRow("message with receipt request")
         << QByteArray(
-            "<message xml:lang=\"en\" "
-                "to=\"northumberland@shakespeare.lit/westminster\" "
-                "from=\"kingrichard@royalty.england.lit/throne\" "
-                "type=\"chat\" id=\"bi29sg183b4v\" "
-            "> "
-                "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
-                "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
-                "<request xmlns=\"urn:xmpp:receipts\"/> "
-                "<body>1</body> "
-            "</message>")
+               "<message xml:lang=\"en\" "
+               "to=\"northumberland@shakespeare.lit/westminster\" "
+               "from=\"kingrichard@royalty.england.lit/throne\" "
+               "type=\"chat\" id=\"bi29sg183b4v\" "
+               "> "
+               "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+               "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+               "<request xmlns=\"urn:xmpp:receipts\"/> "
+               "<body>1</body> "
+               "</message>")
         << false
         << true
         << false;
-        
+
     QTest::newRow("message with no receipt request")
         << QByteArray(
-            "<message xml:lang=\"en\" "
-                "to=\"northumberland@shakespeare.lit/westminster\" "
-                "from=\"kingrichard@royalty.england.lit/throne\" "
-                "type=\"chat\" id=\"bi29sg183b4v\" "
-            "> "
-                "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
-                "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
-                "<body>1</body> "
-            "</message>")
+               "<message xml:lang=\"en\" "
+               "to=\"northumberland@shakespeare.lit/westminster\" "
+               "from=\"kingrichard@royalty.england.lit/throne\" "
+               "type=\"chat\" id=\"bi29sg183b4v\" "
+               "> "
+               "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+               "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+               "<body>1</body> "
+               "</message>")
         << false
         << false
         << false;

--- a/tests/qxmppmessagereceiptmanager/tst_qxmppmessagereceiptmanager.cpp
+++ b/tests/qxmppmessagereceiptmanager/tst_qxmppmessagereceiptmanager.cpp
@@ -41,15 +41,32 @@ private slots:
     {
         m_messageDelivered = true;
     }
+    void onLoggerMessage(QXmppLogger::MessageType type, const QString& text) 
+    {
+        m_receiptSent = true;
+    }
 
 private:
-    QXmppMessageReceiptManager m_manager;
+    QXmppMessageReceiptManager* m_manager;
+    QXmppClient m_client;
+    QXmppLogger* m_logger;
     bool m_messageDelivered = false;
+    bool m_receiptSent = false;
 };
 
 void tst_QXmppMessageReceiptManager::initTestCase()
 {
-    connect(&m_manager, &QXmppMessageReceiptManager::messageDelivered,
+    m_manager = new QXmppMessageReceiptManager();
+    m_logger = new QXmppLogger();
+    
+    m_client.addExtension(m_manager);
+    m_logger->setLoggingType(QXmppLogger::SignalLogging);
+    m_client.setLogger(m_logger);
+    
+    connect(m_logger, &QXmppLogger::message, 
+            this, &tst_QXmppMessageReceiptManager::onLoggerMessage);
+    
+    connect(m_manager, &QXmppMessageReceiptManager::messageDelivered,
             this, &tst_QXmppMessageReceiptManager::handleMessageDelivered);
 }
 
@@ -57,6 +74,8 @@ void tst_QXmppMessageReceiptManager::testReceipt_data()
 {
     QTest::addColumn<QByteArray>("xml");
     QTest::addColumn<bool>("accept");
+    QTest::addColumn<bool>("sent");
+    QTest::addColumn<bool>("handled");
 
     QTest::newRow("correct")
         << QByteArray(
@@ -66,6 +85,8 @@ void tst_QXmppMessageReceiptManager::testReceipt_data()
                "type=\"normal\">"
                "<received xmlns=\"urn:xmpp:receipts\" id=\"richard2-4.1.247\"/>"
                "</message>")
+        << true
+        << false
         << true;
     QTest::newRow("from-to-equal")
         << QByteArray(
@@ -75,22 +96,80 @@ void tst_QXmppMessageReceiptManager::testReceipt_data()
                "type=\"normal\">"
                "<received xmlns=\"urn:xmpp:receipts\" id=\"richard2-4.1.247\"/>"
                "</message>")
+        << false
+        << false
+        << true;
+    QTest::newRow("error")
+        << QByteArray(
+            "<message xml:lang=\"en\" "
+                "to=\"northumberland@shakespeare.lit/westminster\" "
+                "from=\"kingrichard@royalty.england.lit/throne\" "
+                "type=\"error\" id=\"bi29sg183b4v\" "
+            "> "
+                "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+                "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+                "<delay xmlns=\"urn:xmpp:delay\" stamp=\"2020-03-26T20:30:41.678Z\"/> "
+                "<request xmlns=\"urn:xmpp:receipts\"/> "
+                "<error code=\"500\" type=\"wait\"> "
+                    "<resource-constraint xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/> "
+                    "<text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" xml:lang=\"en\">"
+                        "Your contact offline message queue is full. The message has been discarded."
+                    "</text>"
+                "</error>"
+                "<body>1</body> "
+            "</message>")
+        << false
+        << false
+        << false;
+    QTest::newRow("message with receipt request")
+        << QByteArray(
+            "<message xml:lang=\"en\" "
+                "to=\"northumberland@shakespeare.lit/westminster\" "
+                "from=\"kingrichard@royalty.england.lit/throne\" "
+                "type=\"chat\" id=\"bi29sg183b4v\" "
+            "> "
+                "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+                "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+                "<request xmlns=\"urn:xmpp:receipts\"/> "
+                "<body>1</body> "
+            "</message>")
+        << false
+        << true
+        << false;
+        
+    QTest::newRow("message with no receipt request")
+        << QByteArray(
+            "<message xml:lang=\"en\" "
+                "to=\"northumberland@shakespeare.lit/westminster\" "
+                "from=\"kingrichard@royalty.england.lit/throne\" "
+                "type=\"chat\" id=\"bi29sg183b4v\" "
+            "> "
+                "<archived xmlns=\"urn:xmpp:mam:tmp\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+                "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
+                "<body>1</body> "
+            "</message>")
+        << false
+        << false
         << false;
 }
 
 void tst_QXmppMessageReceiptManager::testReceipt()
 {
     m_messageDelivered = false;
+    m_receiptSent = false;
 
     QFETCH(QByteArray, xml);
     QFETCH(bool, accept);
+    QFETCH(bool, sent);
+    QFETCH(bool, handled);
 
     QDomDocument doc;
     QCOMPARE(doc.setContent(xml, true), true);
     QDomElement element = doc.documentElement();
 
-    QVERIFY(m_manager.handleStanza(element));
+    QCOMPARE(m_manager->handleStanza(element), handled);
     QCOMPARE(m_messageDelivered, accept);
+    QCOMPARE(m_receiptSent, sent);
 }
 
 QTEST_MAIN(tst_QXmppMessageReceiptManager)


### PR DESCRIPTION
QXmppMessageReceiptManager sends back messager reception reports even on message with type error

this commit fixes that behaviour and extends test for QXmppMessageReceiptManager

had to recreate PR for it to be based on the proper branch