### PR TITLE
Refactor trust storages

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,8 @@ set(INSTALL_HEADER_FILES
     # Client
     client/QXmppArchiveManager.h
     client/QXmppAtmManager.h
+    client/QXmppAtmTrustMemoryStorage.h
+    client/QXmppAtmTrustStorage.h
     client/QXmppAttentionManager.h
     client/QXmppBookmarkManager.h
     client/QXmppCarbonManager.h
@@ -196,6 +198,8 @@ set(SOURCE_FILES
     # Client
     client/QXmppArchiveManager.cpp
     client/QXmppAtmManager.cpp
+    client/QXmppAtmTrustMemoryStorage.cpp
+    client/QXmppAtmTrustStorage.cpp
     client/QXmppAttentionManager.cpp
     client/QXmppBookmarkManager.cpp
     client/QXmppCarbonManager.cpp

--- a/src/client/QXmppAtmManager.cpp
+++ b/src/client/QXmppAtmManager.cpp
@@ -8,12 +8,10 @@
 #include "QXmppClient.h"
 #include "QXmppConstants_p.h"
 #include "QXmppFutureUtils_p.h"
+#include "QXmppMessage.h"
 #include "QXmppTrustMessageElement.h"
+#include "QXmppTrustMessageKeyOwner.h"
 #include "QXmppUtils.h"
-
-#include <QCoreApplication>
-#include <QDomElement>
-#include <QList>
 
 using namespace QXmpp::Private;
 
@@ -27,21 +25,10 @@ using namespace QXmpp::Private;
 /// storage interface must be added.
 /// That implementation has to be adapted to your storage such as a database.
 /// In case you only need memory and no peristent storage, you can use the
-/// existing implementation:
+/// existing implementation and add the storage with it:
 ///
 ///\code
-/// QXmppTrustStorage *trustStorage = new QXmppTrustMemoryStorage;
-/// \endcode
-///
-/// You can set a security policy used by ATM via the trust manager.
-/// Is is recommended to apply TOAKAFA for good security and usability when
-/// using \xep{0384, OMEMO Encryption}:
-/// \code
-/// trustStorage->setSecurityPolicy("urn:xmpp:omemo:2", QXmppTrustStorage::Toakafa);
-/// \endcode
-///
-/// Afterwards, this manager must be added with the storage:
-/// \code
+/// QXmppAtmTrustStorage *trustStorage = new QXmppAtmTrustMemoryStorage;
 /// QXmppAtmManager *manager = new QXmppAtmManager(trustStorage);
 /// client->addExtension(manager);
 /// \endcode
@@ -73,7 +60,7 @@ using namespace QXmpp::Private;
 ///
 /// \param trustStorage trust storage implementation
 ///
-QXmppAtmManager::QXmppAtmManager(QXmppTrustStorage *trustStorage)
+QXmppAtmManager::QXmppAtmManager(QXmppAtmTrustStorage *trustStorage)
 {
     m_trustStorage = trustStorage;
 }

--- a/src/client/QXmppAtmManager.h
+++ b/src/client/QXmppAtmManager.h
@@ -5,18 +5,19 @@
 #ifndef QXMPPATMMANAGER_H
 #define QXMPPATMMANAGER_H
 
+#include "QXmppAtmTrustStorage.h"
 #include "QXmppClientExtension.h"
-#include "QXmppMessage.h"
 #include "QXmppSendResult.h"
-#include "QXmppTrustMessageKeyOwner.h"
-#include "QXmppTrustStorage.h"
+
+class QXmppMessage;
+class QXmppTrustMessageKeyOwner;
 
 class QXMPP_EXPORT QXmppAtmManager : public QXmppClientExtension
 {
     Q_OBJECT
 
 public:
-    QXmppAtmManager(QXmppTrustStorage *trustStorage);
+    QXmppAtmManager(QXmppAtmTrustStorage *trustStorage);
     QFuture<void> makeTrustDecisions(const QString &encryption, const QString &keyOwnerJid, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting = {});
 
     /// \cond
@@ -41,7 +42,7 @@ private:
 
     QFuture<QXmpp::SendResult> sendTrustMessage(const QString &encryption, const QList<QXmppTrustMessageKeyOwner> &keyOwners, const QString &recipientJid);
 
-    QXmppTrustStorage *m_trustStorage;
+    QXmppAtmTrustStorage *m_trustStorage;
 
     friend class tst_QXmppAtmManager;
 };

--- a/src/client/QXmppAtmTrustMemoryStorage.cpp
+++ b/src/client/QXmppAtmTrustMemoryStorage.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2022 Melvin Keskin <melvo@olomono.de>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QXmppAtmTrustMemoryStorage.h"
+
+#include "QXmppFutureUtils_p.h"
+#include "QXmppTrustMessageKeyOwner.h"
+
+using namespace QXmpp::Private;
+
+///
+/// \class QXmppAtmTrustMemoryStorage
+///
+/// \brief The QXmppAtmTrustMemoryStorage class stores trust data for
+/// \xep{0450, Automatic Trust Management (ATM)} in the memory.
+///
+/// \warning THIS API IS NOT FINALIZED YET!
+///
+/// \since QXmpp 1.5
+///
+
+struct UnprocessedKey
+{
+    QByteArray id;
+    QString ownerJid;
+    QByteArray senderKeyId;
+    bool trust;
+};
+
+class QXmppAtmTrustMemoryStoragePrivate
+{
+public:
+    // encryption protocols mapped to trust message data received from endpoints
+    // with unauthenticated keys
+    QMultiHash<QString, UnprocessedKey> keys;
+};
+
+///
+/// Constructs an ATM trust memory storage.
+///
+QXmppAtmTrustMemoryStorage::QXmppAtmTrustMemoryStorage()
+    : d(new QXmppAtmTrustMemoryStoragePrivate)
+{
+}
+
+QXmppAtmTrustMemoryStorage::~QXmppAtmTrustMemoryStorage() = default;
+
+/// \cond
+QFuture<void> QXmppAtmTrustMemoryStorage::addKeysForPostponedTrustDecisions(const QString &encryption, const QByteArray &senderKeyId, const QList<QXmppTrustMessageKeyOwner> &keyOwners)
+{
+    const auto addKeys = [&](const QXmppTrustMessageKeyOwner &keyOwner, bool trust, const QList<QByteArray> &keyIds) {
+        for (const auto &keyId : keyIds) {
+            auto isKeyFound = false;
+
+            for (auto itr = d->keys.find(encryption); itr != d->keys.end() && itr.key() == encryption; ++itr) {
+                auto &key = itr.value();
+                if (key.id == keyId && key.ownerJid == keyOwner.jid() && key.senderKeyId == senderKeyId) {
+                    // Update the stored trust if it differs from the new one.
+                    if (key.trust != trust) {
+                        key.trust = trust;
+                    }
+
+                    isKeyFound = true;
+                    break;
+                }
+            }
+
+            // Create a new entry and store it if there is no such entry yet.
+            if (!isKeyFound) {
+                UnprocessedKey key;
+                key.id = keyId;
+                key.ownerJid = keyOwner.jid();
+                key.senderKeyId = senderKeyId;
+                key.trust = trust;
+                d->keys.insert(encryption, key);
+            }
+        }
+    };
+
+    for (const auto &keyOwner : keyOwners) {
+        addKeys(keyOwner, true, keyOwner.trustedKeys());
+        addKeys(keyOwner, false, keyOwner.distrustedKeys());
+    }
+
+    return makeReadyFuture();
+}
+
+QFuture<void> QXmppAtmTrustMemoryStorage::removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting)
+{
+    for (auto itr = d->keys.find(encryption);
+         itr != d->keys.end() && itr.key() == encryption;) {
+        const auto &key = itr.value();
+        if ((key.trust && keyIdsForAuthentication.contains(key.id)) ||
+            (!key.trust && keyIdsForDistrusting.contains(key.id))) {
+            itr = d->keys.erase(itr);
+        } else {
+            ++itr;
+        }
+    }
+
+    return makeReadyFuture();
+}
+
+QFuture<void> QXmppAtmTrustMemoryStorage::removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds)
+{
+    for (auto itr = d->keys.find(encryption);
+         itr != d->keys.end() && itr.key() == encryption;) {
+        if (senderKeyIds.contains(itr.value().senderKeyId)) {
+            itr = d->keys.erase(itr);
+        } else {
+            ++itr;
+        }
+    }
+
+    return makeReadyFuture();
+}
+
+QFuture<void> QXmppAtmTrustMemoryStorage::removeKeysForPostponedTrustDecisions(const QString &encryption)
+{
+    d->keys.remove(encryption);
+    return makeReadyFuture();
+}
+
+QFuture<QHash<bool, QMultiHash<QString, QByteArray>>> QXmppAtmTrustMemoryStorage::keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds)
+{
+    QHash<bool, QMultiHash<QString, QByteArray>> keys;
+
+    const auto storedKeys = d->keys.values(encryption);
+    for (const auto &key : storedKeys) {
+        if (senderKeyIds.contains(key.senderKeyId) || senderKeyIds.isEmpty()) {
+            keys[key.trust].insert(key.ownerJid, key.id);
+        }
+    }
+
+    return makeReadyFuture(std::move(keys));
+}
+
+QFuture<void> QXmppAtmTrustMemoryStorage::resetAll(const QString &encryption)
+{
+    QXmppTrustMemoryStorage::resetAll(encryption);
+    d->keys.remove(encryption);
+    return makeReadyFuture();
+}
+/// \endcond

