### PR TITLE
Refactor stream management

### DIFF
--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -35,9 +35,9 @@ class QSslSocket;
 class QXmppStanza;
 class QXmppStreamPrivate;
 
+///
 /// \brief The QXmppStream class is the base class for all XMPP streams.
 ///
-
 class QXMPP_EXPORT QXmppStream : public QXmppLoggable
 {
     Q_OBJECT
@@ -76,8 +76,8 @@ protected:
 
     // XEP-0198: Stream Management
     void enableStreamManagement(bool resetSequenceNumber);
-    unsigned lastIncomingSequenceNumber() const;
-    void setAcknowledgedSequenceNumber(unsigned sequenceNumber);
+    unsigned int lastIncomingSequenceNumber() const;
+    void setAcknowledgedSequenceNumber(unsigned int sequenceNumber);
 
 private:
     // XEP-0198: Stream Management

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -79,12 +79,6 @@ protected:
     unsigned int lastIncomingSequenceNumber() const;
     void setAcknowledgedSequenceNumber(unsigned int sequenceNumber);
 
-private:
-    // XEP-0198: Stream Management
-    void handleAcknowledgement(QDomElement &element);
-    void sendAcknowledgement();
-    void sendAcknowledgementRequest();
-
 public Q_SLOTS:
     virtual void disconnectFromHost();
     virtual bool sendData(const QByteArray &);

--- a/src/base/QXmppStreamManagement_p.h
+++ b/src/base/QXmppStreamManagement_p.h
@@ -30,6 +30,9 @@
 #include <QDomDocument>
 #include <QXmlStreamWriter>
 
+class QXmppStream;
+
+//
 //  W A R N I N G
 //  -------------
 //
@@ -189,6 +192,39 @@ public:
     /// \cond
     static void toXml(QXmlStreamWriter *writer);
     /// \endcond
+};
+
+//
+// This manager is used in the QXmppStream. It contains the parts of stream
+// management that are shared between server and client connections.
+//
+class QXmppStreamManager
+{
+public:
+    explicit QXmppStreamManager(QXmppStream *stream);
+
+    unsigned int lastIncomingSequenceNumber() const;
+
+    void handleDisconnect();
+    void handleStart();
+    void handlePacketSent(const QXmppStanza &packet, const QByteArray &data);
+    bool handleStanza(const QDomElement &stanza);
+
+    void enableStreamManagement(bool resetSequenceNumber);
+    void setAcknowledgedSequenceNumber(unsigned int sequenceNumber);
+
+private:
+    void handleAcknowledgement(const QDomElement &element);
+
+    void sendAcknowledgement();
+    void sendAcknowledgementRequest();
+
+    QXmppStream *stream;
+
+    bool m_enabled = false;
+    QMap<unsigned int, QByteArray> m_unacknowledgedStanzas;
+    unsigned int m_lastOutgoingSequenceNumber = 0;
+    unsigned int m_lastIncomingSequenceNumber = 0;
 };
 
 #endif

--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -350,6 +350,24 @@ void QXmppClient::setActive(bool active)
     }
 }
 
+///
+/// Returns the current \xep{0198}: Stream Management state of the connection.
+///
+/// Upon connection of the client this can be used to check whether the
+/// previous stream has been resumed.
+///
+/// \since QXmpp 1.4
+///
+QXmppClient::StreamManagementState QXmppClient::streamManagementState() const
+{
+    if (d->stream->isStreamManagementEnabled()) {
+        if (d->stream->isStreamResumed())
+            return ResumedStream;
+        return NewStream;
+    }
+    return NoStreamManagement;
+}
+
 /// Returns the reference to QXmppRosterManager object of the client.
 ///
 /// \return Reference to the roster object of the connected client. Use this to

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -89,7 +89,7 @@ class QXmppVersionManager;
 /// - QXmppEntityTimeManager
 ///
 /// \ingroup Core
-
+///
 class QXMPP_EXPORT QXmppClient : public QXmppLoggable
 {
     Q_OBJECT
@@ -118,6 +118,16 @@ public:
     };
     Q_ENUM(State)
 
