### PR TITLE
src: CMakeLists: Fix comment for QXmppBuildConstants.h.in

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/base)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/client)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/server)
 
-# Configure QXmppGlobal.h.in
+# Configure QXmppBuildConstants.h.in
 if(BUILD_SHARED)
     set(QXMPP_BUILD_SHARED true)
 else()


### PR DESCRIPTION
Before opening a pull-request please do:
- [ ] Documentation:
  - [ ] Document every new public class and function
  - [ ] Add `\since QXmpp 1.X` to newly added classes and functions
  - [ ] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [ ] Add unit tests for everything you've changed or added
- [ ] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`
