### PR TITLE
Message: Do not allow XEP-0184 request and received element together

### DIFF
--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -1598,13 +1598,15 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
         }
 
         // XEP-0184: Message Delivery Receipts
+        // An ack message (message containing a "received" element) must not
+        // include a receipt request ("request" element) in order to prevent
+        // looping.
         if (!d->receiptId.isEmpty()) {
             writer->writeStartElement(QStringLiteral("received"));
             writer->writeDefaultNamespace(ns_message_receipts);
             writer->writeAttribute(QStringLiteral("id"), d->receiptId);
             writer->writeEndElement();
-        }
-        if (d->receiptRequested) {
+        } else if (d->receiptRequested) {
             writer->writeStartElement(QStringLiteral("request"));
             writer->writeDefaultNamespace(ns_message_receipts);
             writer->writeEndElement();


### PR DESCRIPTION
…not written

Before opening a pull-request please do:
- [ ] Documentation:
  - [ ] Document every new public class and function
  - [ ] Add `\since QXmpp 1.X` to newly added classes and functions
  - [ ] Fix any doxygen warnings from your code (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] When implementing or updating XEPs add it to `doc/xep.doc`
- [ ] Add unit tests for everything you've changed or added
- [x] On the top level, run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`