--- a/src/client/QXmppAtmTrustMemoryStorage.h
+++ b/src/client/QXmppAtmTrustMemoryStorage.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2022 Melvin Keskin <melvo@olomono.de>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPATMTRUSTMEMORYSTORAGE_H
+#define QXMPPATMTRUSTMEMORYSTORAGE_H
+
+#include "QXmppAtmTrustStorage.h"
+#include "QXmppTrustMemoryStorage.h"
+
+class QXmppAtmTrustMemoryStoragePrivate;
+
+class QXMPP_EXPORT QXmppAtmTrustMemoryStorage : virtual public QXmppAtmTrustStorage, public QXmppTrustMemoryStorage
+{
+public:
+    QXmppAtmTrustMemoryStorage();
+    ~QXmppAtmTrustMemoryStorage();
+
+    /// \cond
+    QFuture<void> addKeysForPostponedTrustDecisions(const QString &encryption, const QByteArray &senderKeyId, const QList<QXmppTrustMessageKeyOwner> &keyOwners) override;
+    QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting) override;
+    QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds) override;
+    QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption) override;
+    QFuture<QHash<bool, QMultiHash<QString, QByteArray>>> keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds = {}) override;
+
+    QFuture<void> resetAll(const QString &encryption) override;
+    /// \endcond
+
+private:
+    std::unique_ptr<QXmppAtmTrustMemoryStoragePrivate> d;
+};
+
+#endif  // QXMPPATMTRUSTMEMORYSTORAGE_H

