### PR TITLE
Find dependencies dependencies of QXmpp when finding QXmpp

### DIFF
--- a/QXmppConfig.cmake.in
+++ b/QXmppConfig.cmake.in
@@ -3,6 +3,12 @@
 # SPDX-License-Identifier: CC0-1.0
 
 @PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Qt@QT_VERSION_MAJOR@Core)
+find_dependency(Qt@QT_VERSION_MAJOR@Network)
+find_dependency(Qt@QT_VERSION_MAJOR@Xml)
+
 include("${CMAKE_CURRENT_LIST_DIR}/QXmpp.cmake")
 check_required_components(QXmpp)
 


### PR DESCRIPTION
This way, users of the library don't need to find QtNetwork and QtXml themselves before finding QXmpp

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/xep.doc`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
