### PR TITLE
QXmppCallStream: Wrap callback in std::function

### DIFF
--- a/src/client/QXmppCallStream.cpp
+++ b/src/client/QXmppCallStream.cpp
@@ -28,6 +28,7 @@
 #include "QXmppStun.h"
 
 #include <cstring>
+
 #include <gst/gst.h>
 
 QXmppCallStreamPrivate::QXmppCallStreamPrivate(QXmppCallStream *parent, GstElement *pipeline_,
@@ -344,7 +345,7 @@ int QXmppCallStream::id() const
     return d->id;
 }
 
-void QXmppCallStream::setReceivePadCallback(void (*cb)(GstPad *))
+void QXmppCallStream::setReceivePadCallback(std::function<void(GstPad *)> cb)
 {
     d->receivePadCB = cb;
     if (d->receivePad) {
@@ -352,7 +353,7 @@ void QXmppCallStream::setReceivePadCallback(void (*cb)(GstPad *))
     }
 }
 
-void QXmppCallStream::setSendPadCallback(void (*cb)(GstPad *))
+void QXmppCallStream::setSendPadCallback(std::function<void(GstPad *)> cb)
 {
     d->sendPadCB = cb;
     if (d->sendPad) {

--- a/src/client/QXmppCallStream.h
+++ b/src/client/QXmppCallStream.h
@@ -28,6 +28,8 @@
 
 #include <gst/gst.h>
 
+#include <functional>
+
 #include <QObject>
 
 class QXmppCallStreamPrivate;
@@ -50,8 +52,8 @@ public:
     QString media() const;
     QString name() const;
     int id() const;
-    void setReceivePadCallback(void (*cb)(GstPad *));
-    void setSendPadCallback(void (*cb)(GstPad *));
+    void setReceivePadCallback(std::function<void(GstPad *)> cb);
+    void setSendPadCallback(std::function<void(GstPad *)> cb);
 
 private:
     QXmppCallStream(GstElement *pipeline, GstElement *rtpbin,

--- a/src/client/QXmppCallStream_p.h
+++ b/src/client/QXmppCallStream_p.h
@@ -88,8 +88,8 @@ public:
     GstElement *apprtpsink;
     GstElement *apprtcpsink;
 
-    void (*sendPadCB)(GstPad *);
-    void (*receivePadCB)(GstPad *);
+    std::function<void(GstPad *)> sendPadCB;
+    std::function<void(GstPad *)> receivePadCB;
 
     QXmppIceConnection *connection;
     QString media;


### PR DESCRIPTION
Allows to use non-static functions (or lambdas with captures)

This should even to some extend be source compatible.