--- a/src/client/QXmppAtmTrustStorage.cpp
+++ b/src/client/QXmppAtmTrustStorage.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2022 Melvin Keskin <melvo@olomono.de>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+///
+/// \class QXmppAtmTrustStorage
+///
+/// \brief The QXmppAtmTrustStorage class stores trust data for
+/// \xep{0450, Automatic Trust Management (ATM)}.
+///
+/// \warning THIS API IS NOT FINALIZED YET!
+///
+/// \since QXmpp 1.5
+///
+
+///
+/// \fn QXmppAtmTrustStorage::addKeysForPostponedTrustDecisions(const QString &encryption, const QByteArray &senderKeyId, const QList<QXmppTrustMessageKeyOwner> &keyOwners)
+///
+/// Adds keys that cannot be authenticated or distrusted directly because the
+/// key of the trust message's sender is not yet authenticated.
+///
+/// Those keys are being authenticated or distrusted once the sender's key is
+/// authenticated.
+/// Each element of keyOwners (i.e., keyOwner) can contain keys for postponed
+/// authentication as trustedKeys or for postponed distrusting as
+/// distrustedKeys.
+///
+/// If keys of keyOwner.trustedKeys() are already stored for postponed
+/// distrusting, they are changed to be used for postponed authentication.
+/// If keys of keyOwner.distrustedKeys() are already stored for postponed
+/// authentication, they are changed to be used for postponed distrusting.
+/// If the same keys are in keyOwner.trustedKeys() and
+/// keyOwner.distrustedKeys(), they are used for postponed distrusting.
+///
+/// \param encryption encryption protocol namespace
+/// \param senderKeyId key ID of the trust message's sender
+/// \param keyOwners key owners containing key IDs for postponed trust decisions
+///
+
+///
+/// \fn QXmppAtmTrustStorage::removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting)
+///
+/// Removes keys for postponed authentication or distrusting.
+///
+/// \param encryption encryption protocol namespace
+/// \param keyIdsForAuthentication IDs of the keys for postponed authentication
+/// \param keyIdsForDistrusting IDs of the keys for postponed distrusting
+///
+
+///
+/// \fn QXmppAtmTrustStorage::removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds)
+///
+/// Removes keys for postponed authentication or distrusting by the trust
+/// message sender's key ID.
+///
+/// \param encryption encryption protocol namespace
+/// \param senderKeyIds key IDs of the trust messages' senders
+///
+
+///
+/// \fn QXmppAtmTrustStorage::removeKeysForPostponedTrustDecisions(const QString &encryption)
+///
+/// Removes all keys for postponed authentication or distrusting for encryption.
+///
+/// \param encryption encryption protocol namespace
+///
+
+///
+/// \fn QXmppAtmTrustStorage::keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds = {})
+///
+/// Returns the JIDs of key owners mapped to the IDs of their keys stored for
+/// postponed authentication (true) or postponed distrusting (false).
+///
+/// If senderKeyIds is empty, all keys for encryption are returned.
+///
+/// \param encryption encryption protocol namespace
+/// \param senderKeyIds key IDs of the trust messages' senders
+///
+/// \return the key owner JIDs mapped to their keys
+///

