### PR TITLE
Skip stream errors on successful account deletion

### DIFF
--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -3,6 +3,7 @@
  *
  * Author:
  *  Manjeet Dahiya
+ *  Melvin Keskin
  *
  * Source:
  *  https://github.com/qxmpp-project/qxmpp
@@ -179,6 +180,8 @@ public:
 
     bool isAuthenticated() const;
     bool isConnected() const;
+
+    void setIsAccountBeingDeleted(bool isAccountBeingDeleted);
 
     bool isActive() const;
     void setActive(bool active);

--- a/src/client/QXmppClient_p.h
+++ b/src/client/QXmppClient_p.h
@@ -62,6 +62,8 @@ public:
     int reconnectionTries;
     QTimer *reconnectionTimer;
 
+    bool isAccountBeingDeleted = false;
+
     // Client state indication
     bool isActive;
 

--- a/src/client/QXmppRegistrationManager.cpp
+++ b/src/client/QXmppRegistrationManager.cpp
@@ -107,6 +107,7 @@ void QXmppRegistrationManager::deleteAccount()
     auto iq = QXmppRegisterIq::createUnregistrationRequest();
     d->deleteAccountIqId = iq.id();
 
+    client()->setIsAccountBeingDeleted(true);
     client()->sendPacket(iq);
 }
 


### PR DESCRIPTION
Some servers send errors after successfully deleting an account. On https://xmpp.org/extensions/xep-0077.html#usecases-cancel, there is only the stream error `<not-authorized/>` specified but during testing I found two error types sent by the tested servers.