### PR TITLE
Fix UB in QXmppTransferManager when parsing stream features

### DIFF
--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -1342,7 +1342,9 @@ void QXmppTransferManager::streamInitiationResultReceived(const QXmppStreamIniti
         job->state() != QXmppTransferJob::OfferState)
         return;
 
-    const auto &fields = iq.featureForm().fields();
+    const auto &form = iq.featureForm();
+    const auto &fields = form.fields();
+
     for (const auto &field : fields) {
         if (field.key() == "stream-method") {
             if ((field.value().toString() == ns_ibb) &&
@@ -1423,7 +1425,9 @@ void QXmppTransferManager::streamInitiationSetReceived(const QXmppStreamInitiati
     job->d->sid = iq.siId();
     job->d->mimeType = iq.mimeType();
     job->d->fileInfo = iq.fileInfo();
-    const auto &fields = iq.featureForm().fields();
+    
+    const auto &form = iq.featureForm();
+    const auto &fields = form.fields();
     for (const auto &field : fields) {
         if (field.key() == "stream-method") {
             QPair<QString, QString> option;


### PR DESCRIPTION
`featureForm()` returns a `QXmppDataForm` by value - directly taking a reference to a member of this class is undefined behavior and leads to a crash.

This PR changes the code to take references to both the form and the fields inside, thus extending the lifetime to the end of the function, fixing said crash.