--- a/src/client/QXmppAtmTrustStorage.h
+++ b/src/client/QXmppAtmTrustStorage.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2022 Melvin Keskin <melvo@olomono.de>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPATMTRUSTSTORAGE_H
+#define QXMPPATMTRUSTSTORAGE_H
+
+#include "QXmppTrustStorage.h"
+
+class QXmppTrustMessageKeyOwner;
+
+class QXMPP_EXPORT QXmppAtmTrustStorage : virtual public QXmppTrustStorage
+{
+public:
+    virtual ~QXmppAtmTrustStorage() = default;
+
+    virtual QFuture<void> addKeysForPostponedTrustDecisions(const QString &encryption, const QByteArray &senderKeyId, const QList<QXmppTrustMessageKeyOwner> &keyOwners) = 0;
+    virtual QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting) = 0;
+    virtual QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds) = 0;
+    virtual QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption) = 0;
+    virtual QFuture<QHash<bool, QMultiHash<QString, QByteArray>>> keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds = {}) = 0;
+};
+
+#endif  // QXMPPATMTRUSTSTORAGE_H

--- a/src/client/QXmppTrustMemoryStorage.h
+++ b/src/client/QXmppTrustMemoryStorage.h
@@ -5,39 +5,40 @@
 #ifndef QXMPPTRUSTMEMORYSTORAGE_H
 #define QXMPPTRUSTMEMORYSTORAGE_H
 
-#include "QXmppGlobal.h"
 #include "QXmppTrustStorage.h"
 
 #include <memory>
 
 class QXmppTrustMemoryStoragePrivate;
 
