### PR TITLE
QXmppMessageReceiptManager: Ignore *all* error messages

### DIFF
--- a/src/client/QXmppMessageReceiptManager.cpp
+++ b/src/client/QXmppMessageReceiptManager.cpp
@@ -53,6 +53,9 @@ bool QXmppMessageReceiptManager::handleStanza(const QDomElement &stanza)
     QXmppMessage message;
     message.parse(stanza);
 
+    if (message.type() == QXmppMessage::Error)
+        return false;
+
     // Handle receipts and cancel any further processing.
     if (!message.receiptId().isEmpty()) {
         // Buggy clients also mark carbon messages as received; to avoid this
@@ -64,7 +67,7 @@ bool QXmppMessageReceiptManager::handleStanza(const QDomElement &stanza)
     }
 
     // If requested, send a receipt.
-    if (message.isReceiptRequested() && !message.from().isEmpty() && !message.id().isEmpty() && message.type() != QXmppMessage::Error) {
+    if (message.isReceiptRequested() && !message.from().isEmpty() && !message.id().isEmpty()) {
         QXmppMessage receipt;
         receipt.setTo(message.from());
         receipt.setReceiptId(message.id());

--- a/tests/qxmppmessagereceiptmanager/tst_qxmppmessagereceiptmanager.cpp
+++ b/tests/qxmppmessagereceiptmanager/tst_qxmppmessagereceiptmanager.cpp
@@ -99,7 +99,7 @@ void tst_QXmppMessageReceiptManager::testReceipt_data()
         << false
         << false
         << true;
-    QTest::newRow("error")
+    QTest::newRow("error-request")
         << QByteArray(
                "<message xml:lang=\"en\" "
                "to=\"northumberland@shakespeare.lit/westminster\" "
@@ -110,6 +110,25 @@ void tst_QXmppMessageReceiptManager::testReceipt_data()
                "<stanza-id xmlns=\"urn:xmpp:sid:0\" by=\"kingrichard@royalty.england.lit\" id=\"1585254642941569\"/> "
                "<delay xmlns=\"urn:xmpp:delay\" stamp=\"2020-03-26T20:30:41.678Z\"/> "
                "<request xmlns=\"urn:xmpp:receipts\"/> "
+               "<error code=\"500\" type=\"wait\"> "
+               "<resource-constraint xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/> "
+               "<text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" xml:lang=\"en\">"
+               "Your contact offline message queue is full. The message has been discarded."
+               "</text>"
+               "</error>"
+               "<body>1</body> "
+               "</message>")
+        << false
+        << false
+        << false;
+    QTest::newRow("error-receipt")
+        << QByteArray(
+               "<message xml:lang=\"en\" "
+               "to=\"northumberland@shakespeare.lit/westminster\" "
+               "from=\"kingrichard@royalty.england.lit/throne\" "
+               "type=\"error\" id=\"bi29sg183b4v\" "
+               "> "
+               "<received xmlns=\"urn:xmpp:receipts\" id=\"richard2-4.1.247\"/>"
                "<error code=\"500\" type=\"wait\"> "
                "<resource-constraint xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\"/> "
                "<text xmlns=\"urn:ietf:params:xml:ns:xmpp-stanzas\" xml:lang=\"en\">"


### PR DESCRIPTION
Not only receipt requests, but also receipts from error messages should
not be used.