### PR TITLE
Avoid depending on gst/gst.h in a public header

### DIFF
--- a/src/client/QXmppCallStream.h
+++ b/src/client/QXmppCallStream.h
@@ -26,11 +26,12 @@
 
 #include <QXmppGlobal.h>
 
-#include <gst/gst.h>
-
 #include <functional>
 
 #include <QObject>
+
+typedef struct _GstPad GstPad;
+typedef struct _GstElement GstElement;
 
 class QXmppCallStreamPrivate;
 class QXmppIceConnection;


### PR DESCRIPTION
The gstreamer types used in QXmpp headers could just be forward-declared, so that the users of the library that don't care about gstreamer specifics can just not bother with gstreamer.