-class QXMPP_EXPORT QXmppTrustMemoryStorage : public QXmppTrustStorage
+class QXMPP_EXPORT QXmppTrustMemoryStorage : virtual public QXmppTrustStorage
 {
 public:
     QXmppTrustMemoryStorage();
     ~QXmppTrustMemoryStorage();
 
     /// \cond
-    QFuture<void> setSecurityPolicies(const QString &encryption = {}, SecurityPolicy securityPolicy = QXmppTrustStorage::NoSecurityPolicy) override;
+    QFuture<void> setSecurityPolicy(const QString &encryption, SecurityPolicy securityPolicy) override;
+    QFuture<void> resetSecurityPolicy(const QString &encryption) override;
     QFuture<SecurityPolicy> securityPolicy(const QString &encryption) override;
 
-    QFuture<void> addOwnKey(const QString &encryption, const QByteArray &keyId) override;
-    QFuture<void> removeOwnKey(const QString &encryption) override;
+    QFuture<void> setOwnKey(const QString &encryption, const QByteArray &keyId) override;
+    QFuture<void> resetOwnKey(const QString &encryption) override;
     QFuture<QByteArray> ownKey(const QString &encryption) override;
 
     QFuture<void> addKeys(const QString &encryption, const QString &keyOwnerJid, const QList<QByteArray> &keyIds, TrustLevel trustLevel = TrustLevel::AutomaticallyDistrusted) override;
-    QFuture<void> removeKeys(const QString &encryption = {}, const QList<QByteArray> &keyIds = {}) override;
+    QFuture<void> removeKeys(const QString &encryption, const QList<QByteArray> &keyIds) override;
+    QFuture<void> removeKeys(const QString &encryption, const QString &keyOwnerJid) override;
+    QFuture<void> removeKeys(const QString &encryption) override;
     QFuture<QHash<TrustLevel, QMultiHash<QString, QByteArray>>> keys(const QString &encryption, TrustLevels trustLevels = {}) override;
+    QFuture<QHash<QString, QHash<QByteArray, TrustLevel>>> keys(const QString &encryption, const QList<QString> &keyOwnerJids, TrustLevels trustLevels = {}) override;
+    QFuture<bool> hasKey(const QString &encryption, const QString &keyOwnerJid, TrustLevels trustLevels) override;
 
     QFuture<void> setTrustLevel(const QString &encryption, const QMultiHash<QString, QByteArray> &keyIds, const TrustLevel trustLevel) override;
     QFuture<void> setTrustLevel(const QString &encryption, const QList<QString> &keyOwnerJids, const TrustLevel oldTrustLevel, const TrustLevel newTrustLevel) override;
     QFuture<TrustLevel> trustLevel(const QString &encryption, const QByteArray &keyId) override;
 
-    QFuture<void> addKeysForPostponedTrustDecisions(const QString &encryption, const QByteArray &senderKeyId, const QList<QXmppTrustMessageKeyOwner> &keyOwners) override;
-    QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting) override;
-    QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption = {}, const QList<QByteArray> &senderKeyIds = {}) override;
-    QFuture<QHash<bool, QMultiHash<QString, QByteArray>>> keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds = {}) override;
+    QFuture<void> resetAll(const QString &encryption) override;
     /// \endcond
 
 private:

--- a/src/client/QXmppTrustStorage.cpp
+++ b/src/client/QXmppTrustStorage.cpp
@@ -8,23 +8,28 @@
 /// \brief The QXmppTrustStorage class stores trust data for end-to-end
 /// encryption.
 ///
+/// The term "key" is used for a public long-term key.
+///
 /// \warning THIS API IS NOT FINALIZED YET!
 ///
 /// \since QXmpp 1.5
 ///
 
 ///
-/// \fn QXmppTrustStorage::setSecurityPolicies(const QString &encryption = {}, SecurityPolicy securityPolicy = SecurityPolicy::NoSecurityPolicy)
+/// \fn QXmppTrustStorage::setSecurityPolicy(const QString &encryption, SecurityPolicy securityPolicy)
 ///
-/// Sets the security policy for an encryption protocol or resets the set
-/// security policies.
-///
-/// If securityPolicy is not passed, the set security policy for encryption is
-/// reset.
-/// If also encryption is not passed, all set security policies are reset.
+/// Sets the security policy for an encryption protocol.
 ///
 /// \param encryption encryption protocol namespace
 /// \param securityPolicy security policy being applied
+///
+
+///
+/// \fn QXmppTrustStorage::resetSecurityPolicy(const QString &encryption)
+///
+/// Resets the security policy for an encryption protocol.
+///
+/// \param encryption encryption protocol namespace
 ///
 
 ///
@@ -38,18 +43,20 @@
 ///
 
 ///
-/// \fn QXmppTrustStorage::addOwnKey(const QString &encryption, const QByteArray &keyId)
+/// \fn QXmppTrustStorage::setOwnKey(const QString &encryption, const QByteArray &keyId)
 ///
-/// Adds an own key (i.e., the key used by this client instance).
+/// Sets the own key (i.e., the key used by this client instance) for an
+/// encryption protocol.
 ///
 /// \param encryption encryption protocol namespace
 /// \param keyId ID of the key
 ///
 
 ///
-/// \fn QXmppTrustStorage::removeOwnKey(const QString &encryption)
+/// \fn QXmppTrustStorage::resetOwnKey(const QString &encryption)
 ///
