### PR TITLE
Fix PubSub methods with a standard item ID parameter

### DIFF
--- a/src/client/QXmppPubSubManager.cpp
+++ b/src/client/QXmppPubSubManager.cpp
@@ -424,9 +424,6 @@ auto QXmppPubSubManager::retractItem(const QString &jid, const QString &nodeName
 ///
 /// Deletes an item from a pubsub node.
 ///
-/// The default value of itemId is used for singleton nodes (i.e., the node's
-/// single item is deleted).
-///
 /// \param jid Jabber ID of the entity hosting the pubsub service
 /// \param nodeName the name of the node to delete the item from
 /// \param itemId the ID of the item to delete
@@ -827,9 +824,6 @@ QFuture<QXmppPubSubManager::Result> QXmppPubSubManager::unsubscribeFromNode(cons
 ///
 /// Requests a specific item of a PEP node.
 ///
-/// The default value of itemId is used for singleton nodes (i.e., the node's
-/// single item is requested).
-///
 /// This is a convenience method equivalent to calling
 /// QXmppPubSubManager::requestItem on the current account's bare JID.
 ///
@@ -876,9 +870,6 @@ QFuture<QXmppPubSubManager::Result> QXmppPubSubManager::unsubscribeFromNode(cons
 /// \fn QXmppPubSubManager::retractPepItem(const QString &nodeName, StandardItemId itemId)
 ///
 /// Deletes an item from a PEP node.
-///
-/// The default value of itemId is used for singleton nodes (i.e., the node's
-/// single item is deleted).
 ///
 /// This is a convenience method equivalent to calling
 /// QXmppPubSubManager::retractItem on the current account's bare JID.

--- a/src/client/QXmppPubSubManager.h
+++ b/src/client/QXmppPubSubManager.h
@@ -38,7 +38,7 @@ public:
     /// Pre-defined ID of a PubSub item
     ///
     enum StandardItemId {
-        Current  ///< Item of a singleton node
+        Current  ///< Item of a singleton node (i.e., the node's single item)
     };
 
     ///
@@ -126,7 +126,7 @@ public:
     template<typename T = QXmppPubSubItem>
     inline QFuture<ItemResult<T>> requestPepItem(const QString &nodeName, const QString &itemId) { return requestItem<T>(client()->configuration().jidBare(), nodeName, itemId); }
     template<typename T = QXmppPubSubItem>
-    inline QFuture<ItemResult<T>> requestPepItem(const QString &nodeName, StandardItemId itemId = Current) { return requestItem<T>(client()->configuration().jidBare(), nodeName, itemId); }
+    inline QFuture<ItemResult<T>> requestPepItem(const QString &nodeName, StandardItemId itemId) { return requestItem<T>(client()->configuration().jidBare(), nodeName, itemId); }
     template<typename T = QXmppPubSubItem>
     inline QFuture<ItemsResult<T>> requestPepItems(const QString &nodeName) { return requestItems(client()->configuration().jidBare(), nodeName); }
     inline QFuture<ItemIdsResult> requestPepItemIds(const QString &nodeName) { return requestItemIds(client()->configuration().jidBare(), nodeName); }
@@ -188,9 +188,6 @@ QFuture<QXmppPubSubManager::ItemResult<T>> QXmppPubSubManager::requestItem(const
 
 ///
 /// Requests a specific item of an entity's node.
-///
-/// The default value of itemId is used for singleton nodes (i.e., the node's
-/// single item is requested).
 ///
 /// \param jid Jabber ID of the entity hosting the pubsub service. For PEP this
 /// should be an account's bare JID

--- a/tests/qxmpppubsubmanager/tst_qxmpppubsubmanager.cpp
+++ b/tests/qxmpppubsubmanager/tst_qxmpppubsubmanager.cpp
@@ -868,7 +868,7 @@ void tst_QXmppPubSubManager::testRequestCurrentPepItem()
 {
     auto [test, psManager] = Client();
 
-    auto future = psManager->requestPepItem(QStringLiteral("princely_musings"));
+    auto future = psManager->requestPepItem(QStringLiteral("princely_musings"), PSManager::Current);
     test.expect(QStringLiteral("<iq id='qxmpp1' type='get'>"
                                "<pubsub xmlns='http://jabber.org/protocol/pubsub'>"
                                "<items node='princely_musings'>"


### PR DESCRIPTION
Before opening a pull-request please do:
- [ ] Documentation:
  - [ ] Document every new public class and function
  - [ ] Add `\since QXmpp 1.X` to newly added classes and functions
  - [ ] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [x] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

This fixes inconsistencies introduced by @LNJ's commits after https://github.com/qxmpp-project/qxmpp/pull/392#discussion_r846669515.