### PR TITLE
server: Add 'to' and 'from' attributes to dialback init stream header

### DIFF
--- a/src/server/QXmppOutgoingServer.cpp
+++ b/src/server/QXmppOutgoingServer.cpp
@@ -148,11 +148,14 @@ void QXmppOutgoingServer::handleStart()
     QXmppStream::handleStart();
 
     QString data = QString("<?xml version='1.0'?><stream:stream"
-                           " xmlns='%1' xmlns:db='%2' xmlns:stream='%3' version='1.0'>")
+                           " xmlns='%1' xmlns:db='%2' xmlns:stream='%3' version='1.0'"
+                           " from='%4' to='%5'>")
                        .arg(
                            ns_server,
                            ns_server_dialback,
-                           ns_stream);
+                           ns_stream,
+                           d->localDomain,
+                           d->remoteDomain);
     sendData(data.toUtf8());
 }
 


### PR DESCRIPTION
The attributes are mandatory (see RFC 6120 paragraphs [8.1.1.2](https://tools.ietf.org/html/rfc6120#section-8.1.1.2) and [8.1.2.2](https://tools.ietf.org/html/rfc6120#section-8.1.2.2); also the attributes are listed in the example of stream header for [XEP-0220](https://xmpp.org/extensions/xep-0220.html#advertisement-traditional)).

This commit fixes S2S messaging with Prosody server (and probably many others).