### PR TITLE
clang-format: Use brace wrapping after struct

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,6 +4,7 @@ BasedOnStyle: WebKit
 BraceWrapping:
   AfterClass: true
   AfterFunction: true
+  AfterStruct: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakConstructorInitializers: BeforeColon


### PR DESCRIPTION
Before opening a pull-request please do:
- [ ] Documentation:
  - [ ] Document every new public class and function
  - [ ] Add `\since QXmpp 1.X` to newly added classes and functions
  - [ ] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [ ] Add unit tests for everything you've changed or added

This change is made to comply with https://github.com/qxmpp-project/qxmpp/pull/353#discussion_r696720652 and https://github.com/qxmpp-project/qxmpp/pull/353#discussion_r696720778.