-/// Removes an own key (i.e., the key used by this client instance).
+/// Resets the own key (i.e., the key used by this client instance) for an
+/// encryption protocol.
 ///
 /// \param encryption encryption protocol namespace
 ///
@@ -57,7 +64,8 @@
 ///
 /// \fn QXmppTrustStorage::ownKey(const QString &encryption)
 ///
-/// Returns an own key (i.e., the key used by this client instance).
+/// Returns the own key (i.e., the key used by this client instance) for an
+/// encryption protocol.
 ///
 /// \param encryption encryption protocol namespace
 ///
@@ -80,25 +88,68 @@
 ///
 /// Removes keys.
 ///
-/// If keyIds is not passed, all keys for encryption are removed.
-/// If encryption is also not passed, all keys are removed.
-///
 /// \param encryption encryption protocol namespace
 /// \param keyIds IDs of the keys
 ///
 
 ///
+/// \fn QXmppTrustStorage::removeKeys(const QString &encryption, const QString &keyOwnerJid)
+///
+/// Removes all keys of a key owner.
+///
+/// \param encryption encryption protocol namespace
+/// \param keyOwnerJid key owner's bare JID
+///
+
+///
+/// \fn QXmppTrustStorage::removeKeys(const QString &encryption)
+///
+/// Removes all keys for encryption.
+///
+/// \param encryption encryption protocol namespace
+///
+
+///
 /// \fn QXmppTrustStorage::keys(const QString &encryption, TrustLevels trustLevels = {})
 ///
-/// Returns the JIDs of the key owners mapped to the IDs of their keys with a
-/// specific trust level.
+/// Returns the JIDs of all key owners mapped to the IDs of their keys with
+/// specific trust levels.
 ///
-/// If no trust levels are passed, all keys are returned.
+/// If no trust levels are passed, all keys for encryption are returned.
 ///
 /// \param encryption encryption protocol namespace
 /// \param trustLevels trust levels of the keys
 ///
-/// \return the key owner JIDs mapped to their keys with a specific trust level
+/// \return the key owner JIDs mapped to their keys with specific trust levels
+///
+
+///
+/// \fn QXmppTrustStorage::keys(const QString &encryption, const QList<QString> &keyOwnerJids, TrustLevels trustLevels = {})
+///
+/// Returns the IDs of keys mapped to their trust levels for specific key
+/// owners.
+///
+/// If no trust levels are passed, all keys for encryption and keyOwnerJids are
+/// returned.
+///
+/// \param encryption encryption protocol namespace
+/// \param keyOwnerJids key owners' bare JIDs
+/// \param trustLevels trust levels of the keys
+///
+/// \return the key IDs mapped to their trust levels for specific key owners
+///
+
+///
+/// \fn QXmppTrustStorage::hasKey(const QString &encryption, const QString &keyOwnerJid, TrustLevels trustLevels)
+///
+/// Returns whether at least one key of a key owner with a specific trust level
+/// is stored.
+///
+/// \param encryption encryption protocol namespace
+/// \param keyOwnerJid key owner's bare JID
+/// \param trustLevels possible trust levels of the key
+///
+/// \return whether a key of the key owner with a passed trust level is stored
 ///
 
 ///
@@ -129,7 +180,7 @@
 ///
 /// Returns the trust level of a key.
 ///
-/// If the key is not stored, it is seen as automatically distrusted.
+/// If the key is not stored, the trust in that key is undecided.
 ///
 /// \param encryption encryption protocol namespace
 /// \param keyId ID of the key
@@ -138,62 +189,9 @@
 ///
 
 ///
-/// \fn QXmppTrustStorage::addKeysForPostponedTrustDecisions(const QString &encryption, const QByteArray &senderKeyId, const QList<QXmppTrustMessageKeyOwner> &keyOwners)
+/// \fn QXmppTrustStorage::resetAll(const QString &encryption)
 ///
