### PR TITLE
Use upper camel case for encryption method names

### DIFF
--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -85,14 +85,14 @@ public:
     /// \since QXmpp 1.1
     ///
     enum EncryptionMethod {
-        NoEncryption,       ///< No encryption
-        UnknownEncryption,  ///< Unknown encryption
-        OTR,                ///< \xep{0364, Current Off-the-Record Messaging Usage}
-        LegacyOpenPGP,      ///< \xep{0027, Current Jabber OpenPGP Usage}
-        OX,                 ///< \xep{0373, OpenPGP for XMPP}
-        OMEMO,              ///< \xep{0384, OMEMO Encryption}
-        OMEMO1,             ///< \xep{0384, OMEMO Encryption} since version 0.4
-        OMEMO2              ///< \xep{0384, OMEMO Encryption} since version 0.8
+        NoEncryption,                                  ///< No encryption
+        UnknownEncryption,                             ///< Unknown encryption
+        Otr, OTR = Otr,                                ///< \xep{0364, Current Off-the-Record Messaging Usage}
+        LegacyOpenPgp, LegacyOpenPGP = LegacyOpenPgp,  ///< \xep{0027, Current Jabber OpenPGP Usage}
+        Ox, OX = Ox,                                   ///< \xep{0373, OpenPGP for XMPP}
+        Omemo, OMEMO = Omemo,                          ///< \xep{0384, OMEMO Encryption}
+        Omemo1,                                        ///< \xep{0384, OMEMO Encryption} since version 0.4
+        Omemo2                                         ///< \xep{0384, OMEMO Encryption} since version 0.8
     };
 
     QXmppMessage(const QString &from = QString(), const QString &to = QString(),

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -776,7 +776,7 @@ void tst_QXmppMessage::testEme()
     QXmppMessage messageOmemo;
     parsePacket(messageOmemo, xmlOmemo);
     QCOMPARE(messageOmemo.encryptionMethodNs(), QString("eu.siacs.conversations.axolotl"));
-    QCOMPARE(messageOmemo.encryptionMethod(), QXmppMessage::OMEMO);
+    QCOMPARE(messageOmemo.encryptionMethod(), QXmppMessage::Omemo);
     QCOMPARE(messageOmemo.encryptionName(), QString("OMEMO"));
     serializePacket(messageOmemo, xmlOmemo);
 
@@ -796,8 +796,8 @@ void tst_QXmppMessage::testEme()
 
     // test setters/getters
     QXmppMessage message;
-    message.setEncryptionMethod(QXmppMessage::LegacyOpenPGP);
-    QCOMPARE(message.encryptionMethod(), QXmppMessage::LegacyOpenPGP);
+    message.setEncryptionMethod(QXmppMessage::LegacyOpenPgp);
+    QCOMPARE(message.encryptionMethod(), QXmppMessage::LegacyOpenPgp);
     QCOMPARE(message.encryptionMethodNs(), QString("jabber:x:encrypted"));
     QCOMPARE(message.encryptionName(), QString("Legacy OpenPGP"));
 


### PR DESCRIPTION
Before opening a pull-request please do:
- [ ] Documentation:
  - [ ] Document every new public class and function
  - [ ] Add `\since QXmpp 1.X` to newly added classes and functions
  - [ ] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [x] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`
