### PR TITLE
/// Sends a message to the room. Use the parameter msg to send it.

### DIFF
--- a/src/client/QXmppMucManager.cpp
+++ b/src/client/QXmppMucManager.cpp
@@ -343,6 +343,20 @@ bool QXmppMucRoom::sendMessage(const QString &text)
     return d->client->sendPacket(msg);
 }
 
+/// Sends a message to the room. Use the parameter msg to send it.
+///
+/// msg's To, Type, and Body will be set by this function.
+///
+/// \return true if the request was sent, false otherwise
+
+bool QXmppMucRoom::sendMessage(const QString &text, QXmppMessage &msg)
+{
+    msg.setTo(d->jid);
+    msg.setType(QXmppMessage::GroupChat);
+    msg.setBody(text);
+    return d->client->sendPacket(msg);
+}
+
 /// Sets your own nickname.
 ///
 /// You need to set your nickname before calling join().

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -244,6 +244,7 @@ public Q_SLOTS:
     bool setPermissions(const QList<QXmppMucItem> &permissions);
     bool sendInvitation(const QString &jid, const QString &reason);
     bool sendMessage(const QString &text);
+    bool sendMessage(const QString &text, QXmppMessage &msg);
 
 private Q_SLOTS:
     void _q_disconnected();


### PR DESCRIPTION
///
/// msg's To, Type, and Body will be set by this function.
///
/// \return true if the request was sent, false otherwise

bool QXmppMucRoom::sendMessage(const QString &text, QXmppMessage &msg)
{
    msg.setTo(d->jid);
    msg.setType(QXmppMessage::GroupChat);
    msg.setBody(text);
    return d->client->sendPacket(msg);
}