### PR TITLE
Enable QURL_NO_CAST_FROM_STRING+QT_NO_CAST_TO_ASCII and fix compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ option(BUILD_EXAMPLES "Build examples." ON)
 
 option(WITH_GSTREAMER "Build with GStreamer support for Jingle" OFF)
 
+add_definitions(-DQURL_NO_CAST_FROM_STRING -DQT_NO_CAST_TO_ASCII)
+
 add_subdirectory(src)
 
 if(BUILD_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,11 @@ option(BUILD_EXAMPLES "Build examples." ON)
 
 option(WITH_GSTREAMER "Build with GStreamer support for Jingle" OFF)
 
-add_definitions(-DQURL_NO_CAST_FROM_STRING -DQT_NO_CAST_TO_ASCII)
+add_definitions(
+    -DQURL_NO_CAST_FROM_STRING
+    -DQT_NO_CAST_TO_ASCII
+    -DQT_NO_FOREACH
+)
 
 add_subdirectory(src)
 

--- a/examples/example_7_archiveHandling/example_7_archiveHandling.cpp
+++ b/examples/example_7_archiveHandling/example_7_archiveHandling.cpp
@@ -104,7 +104,7 @@ void xmppClient::archiveListReceived(const QList<QXmppArchiveChat> &chats, const
         logEnd("no items");
     } else {
         logEnd(QString("items %1 to %2 of %3").arg(QString::number(rsmReply.index()), QString::number(rsmReply.index() + chats.size() - 1), QString::number(rsmReply.count())));
-        foreach (const QXmppArchiveChat &chat, chats) {
+        for (const auto &chat : chats) {
             qDebug("chat start %s", qPrintable(chat.start().toString()));
             // NOTE: to actually retrieve conversations, uncomment this
             //archiveManager->retrieveCollection(chat.with(), chat.start());
@@ -127,8 +127,11 @@ void xmppClient::archiveListReceived(const QList<QXmppArchiveChat> &chats, const
 
 void xmppClient::archiveChatReceived(const QXmppArchiveChat &chat, const QXmppResultSetReply &rsmReply)
 {
-    logEnd(QString("chat received, RSM count %1").arg(QString::number(rsmReply.count())));
-    foreach (const QXmppArchiveMessage &msg, chat.messages()) {
+    logEnd(QString("chat received, RSM count %1")
+               .arg(QString::number(rsmReply.count())));
+
+    const auto messages = chat.messages();
+    for (const auto &msg : messages) {
         qDebug("example_7_archiveHandling : %s", qPrintable(msg.body()));
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,9 +2,6 @@ option(BUILD_SHARED "Build SHARED library" ON)
 
 add_definitions(-DQXMPP_BUILD)
 
-# disable Q_FOREACH()
-add_definitions(-DQT_NO_FOREACH)
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/base)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/client)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/server)

--- a/src/base/QXmppBookmarkSet.cpp
+++ b/src/base/QXmppBookmarkSet.cpp
@@ -196,7 +196,7 @@ void QXmppBookmarkSet::parse(const QDomElement &element)
         } else if (childElement.tagName() == QStringLiteral("url")) {
             QXmppBookmarkUrl url;
             url.setName(childElement.attribute(QStringLiteral("name")));
-            url.setUrl(childElement.attribute(QStringLiteral("url")));
+            url.setUrl(QUrl(childElement.attribute(QStringLiteral("url"))));
             m_urls << url;
         }
         childElement = childElement.nextSiblingElement();

--- a/src/base/QXmppRpcIq.cpp
+++ b/src/base/QXmppRpcIq.cpp
@@ -70,7 +70,7 @@ void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &valu
     }
     case QVariant::Map: {
         writer->writeStartElement(QStringLiteral("struct"));
-        QMap<QString, QVariant> map = value.toMap();
+        const QMap<QString, QVariant> map = value.toMap();
         QMap<QString, QVariant>::ConstIterator index = map.begin();
         while (index != map.end()) {
             writer->writeStartElement(QStringLiteral("member"));

--- a/src/base/QXmppSasl.cpp
+++ b/src/base/QXmppSasl.cpp
@@ -871,7 +871,7 @@ QMap<QByteArray, QByteArray> QXmppSaslDigestMd5::parseMessage(const QByteArray &
     QMap<QByteArray, QByteArray> map;
     int startIndex = 0;
     int pos = 0;
-    while ((pos = ba.indexOf(QStringLiteral("="), startIndex)) >= 0) {
+    while ((pos = ba.indexOf('=', startIndex)) >= 0) {
         // key get name and skip equals
         const QByteArray key = ba.mid(startIndex, pos - startIndex).trimmed();
         pos++;
@@ -927,8 +927,8 @@ QByteArray QXmppSaslDigestMd5::serializeMessage(const QMap<QByteArray, QByteArra
         if (quote) {
             value.replace(QByteArrayLiteral("\\"), QByteArrayLiteral("\\\\"));
             value.replace(QByteArrayLiteral("\""), QByteArrayLiteral("\\\""));
-            ba.append(QStringLiteral("\"") + value + QStringLiteral("\""));
-        } else
+            ba.append(QByteArrayLiteral("\"") + value + QByteArrayLiteral("\""));
+         } else
             ba.append(value);
     }
     return ba;

--- a/tests/qxmppregistrationmanager/tst_qxmppregistrationmanager.cpp
+++ b/tests/qxmppregistrationmanager/tst_qxmppregistrationmanager.cpp
@@ -510,7 +510,7 @@ void tst_QXmppRegistrationManager::sendStreamFeaturesToManager(bool registration
         // hacky hack to include stream namespace
         QByteArray manipulatedXml = buffer.data();
         manipulatedXml.replace("stream:", QByteArray());
-        manipulatedXml.insert(9, QStringLiteral(" xmlns=\"%1\"").arg("http://etherx.jabber.org/streams"));
+        manipulatedXml.insert(9, QByteArrayLiteral(" xmlns=\"http://etherx.jabber.org/streams\""));
 
         QDomDocument doc;
         doc.setContent(manipulatedXml, true);
@@ -522,7 +522,7 @@ void tst_QXmppRegistrationManager::sendStreamFeaturesToManager(bool registration
 
 void tst_QXmppRegistrationManager::setManagerConfig(const QString &username, const QString &server, const QString &password)
 {
-    client.connectToServer(username + QStringLiteral("@") + server, password);
+    client.connectToServer(username + u'@' + server, password);
     client.disconnectFromServer();
 }
 


### PR DESCRIPTION
I have those always enabled, which is how I detected these issues.
This avoids QUrl/QString confusions, and QString/QByteArray confusions.