### PR TITLE
QXmppClient: Reset Stream Management package cache on JID changes

### DIFF
--- a/src/base/QXmppStream.cpp
+++ b/src/base/QXmppStream.cpp
@@ -166,6 +166,19 @@ bool QXmppStream::sendPacket(const QXmppStanza &packet)
 }
 
 ///
+/// Resets the stream management packages cache.
+///
+/// This can be done to prevent that packages from the last connection are being
+/// resent.
+///
+/// \since QXmpp 1.4
+///
+void QXmppStream::resetPacketCache()
+{
+    d->streamManager.resetCache();
+}
+
+///
 /// Returns the QSslSocket used for this stream.
 ///
 QSslSocket *QXmppStream::socket() const

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -49,6 +49,8 @@ public:
     virtual bool isConnected() const;
     bool sendPacket(const QXmppStanza &);
 
+    void resetPacketCache();
+
 Q_SIGNALS:
     /// This signal is emitted when the stream is connected.
     void connected();

--- a/src/base/QXmppStreamManagement.cpp
+++ b/src/base/QXmppStreamManagement.cpp
@@ -454,3 +454,8 @@ void QXmppStreamManager::sendAcknowledgementRequest()
     // send packet
     stream->sendData(data);
 }
+
+void QXmppStreamManager::resetCache()
+{
+    m_unacknowledgedStanzas.clear();
+}

--- a/src/base/QXmppStreamManagement_p.h
+++ b/src/base/QXmppStreamManagement_p.h
@@ -210,6 +210,7 @@ public:
     void handlePacketSent(const QXmppStanza &packet, const QByteArray &data);
     bool handleStanza(const QDomElement &stanza);
 
+    void resetCache();
     void enableStreamManagement(bool resetSequenceNumber);
     void setAcknowledgedSequenceNumber(unsigned int sequenceNumber);
 

--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -232,17 +232,23 @@ QXmppConfiguration& QXmppClient::configuration()
     return d->stream->configuration();
 }
 
+///
 /// Attempts to connect to the XMPP server. Server details and other configurations
 /// are specified using the config parameter. Use signals connected(), error(QXmppClient::Error)
 /// and disconnected() to know the status of the connection.
+///
 /// \param config Specifies the configuration object for connecting the XMPP server.
 /// This contains the host name, user, password etc. See QXmppConfiguration for details.
 /// \param initialPresence The initial presence which will be set for this user
 /// after establishing the session. The default value is QXmppPresence::Available
-
+///
 void QXmppClient::connectToServer(const QXmppConfiguration& config,
                                   const QXmppPresence& initialPresence)
 {
+    // reset package cache from last connection
+    if (d->stream->configuration().jidBare() != config.jidBare())
+        d->stream->resetPacketCache();
+
     d->stream->configuration() = config;
     d->clientPresence = initialPresence;
     d->addProperCapability(d->clientPresence);


### PR DESCRIPTION
The stream management mechanisms cache sent packages until the client
receives an acknowledgement from the server. When the connection gets
lost, the client resends all packages from the last connection that
have not been acknowledged.

And here comes the problem: When connecting with a different JID, the
client still resends all packages from the last connection. Packages
that were never intended to be sent from another account / to another
server.

This commit fixes this behaviour by resetting the package cache, when
the JID changes.