### PR TITLE
Use qMakePair() again to fix compile errors

### DIFF
--- a/src/base/QXmppDataForm.cpp
+++ b/src/base/QXmppDataForm.cpp
@@ -880,7 +880,7 @@ void QXmppDataForm::parse(const QDomElement &element)
             for (auto element = fieldElement.firstChildElement("option");
                  !element.isNull();
                  element = element.nextSiblingElement("option")) {
-                options << QPair(element.attribute("label"), element.firstChildElement("value").text());
+                options << qMakePair(element.attribute("label"), element.firstChildElement("value").text());
             }
             field.setOptions(options);
         }

--- a/src/client/QXmppCallManager.cpp
+++ b/src/client/QXmppCallManager.cpp
@@ -182,7 +182,7 @@ void QXmppCallManager::setStunServers(const QList<QPair<QHostAddress, quint16>> 
 void QXmppCallManager::setStunServer(const QHostAddress &host, quint16 port)
 {
     d->stunServers.clear();
-    d->stunServers.push_back(QPair(host, port));
+    d->stunServers.push_back(qMakePair(host, port));
 }
 
 ///

--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -1318,9 +1318,9 @@ QXmppTransferJob *QXmppTransferManager::sendFile(const QString &jid, QIODevice *
     QXmppDataForm::Field methodField(QXmppDataForm::Field::ListSingleField);
     methodField.setKey("stream-method");
     if (d->supportedMethods & QXmppTransferJob::InBandMethod)
-        methodField.setOptions(methodField.options() << QPair(QString(), QString::fromLatin1(ns_ibb)));
+        methodField.setOptions(methodField.options() << qMakePair(QString(), QString::fromLatin1(ns_ibb)));
     if (d->supportedMethods & QXmppTransferJob::SocksMethod)
-        methodField.setOptions(methodField.options() << QPair(QString(), QString::fromLatin1(ns_bytestreams)));
+        methodField.setOptions(methodField.options() << qMakePair(QString(), QString::fromLatin1(ns_bytestreams)));
     form.setFields(QList<QXmppDataForm::Field>() << methodField);
 
     // start job


### PR DESCRIPTION
Before opening a pull-request please do:
- [x] Documentation:
  - [x] Document every new public class and function
  - [x] Add `\since QXmpp 1.X` to newly added classes and functions
  - [x] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] When implementing or updating XEPs add it to `doc/xep.doc`
- [x] Add unit tests for everything you've changed or added