-/// Adds keys that cannot be authenticated or distrusted directly because the
-/// key of the trust message's sender is not yet authenticated.
-///
-/// Those keys are being authenticated or distrusted once the sender's key is
-/// authenticated.
-/// Each element of keyOwners (i.e., keyOwner) can contain keys for postponed
-/// authentication as trustedKeys or for postponed distrusting as
-/// distrustedKeys.
-///
-/// If keys of keyOwner.trustedKeys() are already stored for postponed
-/// distrusting, they are changed to be used for postponed authentication.
-/// If keys of keyOwner.distrustedKeys() are already stored for postponed
-/// authentication, they are changed to be used for postponed distrusting.
-/// If the same keys are in keyOwner.trustedKeys() and
-/// keyOwner.distrustedKeys(), they are used for postponed distrusting.
+/// Resets all data for encryption.
 ///
 /// \param encryption encryption protocol namespace
-/// \param senderKeyId key ID of the trust message's sender
-/// \param keyOwners key owners containing key IDs for postponed trust decisions
-///
-
-///
-/// \fn QXmppTrustStorage::removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting)
-///
-/// Removes keys for postponed authentication or distrusting.
-///
-/// \param encryption encryption protocol namespace
-/// \param keyIdsForAuthentication IDs of the keys for postponed authentication
-/// \param keyIdsForDistrusting IDs of the keys for postponed distrusting
-///
-
-///
-/// \fn QXmppTrustStorage::removeKeysForPostponedTrustDecisions(const QString &encryption = {}, const QList<QByteArray> &senderKeyIds = {})
-///
-/// Removes keys for postponed authentication or distrusting by the trust
-/// message's sender's key ID.
-///
-/// If senderKeyIds is empty, all keys for encryption are removed.
-/// If encryption is empty too, all keys are removed.
-///
-/// \param encryption encryption protocol namespace
-/// \param senderKeyIds key IDs of the trust messages' senders
-///
-
-///
-/// \fn QXmppTrustStorage::keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds = {})
-///
-/// Returns the JIDs of key owners mapped to the IDs of their keys stored for
-/// postponed authentication (true) or postponed distrusting (false).
-///
-/// If senderKeyIds is empty, all keys for encryption are returned.
-///
-/// \param encryption encryption protocol namespace
-/// \param senderKeyIds key IDs of the trust messages' senders
-///
-/// \return the key owner JIDs mapped to their keys
 ///

--- a/src/client/QXmppTrustStorage.h
+++ b/src/client/QXmppTrustStorage.h
@@ -9,8 +9,6 @@
 
 #include <QFuture>
 
