### PR TITLE
Add integration tests

### DIFF
--- a/tests/IntegrationTesting.h
+++ b/tests/IntegrationTesting.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2008-2021 The QXmpp developers
+ *
+ * Authors:
+ *  Linus Jahn
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#ifndef INTEGRATIONTESTING_H
+#define INTEGRATIONTESTING_H
+
+#include <QtGlobal>
+#include <QDebug>
+
+#include "QXmppConfiguration.h"
+
+#define ENV_ENABLED "QXMPP_TESTS_INTEGRATION_ENABLED"
+#define ENV_JID "QXMPP_TESTS_JID"
+#define ENV_PASSWORD "QXMPP_TESTS_PASSWORD"
+
+#define SKIP_IF_INTEGRATION_TESTS_DISABLED() \
+    if (!IntegrationTests::enabled()) { \
+        QSKIP("Export 'QXMPP_TESTS_INTEGRATION_ENABLED=1' to enable."); \
+    } else if (!IntegrationTests::credentialsAvailable()) { \
+        QFAIL("No credentials for integration tests provided! " \
+              "Export 'QXMPP_TESTS_JID' and 'QXMPP_TESTS_PASSWORD'."); \
+    }
+
+class IntegrationTests
+{
+public:
+    static QString environmentVariable(const char *varName, const QString &defaultValue = {})
+    {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+        return qEnvironmentVariable(varName, defaultValue);
+#else
+        return qEnvironmentVariableIsSet(varName) ? QString::fromLocal8Bit(qgetenv(varName)) : QString();
+#endif
+    }
+
+    static bool enabled()
+    {
+        return environmentVariable(ENV_ENABLED, "0") == "1";
+    }
+
+    static bool credentialsAvailable()
+    {
+        return !qEnvironmentVariableIsEmpty(ENV_JID) && !qEnvironmentVariableIsEmpty(ENV_PASSWORD);
+    }
+
+    static QXmppConfiguration clientConfiguration()
+    {
+        QXmppConfiguration config;
+        config.setJid(environmentVariable(ENV_JID));
+        config.setPassword(environmentVariable(ENV_PASSWORD));
+        return config;
+    }
+};
+
+#undef ENV_ENABLED
+#undef ENV_JID
+#undef ENV_PASSWORD
+
+#endif // INTEGRATIONTESTING_H


### PR DESCRIPTION
In some cases it's hard to test managers or the client itself because it would require a server implementation and a real connection. Implementing everything in QXmpp server would be nice, but is time consuming and in many cases not really needed by anyone. The simpler solution is to test QXmpp with an external server (like a real world ejabberd or prosody server). This also has the advantage that we can test whether QXmpp properly works with other server implementations and if there are any compliance issues (in QXmpp or in a server implementation).

These are the reasons I started to work on simple integration tests. The current approach is using environment variables for the XMPP account JID + password to be used. The integration tests are integrated into the other unit tests, but are skipped unless `QXMPP_TESTS_INTEGRATION_ENABLED=1` is given from the environment.

We can also use the integration tests to get a better code coverage.
For that purpose I can add some secrets to the gitlab ci. That would only works on the branches from the QXmpp main repository (so no pull-requests). However to test pull-requests we could temporarily use integration branches on the QXmpp repo before merging into master.

Another problem could be that the tests might not pass correctly if there are multiple jobs running at the same time with the same account. So for now I'd suggest to only run one job in the configuration with integration tests. Later we could do something more advanced with job dependencies or multiple accounts.

I'm not in a hurry with this and I'm happy about feedback or ideas for improvement.