### PR TITLE
PubSubManager: Make 'standardItemIdToString()' public

### DIFF
--- a/src/client/QXmppPubSubManager.cpp
+++ b/src/client/QXmppPubSubManager.cpp
@@ -933,6 +933,22 @@ QFuture<QXmppPubSubManager::Result> QXmppPubSubManager::unsubscribeFromNode(cons
 /// \sa requestPepNodeConfiguration()
 ///
 
+///
+/// Returns a standard item ID string.
+///
+/// \param itemId standard item ID to be translated
+/// \return the item ID string or a default-constructed string if there is no
+///         corresponding one
+///
+QString QXmppPubSubManager::standardItemIdToString(StandardItemId itemId)
+{
+    switch (itemId) {
+    case Current:
+        return QStringLiteral("current");
+    }
+    return {};
+}
+
 /// \cond
 QStringList QXmppPubSubManager::discoveryFeatures() const
 {
@@ -983,15 +999,6 @@ QXmppPubSubIq<> QXmppPubSubManager::requestItemsIq(const QString &jid, const QSt
         request.setItems(items);
     }
     return request;
-}
-
-QString QXmppPubSubManager::standardItemIdToString(StandardItemId itemId)
-{
-    switch (itemId) {
-    case Current:
-        return QStringLiteral("current");
-    }
-    return {};
 }
 
 auto QXmppPubSubManager::publishItem(QXmppPubSubIqBase &&request) -> QFuture<PublishItemResult>

--- a/src/client/QXmppPubSubManager.h
+++ b/src/client/QXmppPubSubManager.h
@@ -145,6 +145,8 @@ public:
     inline QFuture<Result> configurePepNode(const QString &nodeName, const QXmppPubSubNodeConfig &config) { return configureNode(client()->configuration().jidBare(), nodeName, config); }
     inline QFuture<Result> cancelPepNodeConfiguration(const QString &nodeName) { return cancelNodeConfiguration(client()->configuration().jidBare(), nodeName); }
 
+    static QString standardItemIdToString(StandardItemId itemId);
+
     /// \cond
     QStringList discoveryFeatures() const override;
     bool handleStanza(const QDomElement &element) override;
@@ -154,8 +156,6 @@ private:
     QFuture<PublishItemResult> publishItem(QXmppPubSubIqBase &&iq);
     QFuture<PublishItemsResult> publishItems(QXmppPubSubIqBase &&iq);
     static QXmppPubSubIq<> requestItemsIq(const QString &jid, const QString &nodeName, const QStringList &itemIds);
-
-    static QString standardItemIdToString(StandardItemId itemId);
 
     // We may need a d-ptr in the future.
     void *d = nullptr;

--- a/tests/qxmpppubsubmanager/tst_qxmpppubsubmanager.cpp
+++ b/tests/qxmpppubsubmanager/tst_qxmpppubsubmanager.cpp
@@ -111,6 +111,7 @@ private:
     Q_SLOT void testUnsubscribeFromNode();
     Q_SLOT void testEventNotifications_data();
     Q_SLOT void testEventNotifications();
+    Q_SLOT void testStandardItemToString();
 };
 
 void tst_QXmppPubSubManager::testDiscoFeatures()
@@ -1343,6 +1344,12 @@ void tst_QXmppPubSubManager::testEventNotifications()
     }
 
     QCOMPARE(eventManager->pubSub(), psManager);
+}
+
+void tst_QXmppPubSubManager::testStandardItemToString()
+{
+    auto standardItemString = PSManager::standardItemIdToString(PSManager::Current);
+    QCOMPARE(standardItemString, QStringLiteral("current"));
 }
 
 QTEST_MAIN(tst_QXmppPubSubManager)


### PR DESCRIPTION
This is needed if the IDs of incoming items should be checked externally.

Before opening a pull-request please do:
- [ ] Documentation:
  - [x] Document every new public class and function
  - [ ] Add `\since QXmpp 1.X` to newly added classes and functions
  - [ ] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [x] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`
