### PR TITLE
Fix some unsafety issues

### DIFF
--- a/src/client/QXmppUploadRequestManager.cpp
+++ b/src/client/QXmppUploadRequestManager.cpp
@@ -220,7 +220,8 @@ void QXmppUploadRequestManager::handleDiscoInfo(const QXmppDiscoveryIq &iq)
 
             // get size limit
             bool isFormNsCorrect = false;
-            for (const QXmppDataForm::Field &field : iq.form().fields()) {
+            const auto fields = iq.form().fields();
+            for (const QXmppDataForm::Field &field : fields) {
                 if (field.key() == QStringLiteral("FORM_TYPE")) {
                     isFormNsCorrect = field.value() == ns_http_upload;
                 } else if (isFormNsCorrect && field.key() == QStringLiteral("max-file-size")) {


### PR DESCRIPTION
Before opening a pull-request please do:
- [x] Documentation:
  - [x] Document every new public class and function
  - [x] Add `\since QXmpp 1.X` to newly added classes and functions
  - [x] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
  - [x] When implementing or updating XEPs add it to `doc/xep.doc`
- [x] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`
