### PR TITLE
RosterManager: Add QFuture-based requests

### DIFF
--- a/src/base/QXmppGlobal.h.in
+++ b/src/base/QXmppGlobal.h.in
@@ -92,6 +92,11 @@ enum PacketState : quint8 {
     NotSent,       ///< The packet could not be sent (e.g. connection broke or user disconnected).
 };
 
+///
+/// An empty struct indicating success in results.
+///
+struct Success {};
+
 }
 
 #endif  // QXMPPGLOBAL_H

--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -387,7 +387,7 @@ QFuture<QXmppClient::IqResult> QXmppClient::sendIq(const QXmppIq &iq)
 QFuture<QXmppClient::EmptyResult> QXmppClient::sendGenericIq(const QXmppIq &iq)
 {
     using namespace QXmpp::Private;
-    return chainIq<EmptyResult, QXmppIq>(sendIq(iq), this, [](const QXmppIq &) {
+    return chainIq(sendIq(iq), this, [](const QXmppIq &) -> EmptyResult {
         return QXmpp::Success();
     });
 }

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -105,6 +105,9 @@ class QXMPP_EXPORT QXmppClient : public QXmppLoggable
     Q_PROPERTY(State state READ state NOTIFY stateChanged)
 
 public:
+    using IqResult = std::variant<QDomElement, QXmpp::PacketState>;
+    using EmptyResult = std::variant<QXmpp::Success, QXmppStanza::Error>;
+
     /// An enumeration for type of error.
     /// Error could come due a TCP socket or XML stream or due to various stanzas.
     enum Error {
@@ -220,9 +223,8 @@ public:
     QXmppStanza::Error::Condition xmppStreamError();
 
     QFuture<QXmpp::PacketState> send(const QXmppStanza &);
-
-    using IqResult = std::variant<QDomElement, QXmpp::PacketState>;
     QFuture<IqResult> sendIq(const QXmppIq &);
+    QFuture<EmptyResult> sendGenericIq(const QXmppIq &iq);
 
 #if QXMPP_DEPRECATED_SINCE(1, 1)
     QT_DEPRECATED_X("Use QXmppClient::findExtension<QXmppRosterManager>() instead")

--- a/src/client/QXmppDiscoveryManager.cpp
+++ b/src/client/QXmppDiscoveryManager.cpp
@@ -144,7 +144,7 @@ QFuture<QXmppDiscoveryManager::InfoResult> QXmppDiscoveryManager::requestDiscoIn
         request.setQueryNode(node);
     }
 
-    return chainIq<InfoResult, QXmppDiscoveryIq>(client()->sendIq(request), this);
+    return chainIq<InfoResult>(client()->sendIq(request), this);
 }
 
 ///
@@ -167,7 +167,7 @@ QFuture<QXmppDiscoveryManager::ItemsResult> QXmppDiscoveryManager::requestDiscoI
         request.setQueryNode(node);
     }
 
-    return chainIq<ItemsResult, QXmppDiscoveryIq>(client()->sendIq(request), this, [](QXmppDiscoveryIq &&iq) {
+    return chainIq(client()->sendIq(request), this, [](QXmppDiscoveryIq &&iq) -> ItemsResult {
         return iq.items();
     });
 }

--- a/src/client/QXmppEntityTimeManager.cpp
+++ b/src/client/QXmppEntityTimeManager.cpp
@@ -78,7 +78,7 @@ auto QXmppEntityTimeManager::requestEntityTime(const QString &jid) -> QFuture<En
     iq.setType(QXmppIq::Get);
     iq.setTo(jid);
 
-    return chainIq<EntityTimeResult, QXmppEntityTimeIq>(client()->sendIq(iq), this);
+    return chainIq<EntityTimeResult>(client()->sendIq(iq), this);
 }
 
 /// \cond

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -30,10 +30,14 @@
 #include "QXmppPresence.h"
 #include "QXmppRosterIq.h"
 
+#include <variant>
+
 #include <QMap>
 #include <QObject>
 #include <QStringList>
 
+template<typename T>
+class QFuture;
 class QXmppRosterManagerPrivate;
 
 ///
@@ -71,6 +75,9 @@ class QXMPP_EXPORT QXmppRosterManager : public QXmppClientExtension
     Q_OBJECT
 
 public:
+    /// Empty result containing QXmpp::Success or a QXmppStanza::Error
+    using Result = std::variant<QXmpp::Success, QXmppStanza::Error>;
+
     QXmppRosterManager(QXmppClient *stream);
     ~QXmppRosterManager() override;
 
@@ -83,6 +90,12 @@ public:
         const QString &bareJid) const;
     QXmppPresence getPresence(const QString &bareJid,
                               const QString &resource) const;
+
+    QFuture<Result> addRosterItem(const QString &bareJid, const QString &name = {}, const QSet<QString> &groups = {});
+    QFuture<Result> removeRosterItem(const QString &bareJid);
+    QFuture<Result> renameRosterItem(const QString &bareJid, const QString &name);
+    QFuture<QXmpp::PacketState> subscribeTo(const QString &bareJid, const QString &reason = {});
+    QFuture<QXmpp::PacketState> unsubscribeFrom(const QString &bareJid, const QString &reason = {});
 
     /// \cond
     bool handleStanza(const QDomElement &element) override;

--- a/src/client/QXmppUploadRequestManager.cpp
+++ b/src/client/QXmppUploadRequestManager.cpp
@@ -267,7 +267,7 @@ auto QXmppUploadRequestManager::requestSlot(const QString &fileName,
     iq.setSize(fileSize);
     iq.setContentType(mimeType);
 
-    return chainIq<SlotResult, QXmppHttpUploadSlotIq>(client()->sendIq(iq), this);
+    return chainIq<SlotResult>(client()->sendIq(iq), this);
 }
 
 /// Returns true if an HTTP File Upload service has been discovered.


### PR DESCRIPTION
Before opening a pull-request please check you've done:
- [x] Document every new public class and function
- [x] Add `\since QXmpp 1.X` to newly added classes and functions
- [x] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)

