### PR TITLE
Add new e2ee capable carbon manager

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 PR check list:
 - [ ] Document your code
-- [ ] Add `\since QXmpp 1.X`
+- [ ] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
 - [ ] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
 - [ ] Update `doc/xep.doc`
 - [ ] Add unit tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ set(INSTALL_HEADER_FILES
     client/QXmppAttentionManager.h
     client/QXmppBookmarkManager.h
     client/QXmppCarbonManager.h
+    client/QXmppCarbonManagerV2.h
     client/QXmppClient.h
     client/QXmppClientExtension.h
     client/QXmppConfiguration.h
@@ -210,6 +211,7 @@ set(SOURCE_FILES
     client/QXmppAttentionManager.cpp
     client/QXmppBookmarkManager.cpp
     client/QXmppCarbonManager.cpp
+    client/QXmppCarbonManagerV2.cpp
     client/QXmppClient.cpp
     client/QXmppClientExtension.cpp
     client/QXmppConfiguration.cpp

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -106,6 +106,7 @@ public:
 
     // XEP-0280: Message Carbons
     bool privatemsg;
+    bool isCarbonForwarded;
 
     // XEP-0308: Last Message Correction
     QString replaceId;
@@ -159,6 +160,7 @@ QXmppMessagePrivate::QXmppMessagePrivate()
       receiptRequested(false),
       attentionRequested(false),
       privatemsg(false),
+      isCarbonForwarded(false),
       markable(false),
       marker(QXmppMessage::NoMarker),
       hints(0),
@@ -658,6 +660,28 @@ bool QXmppMessage::isPrivate() const
 void QXmppMessage::setPrivate(const bool priv)
 {
     d->privatemsg = priv;
+}
+
+///
+/// Returns whether this message has been forwarded using carbons.
+///
+/// \since QXmpp 1.5
+///
+bool QXmppMessage::isCarbonForwarded() const
+{
+    return d->isCarbonForwarded;
+}
+
+///
+/// Sets whether this message has been forwarded using carbons.
+///
+/// Setting this to true has no effect, this is purely informational.
+///
+/// \since QXmpp 1.5
+///
+void QXmppMessage::setCarbonForwarded(bool forwarded)
+{
+    d->isCarbonForwarded = forwarded;
 }
 
 ///

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -173,6 +173,8 @@ public:
     // XEP-0280: Message Carbons
     bool isPrivate() const;
     void setPrivate(const bool);
+    bool isCarbonForwarded() const;
+    void setCarbonForwarded(bool);
 
     // XEP-0308: Last Message Correction
     QString replaceId() const;

--- a/src/client/QXmppCarbonManager.cpp
+++ b/src/client/QXmppCarbonManager.cpp
@@ -91,6 +91,7 @@ bool QXmppCarbonManager::handleStanza(const QDomElement &element)
 
     QXmppMessage message;
     message.parse(messageElement);
+    message.setCarbonForwarded(true);
 
     if (sent)
         emit messageSent(message);

--- a/src/client/QXmppCarbonManager.h
+++ b/src/client/QXmppCarbonManager.h
@@ -16,6 +16,8 @@ class QXmppMessage;
 /// This class emits signals whenever another resource of the
 /// currently connected client account sent or received a message.
 ///
+/// \warning This manager does not decrypt e2ee messages. You can use QXmppCarbonManagerV2.
+///
 /// \ingroup Managers
 ///
 /// \since QXmpp 1.0

--- a/src/client/QXmppCarbonManagerV2.cpp
+++ b/src/client/QXmppCarbonManagerV2.cpp
@@ -101,6 +101,8 @@ auto parseIq(std::variant<QDomElement, SendError> &&sendResult) -> std::optional
 /// client.addNewExtension<QXmppCarbonManagerV2>();
 /// \endcode
 ///
+/// To distinguish carbon messages, you can use QXmppMessage::isCarbonMessage().
+///
 /// \ingroup Managers
 ///
 /// \since QXmpp 1.5
@@ -133,6 +135,7 @@ bool Manager::handleStanza(const QDomElement &element, const std::optional<QXmpp
 
     QXmppMessage message;
     message.parse(messageElement);
+    message.setCarbonForwarded(true);
 
     injectMessage(std::move(message));
     return true;

--- a/src/client/QXmppCarbonManagerV2.cpp
+++ b/src/client/QXmppCarbonManagerV2.cpp
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QXmppCarbonManagerV2.h"
+
+#include "QXmppClient.h"
+#include "QXmppConstants_p.h"
+#include "QXmppFutureUtils_p.h"
+#include "QXmppMessage.h"
+
+#include <QDomElement>
+#include <QStringBuilder>
+
+using namespace QXmpp;
+using namespace QXmpp::Private;
+using Manager = QXmppCarbonManagerV2;
+
+class CarbonEnableIq : public QXmppIq
+{
+public:
+    CarbonEnableIq()
+        : QXmppIq()
+    {
+        setType(QXmppIq::Set);
+    }
+
+    // parsing not implemented
+    void parseElementFromChild(const QDomElement &) override
+    {
+    }
+    void toXmlElementFromChild(QXmlStreamWriter *writer) const override
+    {
+        writer->writeStartElement(ns_carbons, "enable");
+        writer->writeEndElement();
+    }
+};
+
+auto firstXmlnsElement(const QDomElement &el, const char *xmlns)
+{
+    for (auto child = el.firstChildElement();
+         !child.isNull();
+         child = child.nextSiblingElement()) {
+        if (child.namespaceURI() == xmlns) {
+            return child;
+        }
+    }
+    return QDomElement();
+}
+
+auto firstChildElement(const QDomElement &el, const char *tagName, const char *xmlns)
+{
+    for (auto child = el.firstChild();
+         !child.isNull();
+         child = child.nextSibling()) {
+        if (child.isElement() && child.namespaceURI() == xmlns) {
+            auto childEl = child.toElement();
+            if (childEl.tagName() == tagName) {
+                return childEl;
+            }
+        }
+    }
+    return QDomElement();
+}
+
+auto parseIq(std::variant<QDomElement, SendError> &&sendResult) -> std::optional<QXmppStanza::Error>
+{
+    if (auto el = std::get_if<QDomElement>(&sendResult)) {
+        auto iqType = el->attribute(QStringLiteral("type"));
+        if (iqType == "result") {
+            return {};
+        }
+        QXmppIq iq;
+        iq.parse(*el);
+        return iq.error();
+    } else if (auto err = std::get_if<SendError>(&sendResult)) {
+        using Error = QXmppStanza::Error;
+        return Error(Error::Wait, Error::UndefinedCondition,
+                     QStringLiteral("Couldn't send request: ") + err->text);
+    }
+    return {};
+}
+
+///
+/// \class QXmppCarbonManagerV2
+///
+/// \brief The QXmppCarbonManagerV2 class handles message carbons as described in \xep{0280,
+/// Message Carbons}.
+///
+/// The manager automatically enables carbons when a connection is established. If the connection
+/// could be resumed, no new request is done. Carbon copied messages from other devices of the same
+/// account and carbon copied messages from other accounts are injected into the QXmppClient. This
+/// way you can handle them like any other incoming message by implementing QXmppMessageHandler.
+///
+/// Checks are done to ensure that the entity sending the carbon copy is allowed to send the
+/// forwarded message.
+///
+/// You don't need to do anything other than adding the extension to the client to use it.
+/// \code
+/// QXmppClient client;
+/// client.addNewExtension<QXmppCarbonManagerV2>();
+/// \endcode
+///
+/// \ingroup Managers
+///
+/// \since QXmpp 1.5
+///
+
+bool Manager::handleStanza(const QDomElement &element, const std::optional<QXmppE2eeMetadata> &)
+{
+    if (element.tagName() != "message") {
+        return false;
+    }
+
+    auto carbon = firstXmlnsElement(element, ns_carbons);
+    if (carbon.isNull() || (carbon.tagName() != "sent" && carbon.tagName() != "received")) {
+        return false;
+    }
+
+    // carbon copies must always come from our bare JID
+    auto from = element.attribute(QStringLiteral("from"));
+    if (from != client()->configuration().jidBare()) {
+        info("Received carbon copy from attacker or buggy client '" % from %
+             "' trying to use CVE-2017-5603.");
+        return false;
+    }
+
+    auto forwarded = firstChildElement(carbon, "forwarded", ns_forwarding);
+    auto messageElement = firstChildElement(forwarded, "message", ns_client);
+    if (messageElement.isNull()) {
+        return false;
+    }
+
+    QXmppMessage message;
+    message.parse(messageElement);
+
+    injectMessage(std::move(message));
+    return true;
+}
+
+void Manager::setClient(QXmppClient *newClient)
+{
+    if (client()) {
+        disconnect(client(), &QXmppClient::connected, this, &Manager::enableCarbons);
+    }
+
+    QXmppClientExtension::setClient(newClient);
+    connect(newClient, &QXmppClient::connected, this, &Manager::enableCarbons);
+}
+
+void Manager::enableCarbons()
+{
+    if (client()->streamManagementState() == QXmppClient::ResumedStream) {
+        // skip re-enabling for resumed streams
+        return;
+    }
+
+    await(client()->sendIq(CarbonEnableIq()), this, [this](QXmppClient::IqResult domResult) {
+        if (auto err = parseIq(std::move(domResult))) {
+            warning("Could not enable message carbons: " % err->text());
+        } else {
+            info("Message Carbons enabled.");
+        }
+    });
+}

--- a/src/client/QXmppCarbonManagerV2.h
+++ b/src/client/QXmppCarbonManagerV2.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPCARBONMANAGERV2_H
+#define QXMPPCARBONMANAGERV2_H
+
+#include "QXmppClientExtension.h"
+
+class QXMPP_EXPORT QXmppCarbonManagerV2 : public QXmppClientExtension
+{
+    Q_OBJECT
+public:
+    bool handleStanza(const QDomElement &, const std::optional<QXmppE2eeMetadata> &) override;
+
+protected:
+    void setClient(QXmppClient *client) override;
+
+private:
+    void enableCarbons();
+
+    // placeholder (we may need a d-ptr in the future)
+    void *d;
+};
+
+#endif  // QXMPPCARBONMANAGERV2_H

--- a/tests/qxmppcarbonmanager/tst_qxmppcarbonmanager.cpp
+++ b/tests/qxmppcarbonmanager/tst_qxmppcarbonmanager.cpp
@@ -28,6 +28,7 @@ void compareMessages(const QXmppMessage &lhs, const QXmppMessage &rhs)
     QCOMPARE(lhs.thread(), rhs.thread());
     QCOMPARE(lhs.stamp(), rhs.stamp());
     QCOMPARE(lhs.type(), rhs.type());
+    QCOMPARE(lhs.isCarbonForwarded(), rhs.isCarbonForwarded());
 }
 
 class QXmppCarbonTestHelper : public QObject
@@ -243,6 +244,7 @@ void tst_QXmppCarbonManager::testHandleStanza()
     if (!forwardedxml.isEmpty()) {
         parsePacket(expectedMessage, forwardedxml);
     }
+    expectedMessage.setCarbonForwarded(true);
 
     {
         m_helper.m_expectedMessage = expectedMessage;


### PR DESCRIPTION
- Add new message carbons manager
- tests: CarbonManager: Also test manager v2 & refactor
- Message: Add isCarbonForwarded attribute

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/xep.doc`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
