### PR TITLE
Set QXmppRosterIq subscription type correctly

### DIFF
--- a/src/base/QXmppRosterIq.cpp
+++ b/src/base/QXmppRosterIq.cpp
@@ -348,7 +348,7 @@ QString QXmppRosterIq::Item::getSubscriptionTypeStr() const
 
 void QXmppRosterIq::Item::setSubscriptionTypeFromStr(const QString &type)
 {
-    if (type.isEmpty() && !type.isNull())  // TODO CHECK
+    if (type.isEmpty())
         setSubscriptionType(NotSet);
     else if (type == QStringLiteral("none"))
         setSubscriptionType(None);


### PR DESCRIPTION
If the IQ stanza does not contain a subscription state (that is the case when the stanza contains a subscription status (`ask` attribute)), it should be set correctly as `NotSet` because otherwise the warning `QXmppRosterIq::Item::setTypeFromStr(): invalid type` is logged.