-class QXmppTrustMessageKeyOwner;
-
 class QXMPP_EXPORT QXmppTrustStorage
 {
 public:
@@ -20,7 +18,7 @@ public:
     ///
     enum SecurityPolicy {
         NoSecurityPolicy,  ///< New keys must be trusted manually.
-        Toakafa,           ///< New keys are trusted automatically until the first authentication but automatically distrusted afterwards.
+        Toakafa,           ///< New keys are trusted automatically until the first authentication but automatically distrusted afterwards. \see \xep{0450, Automatic Trust Management (ATM)}
     };
 
     ///
@@ -28,35 +26,38 @@ public:
     /// protocols
     ///
     enum TrustLevel {
-        AutomaticallyDistrusted = 1,  ///< The key is automatically distrusted (e.g., by ATM's security policy).
-        ManuallyDistrusted = 2,       ///< The key is manually distrusted (e.g., by clicking a button or ATM).
-        AutomaticallyTrusted = 4,     ///< The key is automatically trusted (e.g., by the client for all keys of a bare JID until one of it is authenticated).
-        ManuallyTrusted = 8,          ///< The key is manually trusted (e.g., by clicking a button).
-        Authenticated = 16,           ///< The key is authenticated (e.g., by QR code scanning or ATM).
+        Undecided = 1,                ///< The key's trust is not decided.
+        AutomaticallyDistrusted = 2,  ///< The key is automatically distrusted (e.g., by the security policy TOAKAFA). \see SecurityPolicy
+        ManuallyDistrusted = 4,       ///< The key is manually distrusted (e.g., by clicking a button or \xep{0450, Automatic Trust Management (ATM)}).
+        AutomaticallyTrusted = 8,     ///< The key is automatically trusted (e.g., by the client for all keys of a bare JID until one of it is authenticated).
+        ManuallyTrusted = 16,         ///< The key is manually trusted (e.g., by clicking a button).
+        Authenticated = 32,           ///< The key is authenticated (e.g., by QR code scanning or \xep{0450, Automatic Trust Management (ATM)}).
     };
     Q_DECLARE_FLAGS(TrustLevels, TrustLevel)
 
     virtual ~QXmppTrustStorage() = default;
 
-    virtual QFuture<void> setSecurityPolicies(const QString &encryption = {}, SecurityPolicy securityPolicy = SecurityPolicy::NoSecurityPolicy) = 0;
+    virtual QFuture<void> setSecurityPolicy(const QString &encryption, SecurityPolicy securityPolicy) = 0;
+    virtual QFuture<void> resetSecurityPolicy(const QString &encryption) = 0;
     virtual QFuture<SecurityPolicy> securityPolicy(const QString &encryption) = 0;
 
-    virtual QFuture<void> addOwnKey(const QString &encryption, const QByteArray &keyId) = 0;
-    virtual QFuture<void> removeOwnKey(const QString &encryption) = 0;
+    virtual QFuture<void> setOwnKey(const QString &encryption, const QByteArray &keyId) = 0;
+    virtual QFuture<void> resetOwnKey(const QString &encryption) = 0;
     virtual QFuture<QByteArray> ownKey(const QString &encryption) = 0;
 
     virtual QFuture<void> addKeys(const QString &encryption, const QString &keyOwnerJid, const QList<QByteArray> &keyIds, TrustLevel trustLevel = TrustLevel::AutomaticallyDistrusted) = 0;
-    virtual QFuture<void> removeKeys(const QString &encryption = {}, const QList<QByteArray> &keyIds = {}) = 0;
+    virtual QFuture<void> removeKeys(const QString &encryption, const QList<QByteArray> &keyIds) = 0;
+    virtual QFuture<void> removeKeys(const QString &encryption, const QString &keyOwnerJid) = 0;
+    virtual QFuture<void> removeKeys(const QString &encryption) = 0;
     virtual QFuture<QHash<TrustLevel, QMultiHash<QString, QByteArray>>> keys(const QString &encryption, TrustLevels trustLevels = {}) = 0;
+    virtual QFuture<QHash<QString, QHash<QByteArray, TrustLevel>>> keys(const QString &encryption, const QList<QString> &keyOwnerJids, TrustLevels trustLevels = {}) = 0;
+    virtual QFuture<bool> hasKey(const QString &encryption, const QString &keyOwnerJid, TrustLevels trustLevels) = 0;
 
     virtual QFuture<void> setTrustLevel(const QString &encryption, const QMultiHash<QString, QByteArray> &keyIds, TrustLevel trustLevel) = 0;
     virtual QFuture<void> setTrustLevel(const QString &encryption, const QList<QString> &keyOwnerJids, TrustLevel oldTrustLevel, TrustLevel newTrustLevel) = 0;
     virtual QFuture<TrustLevel> trustLevel(const QString &encryption, const QByteArray &keyId) = 0;
 
-    virtual QFuture<void> addKeysForPostponedTrustDecisions(const QString &encryption, const QByteArray &senderKeyId, const QList<QXmppTrustMessageKeyOwner> &keyOwners) = 0;
-    virtual QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &keyIdsForAuthentication, const QList<QByteArray> &keyIdsForDistrusting) = 0;
-    virtual QFuture<void> removeKeysForPostponedTrustDecisions(const QString &encryption = {}, const QList<QByteArray> &senderKeyIds = {}) = 0;
-    virtual QFuture<QHash<bool, QMultiHash<QString, QByteArray>>> keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds = {}) = 0;
+    virtual QFuture<void> resetAll(const QString &encryption) = 0;
 };
 
 Q_DECLARE_METATYPE(QXmppTrustStorage::SecurityPolicy)


### PR DESCRIPTION
QXmppTrustStorage is now the base class for all trust storages used by
end-to-end encryption managers.
QXmppAtmTrustStorage is used by QXmppAtmManager.

QXmppTrustMemoryStorage is now the base class for all trust storages
that use the memory for storing data.
QXmppAtmTrustMemoryStorage can be used by QXmppAtmManager.

Methods needed by the upcoming OMEMO implementation are added.
Some existing methods are refactored.

Before opening a pull-request please do:
- [x] Documentation:
  - [x] Document every new public class and function
  - [x] Add `\since QXmpp 1.X` to newly added classes and functions
  - [x] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [x] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`
