### PR TITLE
Implement XEP-0245: The /me Command

### DIFF
--- a/doc/xep.doc
+++ b/doc/xep.doc
@@ -37,6 +37,7 @@ Complete:
 - XEP-0224: Attention
 - XEP-0231: Bits of Binary (v1.0)
 - XEP-0237: Roster Versioning (partially)
+- XEP-0245: The /me Command (v1.0)
 - XEP-0249: Direct MUC Invitations (v1.2)
 - XEP-0280: Message Carbons
 - XEP-0308: Last Message Correction

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -523,6 +523,66 @@ void QXmppMessage::setBitsOfBinaryData(const QXmppBitsOfBinaryDataList &bitsOfBi
     d->bitsOfBinaryData = bitsOfBinaryData;
 }
 
+///
+/// Returns whether the given text is a '/me command' as defined in \xep{0245}:
+/// The /me Command.
+///
+/// \since QXmpp 1.3
+///
+bool QXmppMessage::isSlashMeCommand(const QString &body)
+{
+    return body.startsWith(QStringLiteral("/me "));
+}
+
+///
+/// Returns whether the body of the message is a '/me command' as defined in
+/// \xep{0245}: The /me Command.
+///
+/// \note If you want to check a custom string for the /me command, you can use
+/// the static version of this method. This can be helpful when checking user
+/// input before a message was sent.
+///
+/// \since QXmpp 1.3
+///
+bool QXmppMessage::isSlashMeCommand() const
+{
+    return isSlashMeCommand(d->body);
+}
+
+///
+/// Returns the part of the body after the /me command.
+///
+/// This cuts off '/me ' (with the space) from the body, in case the body
+/// starts with that. In case the body does not contain a /me command as
+/// defined in \xep{0245}: The /me Command, a null string is returned.
+///
+/// This is useful when displaying the /me command correctly to the user.
+///
+/// \since QXmpp 1.3
+///
+QString QXmppMessage::slashMeCommandText(const QString &body)
+{
+    if (isSlashMeCommand(body))
+        return body.mid(4);
+    return {};
+}
+
+///
+/// Returns the part of the body after the /me command.
+///
+/// This cuts off '/me ' (with the space) from the body, in case the body
+/// starts with that. In case the body does not contain a /me command as
+/// defined in \xep{0245}: The /me Command, a null string is returned.
+///
+/// This is useful when displaying the /me command correctly to the user.
+///
+/// \since QXmpp 1.3
+///
+QString QXmppMessage::slashMeCommandText() const
+{
+    return slashMeCommandText(d->body);
+}
+
 /// Returns if the message is marked with a <private> tag,
 /// in which case it will not be forwarded to other resources
 /// according to \xep{0280}: Message Carbons.

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -160,6 +160,12 @@ public:
     QXmppBitsOfBinaryDataList &bitsOfBinaryData();
     void setBitsOfBinaryData(const QXmppBitsOfBinaryDataList &bitsOfBinaryData);
 
+    // XEP-0245: The /me Command
+    static bool isSlashMeCommand(const QString &body);
+    bool isSlashMeCommand() const;
+    static QString slashMeCommandText(const QString &body);
+    QString slashMeCommandText() const;
+
     // XEP-0280: Message Carbons
     bool isPrivate() const;
     void setPrivate(const bool);


### PR DESCRIPTION
This adds parsing for recognizing /me commands in message bodies. It
complies with version 1.0 of XEP-0245: The /me Command.

https://xmpp.org/extensions/xep-0245.html