### PR TITLE
PubSubManager: Fix template usage of 'requestItem()'

### DIFF
--- a/src/client/QXmppPubSubManager.h
+++ b/src/client/QXmppPubSubManager.h
@@ -203,7 +203,7 @@ QFuture<QXmppPubSubManager::ItemResult<T>> QXmppPubSubManager::requestItem(const
                                                                            const QString &nodeName,
                                                                            StandardItemId itemId)
 {
-    return requestItem(jid, nodeName, standardItemIdToString(itemId));
+    return requestItem<T>(jid, nodeName, standardItemIdToString(itemId));
 }
 
 ///


### PR DESCRIPTION
Before opening a pull-request please do:
- [ ] Documentation:
  - [ ] Document every new public class and function
  - [ ] Add `\since QXmpp 1.X` to newly added classes and functions
  - [ ] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [ ] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`
