### PR TITLE
QXmppCallStream: use new GStreamer method

### DIFF
--- a/src/client/QXmppCallStream.cpp
+++ b/src/client/QXmppCallStream.cpp
@@ -226,7 +226,11 @@ void QXmppCallStreamPrivate::addEncoder(QXmppCallPrivate::GstCodec &codec)
 
     gst_element_sync_state_with_parent(encoderBin);
 
+#if GST_CHECK_VERSION(1,20,0)
+    addRtcpSender(gst_element_request_pad_simple(rtpbin, QStringLiteral("send_rtcp_src_%1").arg(id).toLatin1().data()));
+#else
     addRtcpSender(gst_element_get_request_pad(rtpbin, QStringLiteral("send_rtcp_src_%1").arg(id).toLatin1().data()));
+#endif
 }
 
 void QXmppCallStreamPrivate::addDecoder(GstPad *pad, QXmppCallPrivate::GstCodec &codec)


### PR DESCRIPTION
instead of deprecated one  when build with GStreamer >= 1.20.0