+    /// Describes the use of \xep{0198}: Stream Management
+    enum StreamManagementState {
+        /// Stream Management is not used.
+        NoStreamManagement,
+        /// Stream Management is used and the previous stream has not been resumed.
+        NewStream,
+        /// Stream Management is used and the previous stream has been resumed.
+        ResumedStream
+    };
+
     QXmppClient(QObject *parent = nullptr);
     ~QXmppClient() override;
 
@@ -127,6 +137,7 @@ public:
 
     QList<QXmppClientExtension *> extensions();
 
+    ///
     /// \brief Returns the extension which can be cast into type T*, or 0
     /// if there is no such extension.
     ///
@@ -151,6 +162,7 @@ public:
         return nullptr;
     }
 
+    ///
     /// \brief Returns the index of an extension
     ///
     /// Usage example:
@@ -181,6 +193,8 @@ public:
 
     bool isActive() const;
     void setActive(bool active);
+
+    StreamManagementState streamManagementState() const;
 
     QXmppPresence clientPresence() const;
     void setClientPresence(const QXmppPresence &presence);

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -55,6 +55,8 @@ public:
     bool isAuthenticated() const;
     bool isConnected() const override;
     bool isClientStateIndicationEnabled() const;
+    bool isStreamManagementEnabled() const;
+    bool isStreamResumed() const;
 
     QSslSocket *socket() const { return QXmppStream::socket(); };
     QXmppStanza::Error::Condition xmppStreamError();

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -35,6 +35,7 @@
 
 class QXmppRosterManagerPrivate;
 
+///
 /// \brief The QXmppRosterManager class provides access to a connected client's
 /// roster.
 ///
@@ -63,7 +64,7 @@ class QXmppRosterManagerPrivate;
 /// roster item changes.
 ///
 /// \ingroup Managers
-
+///
 class QXMPP_EXPORT QXmppRosterManager : public QXmppClientExtension
 {
     Q_OBJECT
@@ -87,13 +88,13 @@ public:
     /// \endcond
 
 public Q_SLOTS:
-    bool acceptSubscription(const QString &bareJid, const QString &reason = QString());
-    bool refuseSubscription(const QString &bareJid, const QString &reason = QString());
-    bool addItem(const QString &bareJid, const QString &name = QString(), const QSet<QString> &groups = QSet<QString>());
+    bool acceptSubscription(const QString &bareJid, const QString &reason = {});
+    bool refuseSubscription(const QString &bareJid, const QString &reason = {});
+    bool addItem(const QString &bareJid, const QString &name = {}, const QSet<QString> &groups = {});
     bool removeItem(const QString &bareJid);
     bool renameItem(const QString &bareJid, const QString &name);
-    bool subscribe(const QString &bareJid, const QString &reason = QString());
-    bool unsubscribe(const QString &bareJid, const QString &reason = QString());
+    bool subscribe(const QString &bareJid, const QString &reason = {});
+    bool unsubscribe(const QString &bareJid, const QString &reason = {});
 
 Q_SIGNALS:
     /// This signal is emitted when the Roster IQ is received after a successful

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -101,6 +101,10 @@ Q_SIGNALS:
     /// connection. That is the roster entries are empty before this signal is emitted.
     /// One should use getRosterBareJids() and getRosterEntry() only after
     /// this signal has been emitted.
+    ///
+    /// \note If the previous stream could be resumed, this signal is not
+    /// emitted since QXmpp 1.4. Changes since the last connection are reported
+    /// via the itemAdded(), itemChanged() and itemRemoved() signals.
     void rosterReceived();
 
     /// This signal is emitted when the presence of a particular bareJid and resource changes.


### PR DESCRIPTION
* Separating the stream management stuff will make the implementation of the QFuture stuff easier (see #96).
* having the stream management state accessible from the QXmppClient will make it possible to fix some  TODOs (The roster manager should not re-request the roster when the stream is resumed, the QXmppClient should not resend presence)

- [x] RosterManager: Don't refetch roster on stream resumption
- [ ] unit tests?

I'm interested in your feedback.