### PR TITLE
Add XEP-0080: User Location

### DIFF
--- a/doc/xep.doc
+++ b/doc/xep.doc
@@ -1,4 +1,4 @@
-/*! \page xep XMPP Extensions
+﻿/*! \page xep XMPP Extensions
 
 This document lists the XMPP Extensions (XEP) available in QXmpp.
 
@@ -15,6 +15,7 @@ Complete:
 - \xep{0066, Out of Band Data} (partially)
 - \xep{0071, XHTML-IM}
 - \xep{0077, In-Band Registration} (v2.4)
+- \xep{0080, User Location} (v1.5)
 - \xep{0078, Non-SASL Authentication}
 - \xep{0082, XMPP Date and Time Profiles}
 - \xep{0085, Chat State Notifications}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,7 @@ set(INSTALL_HEADER_FILES
     base/QXmppElement.h
     base/QXmppEntityTimeIq.h
     base/QXmppFutureUtils_p.h
+    base/QXmppGeolocItem.h
     base/QXmppHttpUploadIq.h
     base/QXmppIbbIq.h
     base/QXmppIq.h
@@ -113,6 +114,7 @@ set(INSTALL_HEADER_FILES
     client/QXmppTrustStorage.h
     client/QXmppUploadRequestManager.h
     client/QXmppUserTuneManager.h
+    client/QXmppUserLocationManager.h
     client/QXmppVCardManager.h
     client/QXmppVersionManager.h
 
@@ -142,6 +144,7 @@ set(SOURCE_FILES
     base/QXmppDiscoveryIq.cpp
     base/QXmppElement.cpp
     base/QXmppEntityTimeIq.cpp
+    base/QXmppGeolocItem.cpp
     base/QXmppHttpUploadIq.cpp
     base/QXmppIbbIq.cpp
     base/QXmppIq.cpp
@@ -218,6 +221,7 @@ set(SOURCE_FILES
     client/QXmppTrustMemoryStorage.cpp
     client/QXmppTrustStorage.cpp
     client/QXmppUploadRequestManager.cpp
+    client/QXmppUserLocationManager.cpp
     client/QXmppUserTuneManager.cpp
     client/QXmppVCardManager.cpp
     client/QXmppVersionManager.cpp

--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -77,6 +77,9 @@ const char* ns_register_feature = "http://jabber.org/features/iq-register";
 // XEP-0078: Non-SASL Authentication
 const char* ns_auth = "jabber:iq:auth";
 const char* ns_authFeature = "http://jabber.org/features/iq-auth";
+// XEP-0080: User Location
+const char* ns_geoloc = "http://jabber.org/protocol/geoloc";
+const char* ns_geoloc_notify = "http://jabber.org/protocol/geoloc+notify";
 // XEP-0085: Chat State Notifications
 const char* ns_chat_states = "http://jabber.org/protocol/chatstates";
 // XEP-0091: Legacy Delayed Delivery

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -89,6 +89,8 @@ extern const char* ns_register_feature;
 // XEP-0078: Non-SASL Authentication
 extern const char* ns_auth;
 extern const char* ns_authFeature;
+// XEP-0080: User Location
+extern const char* ns_geoloc;
 // XEP-0085: Chat State Notifications
 extern const char* ns_chat_states;
 // XEP-0091: Legacy Delayed Delivery

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -91,6 +91,7 @@ extern const char* ns_auth;
 extern const char* ns_authFeature;
 // XEP-0080: User Location
 extern const char* ns_geoloc;
+extern const char* ns_geoloc_notify;
 // XEP-0085: Chat State Notifications
 extern const char* ns_chat_states;
 // XEP-0091: Legacy Delayed Delivery

--- a/src/base/QXmppGeolocItem.cpp
+++ b/src/base/QXmppGeolocItem.cpp
@@ -26,8 +26,8 @@
 #include "QXmppConstants_p.h"
 #include "QXmppUtils.h"
 
-#include <QFloat16>
 #include <QDomElement>
+#include <QFloat16>
 #include <QUrl>
 #include <QXmlStreamWriter>
 

--- a/src/base/QXmppGeolocItem.cpp
+++ b/src/base/QXmppGeolocItem.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2008-2022 The QXmpp developers
+ *
+ * Author:
+ *  Linus Jahn
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#include "QXmppGeolocItem.h"
+
+#include "QXmppConstants_p.h"
+#include "QXmppUtils.h"
+
+#include <QFloat16>
+#include <QDomElement>
+#include <QUrl>
+#include <QXmlStreamWriter>
+
+/// \cond
+class QXmppGeolocItemPrivate : public QSharedData
+{
+public:
+    QXmppGeolocItemPrivate();
+
+    quint8 accuracy;
+    QString country;
+    qfloat16 lat;
+    QString locality;
+    qfloat16 lon;
+};
+
+QXmppGeolocItemPrivate::QXmppGeolocItemPrivate()
+{
+}
+/// \endcond
+
+///
+/// \class QXmppGeolocItem
+///
+/// This class represents a PubSub item for \xep{0080, User Location}.
+///
+/// \since QXmpp 1.5
+///
+
+///
+/// Default constructor
+///
+QXmppGeolocItem::QXmppGeolocItem()
+    : d(new QXmppGeolocItemPrivate)
+{
+}
+
+/// Copy-constructor.
+QXmppGeolocItem::QXmppGeolocItem(const QXmppGeolocItem &other) = default;
+
+QXmppGeolocItem::~QXmppGeolocItem() = default;
+
+/// Assignment operator.
+QXmppGeolocItem &QXmppGeolocItem::operator=(const QXmppGeolocItem &other) = default;
+
+///
+/// Returns the horizontal GPS error in meters.
+///
+quint8 QXmppGeolocItem::accuracy() const
+{
+    return d->accuracy;
+}
+
+///
+/// Sets the horizontal GPS error.
+///
+void QXmppGeolocItem::setAccuracy(const quint8 &accuracy)
+{
+    d->accuracy = accuracy;
+}
+
+///
+/// Returns the country.
+///
+QString QXmppGeolocItem::country() const
+{
+    return d->country;
+}
+
+///
+/// Sets the country.
+///
+void QXmppGeolocItem::setCountry(const QString &country)
+{
+    d->country = country;
+}
+
+///
+/// Returns the latitude in decimal degrees.
+///
+qfloat16 QXmppGeolocItem::lat() const
+{
+    return d->lat;
+}
+
+///
+/// Sets the latitude.
+///
+void QXmppGeolocItem::setLat(qfloat16 &lat)
+{
+    if (lat > 90 || lat < -90)
+        d->lat = 0;
+    else
+        d->lat = lat;
+}
+
+///
+/// Returns the locality such as a town or a city.
+///
+QString QXmppGeolocItem::locality() const
+{
+    return d->locality;
+}
+
+///
+/// Sets the locality.
+///
+void QXmppGeolocItem::setLocality(const QString &locality)
+{
+    d->locality = locality;
+}
+
+///
+/// Returns the longitude in decimal degrees.
+///
+qfloat16 QXmppGeolocItem::lon() const
+{
+    return d->lon;
+}
+
+///
+/// Sets the longitude.
+///
+void QXmppGeolocItem::setLon(qfloat16 &lon)
+{
+    if (lon > 180 || lon < -180)
+        d->lon = 0;
+    else
+        d->lon = lon;
+}
+
+///
+/// Returns true, if the element is a valid \xep{0080}: User Location PubSub item.
+///
+bool QXmppGeolocItem::isItem(const QDomElement &itemElement)
+{
+    auto isPayloadValid = [](const QDomElement &payload) -> bool {
+        return payload.tagName() == QStringLiteral("tune") &&
+            payload.namespaceURI() == ns_geoloc;
+    };
+
+    return QXmppPubSubItem::isItem(itemElement, isPayloadValid);
+}
+
+/// \cond
+void QXmppGeolocItem::parsePayload(const QDomElement &tune)
+{
+    auto child = tune.firstChildElement();
+    while (!child.isNull()) {
+        if (child.tagName() == QStringLiteral("accuracy")) {
+            d->accuracy = child.text().toUShort();
+        } else if (child.tagName() == QStringLiteral("country")) {
+            d->country = child.text();
+        } else if (child.tagName() == QStringLiteral("lat")) {
+            bool ok = false;
+            d->lat = child.text().toLong(&ok);
+            if (!ok || d->lat > 90 || d->lat < -90) {
+                d->lat = 0;
+            }
+        } else if (child.tagName() == QStringLiteral("locality")) {
+            d->locality = child.text();
+        } else if (child.tagName() == QStringLiteral("lon")) {
+            bool ok = false;
+            d->lon = child.text().toLong(&ok);
+            if (!ok || d->lon > 180 || d->lon < -180) {
+                d->lon = 0;
+            }
+        }
+
+        child = child.nextSiblingElement();
+    }
+}
+
+void QXmppGeolocItem::serializePayload(QXmlStreamWriter *writer) const
+{
+    writer->writeStartElement(QStringLiteral("geoloc"));
+    writer->writeDefaultNamespace(ns_geoloc);
+
+    helperToXmlAddTextElement(writer, QStringLiteral("accuracy"), QString::number(d->accuracy));
+    writer->writeTextElement(QStringLiteral("country"), d->country);
+    writer->writeTextElement(QStringLiteral("lat"), QString::number(d->lat));
+    helperToXmlAddTextElement(writer, QStringLiteral("locality"), d->locality);
+    helperToXmlAddTextElement(writer, QStringLiteral("lon"), QString::number(d->lon));
+
+    writer->writeEndElement();
+}
+/// \endcond

--- a/src/base/QXmppGeolocItem.h
+++ b/src/base/QXmppGeolocItem.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2008-2022 The QXmpp developers
+ *
+ * Author:
+ *  Linus Jahn
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#ifndef QXMPPGEOLOCITEM_H
+#define QXMPPGEOLOCITEM_H
+
+#include "QXmppPubSubItem.h"
+
+#include <QSharedDataPointer>
+
+class QXmppGeolocItemPrivate;
+class QUrl;
+
+class QXMPP_EXPORT QXmppGeolocItem : public QXmppPubSubItem
+{
+public:
+    QXmppGeolocItem();
+    QXmppGeolocItem(const QXmppGeolocItem &other);
+    ~QXmppGeolocItem();
+
+    QXmppGeolocItem &operator=(const QXmppGeolocItem &other);
+
+    quint8 accuracy() const;
+    void setAccuracy(const quint8 &accuracy);
+
+    QString country() const;
+    void setCountry(const QString &country);
+
+    qfloat16 lat() const;
+    void setLat(qfloat16 &lat);
+
+    QString locality() const;
+    void setLocality(const QString &locality);
+
+    qfloat16 lon() const;
+    void setLon(qfloat16 &lon);
+
+    static bool isItem(const QDomElement &itemElement);
+
+protected:
+    /// \cond
+    void parsePayload(const QDomElement &payloadElement) override;
+    void serializePayload(QXmlStreamWriter *writer) const override;
+    /// \endcond
+
+private:
+    QSharedDataPointer<QXmppGeolocItemPrivate> d;
+};
+
+Q_DECLARE_METATYPE(QXmppGeolocItem)
+
+#endif  // QXMPPGEOLOCITEM_H

--- a/src/client/QXmppUserLocationManager.cpp
+++ b/src/client/QXmppUserLocationManager.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2008-2022 The QXmpp developers
+ *
+ * Author:
+ *  Linus Jahn
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#include "QXmppUserLocationManager.h"
+
+#include "QXmppConstants_p.h"
+#include "QXmppFutureUtils_p.h"
+#include "QXmppPubSubEvent.h"
+#include "QXmppPubSubManager.h"
+#include "QXmppGeolocItem.h"
+
+using namespace QXmpp::Private;
+
+///
+/// \class QXmppUserLocationManager
+///
+/// The QXmppUserLocationManager implements \xep{0080, User Location}. You'll receive
+/// location updates from all presence subscriptions. You can publish location
+/// information on the user's account (publish()) and request location information
+/// from specific accounts (request()).
+///
+/// The manager needs to be added to the client first and also requires the
+/// QXmppPubSubManager.
+/// \code
+/// QXmppClient client;
+/// auto *pubSubManager = client.addNewExtension<QXmppPubSubManager>();
+/// auto *locationManager = client.addNewExtension<QXmppUserLocationManager>();
+/// \endcode
+///
+/// \since QXmpp 1.5
+///
+
+///
+/// \typedef QXmppUserLocationManager::LocationResult
+///
+/// Contains the User Location information or an error.
+///
+
+///
+/// \typedef QXmppUserLocationManager::PublishResult
+///
+/// Contains the ID of the published item on success or a stanza error.
+///
+
+///
+/// \fn QXmppUserLocationManager::userLocationChanged()
+///
+/// Emitted whenever an \xep{0080, User Location} items event arrives.
+///
+
+QXmppUserLocationManager::QXmppUserLocationManager()
+{
+}
+
+QStringList QXmppUserLocationManager::discoveryFeatures() const
+{
+    return {
+        ns_geoloc,
+        ns_geoloc_notify,
+    };
+}
+
+///
+/// Request User Location information from an account.
+///
+/// \param jid The account JID to request.
+///
+QFuture<QXmppUserLocationManager::LocationResult> QXmppUserLocationManager::request(const QString &jid)
+{
+    using PubSub = QXmppPubSubManager;
+    using Error = QXmppStanza::Error;
+
+    return chain<LocationResult>(pubSub()->requestItems<QXmppGeolocItem>(jid, ns_geoloc), this,
+                             [](PubSub::ItemsResult<QXmppGelocItem> &&result) -> LocationResult {
+                                 if (const auto items = std::get_if<PubSub::Items<QXmppGeolocItem>>(&result)) {
+                                     if (!items->items.isEmpty()) {
+                                         return items->items.constFirst();
+                                     }
+                                     return Error(Error::Cancel, Error::ItemNotFound, QStringLiteral("No location available."));
+                                 } else {
+                                     return std::get<QXmppStanza::Error>(result);
+                                 }
+                             });
+}
+
+///
+/// Publishes User Location information on the user's account.
+///
+/// \param item The User Location item to be published.
+///
+QFuture<QXmppUserLocationManager::PublishResult> QXmppUserLocationManager::publish(const QXmppGeolocItem &item)
+{
+    return pubSub()->publishPepItem(ns_geoloc, item);
+}
+
+/// \cond
+bool QXmppUserLocationManager::handlePubSubEvent(const QDomElement &element, const QString &pubSubService, const QString &nodeName)
+{
+    if (nodeName == ns_geoloc && QXmppPubSubEvent<QXmppGeolocItem>::isPubSubEvent(element)) {
+        QXmppPubSubEvent<QXmppGeolocItem> event;
+        event.parse(element);
+
+        if (event.eventType() == QXmppPubSubEventBase::Items) {
+            if (!event.items().isEmpty()) {
+                emit userLocationChanged(pubSubService, event.items().constFirst());
+            } else {
+                emit userLocationChanged(pubSubService, {});
+            }
+            return true;
+        }
+    }
+    return false;
+}
+/// \endcond

--- a/src/client/QXmppUserLocationManager.cpp
+++ b/src/client/QXmppUserLocationManager.cpp
@@ -25,9 +25,9 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppFutureUtils_p.h"
+#include "QXmppGeolocItem.h"
 #include "QXmppPubSubEvent.h"
 #include "QXmppPubSubManager.h"
-#include "QXmppGeolocItem.h"
 
 using namespace QXmpp::Private;
 
@@ -91,16 +91,16 @@ QFuture<QXmppUserLocationManager::LocationResult> QXmppUserLocationManager::requ
     using Error = QXmppStanza::Error;
 
     return chain<LocationResult>(pubSub()->requestItems<QXmppGeolocItem>(jid, ns_geoloc), this,
-                             [](PubSub::ItemsResult<QXmppGelocItem> &&result) -> LocationResult {
-                                 if (const auto items = std::get_if<PubSub::Items<QXmppGeolocItem>>(&result)) {
-                                     if (!items->items.isEmpty()) {
-                                         return items->items.constFirst();
+                                 [](PubSub::ItemsResult<QXmppGeolocItem> &&result) -> LocationResult {
+                                     if (const auto items = std::get_if<PubSub::Items<QXmppGeolocItem>>(&result)) {
+                                         if (!items->items.isEmpty()) {
+                                             return items->items.constFirst();
+                                         }
+                                         return Error(Error::Cancel, Error::ItemNotFound, QStringLiteral("No location available."));
+                                     } else {
+                                         return std::get<QXmppStanza::Error>(result);
                                      }
-                                     return Error(Error::Cancel, Error::ItemNotFound, QStringLiteral("No location available."));
-                                 } else {
-                                     return std::get<QXmppStanza::Error>(result);
-                                 }
-                             });
+                                 });
 }
 
 ///

--- a/src/client/QXmppUserLocationManager.h
+++ b/src/client/QXmppUserLocationManager.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2008-2022 The QXmpp developers
+ *
+ * Author:
+ *  Linus Jahn
+ *
+ * Source:
+ *  https://github.com/qxmpp-project/qxmpp
+ *
+ * This file is a part of QXmpp library.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+#ifndef QXMPPUSERLOCATIONMANAGER_H
+#define QXMPPUSERLOCATIONMANAGER_H
+
+#include "QXmppPubSubEventManager.h"
+
+#include <variant>
+
+class QXmppGeolocItem;
+
+class QXMPP_EXPORT QXmppUserLocationManager : public QXmppPubSubEventManager
+{
+    Q_OBJECT
+
+public:
+    using LocationResult = std::variant<QXmppGeolocItem, QXmppStanza::Error>;
+    using PublishResult = std::variant<QString, QXmppStanza::Error>;
+
+    QXmppUserLocationManager();
+
+    QStringList discoveryFeatures() const override;
+
+    QFuture<LocationResult> request(const QString &jid);
+    QFuture<PublishResult> publish(const QXmppGeolocItem &);
+
+    Q_SIGNAL void userLocationChanged(const QString &jid, const QXmppGeolocItem &);
+
+protected:
+    /// \cond
+    bool handlePubSubEvent(const QDomElement &element, const QString &pubSubService, const QString &nodeName) override;
+    /// \endcond
+};
+
+#endif  // QXMPPUSERLOCATIONMANAGER_H


### PR DESCRIPTION
WIP

I want to use this XEP in a toy project, so, made this bare minimum implementation copying from User Tune. 

Maybe serious clients can use to send position as messages, as modern messengers do. There is a lot of data fields on the XEP, and I would like some input on what are really useful. 

Before opening a pull-request please do:
- [x] Documentation:
  - [x] Document every new public class and function
  - [x] Add `\since QXmpp 1.X` to newly added classes and functions
  - [x] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] When implementing or updating XEPs add it to `doc/xep.doc`
- [ ] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

