### PR TITLE
Use unique_ptrs

### DIFF
--- a/src/client/QXmppAtmTrustMemoryStorage.h
+++ b/src/client/QXmppAtmTrustMemoryStorage.h
@@ -27,7 +27,7 @@ public:
     /// \endcond
 
 private:
-    std::unique_ptr<QXmppAtmTrustMemoryStoragePrivate> d;
+    const std::unique_ptr<QXmppAtmTrustMemoryStoragePrivate> d;
 };
 
 #endif  // QXMPPATMTRUSTMEMORYSTORAGE_H

--- a/src/client/QXmppAttentionManager.cpp
+++ b/src/client/QXmppAttentionManager.cpp
@@ -89,13 +89,7 @@ QXmppAttentionManager::QXmppAttentionManager(quint8 allowedAttempts, QTime timeF
 {
 }
 
-///
-/// Destructor
-///
-QXmppAttentionManager::~QXmppAttentionManager()
-{
-    delete d;
-}
+QXmppAttentionManager::~QXmppAttentionManager() = default;
 
 ///
 /// Returns the \xep{0224}: Attention feature.

--- a/src/client/QXmppAttentionManager.h
+++ b/src/client/QXmppAttentionManager.h
@@ -43,7 +43,7 @@ private Q_SLOTS:
     void handleMessageReceived(const QXmppMessage &message);
 
 private:
-    QXmppAttentionManagerPrivate *const d;
+    const std::unique_ptr<QXmppAttentionManagerPrivate> d;
 };
 
 #endif  // QXMPPATTENTIONMANAGER_H

--- a/src/client/QXmppBookmarkManager.cpp
+++ b/src/client/QXmppBookmarkManager.cpp
@@ -73,6 +73,7 @@ public:
     bool bookmarksReceived;
 };
 
+///
 /// Constructs a new bookmark manager.
 ///
 QXmppBookmarkManager::QXmppBookmarkManager()
@@ -81,12 +82,7 @@ QXmppBookmarkManager::QXmppBookmarkManager()
     d->bookmarksReceived = false;
 }
 
-/// Destroys a bookmark manager.
-///
-QXmppBookmarkManager::~QXmppBookmarkManager()
-{
-    delete d;
-}
+QXmppBookmarkManager::~QXmppBookmarkManager() = default;
 
 /// Returns true if the bookmarks have been received from the server,
 /// false otherwise.

--- a/src/client/QXmppBookmarkManager.h
+++ b/src/client/QXmppBookmarkManager.h
@@ -46,7 +46,7 @@ private Q_SLOTS:
     void slotDisconnected();
 
 private:
-    QXmppBookmarkManagerPrivate *const d;
+    const std::unique_ptr<QXmppBookmarkManagerPrivate> d;
 };
 
 #endif

--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -236,13 +236,7 @@ QXmppClient::QXmppClient(QObject *parent)
     addExtension(new QXmppDiscoveryManager());
 }
 
-/// Destructor, destroys the QXmppClient object.
-///
-
-QXmppClient::~QXmppClient()
-{
-    delete d;
-}
+QXmppClient::~QXmppClient() = default;
 
 ///
 /// \fn QXmppClient::addNewExtension()

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -11,6 +11,7 @@
 #include "QXmppSendResult.h"
 #include "QXmppSendStanzaParams.h"
 
+#include <memory>
 #include <variant>
 
 #include <QAbstractSocket>
@@ -321,7 +322,7 @@ private Q_SLOTS:
     void _q_streamError(QXmppClient::Error error);
 
 private:
-    QXmppClientPrivate *const d;
+    const std::unique_ptr<QXmppClientPrivate> d;
 
     friend class QXmppClientExtension;
     friend class QXmppInternalClientExtension;

--- a/src/client/QXmppClientExtension.cpp
+++ b/src/client/QXmppClientExtension.cpp
@@ -14,22 +14,16 @@ public:
     QXmppClient *client;
 };
 
+///
 /// Constructs a QXmppClient extension.
 ///
-
 QXmppClientExtension::QXmppClientExtension()
     : d(new QXmppClientExtensionPrivate)
 {
     d->client = nullptr;
 }
 
-/// Destroys a QXmppClient extension.
-///
-
-QXmppClientExtension::~QXmppClientExtension()
-{
-    delete d;
-}
+QXmppClientExtension::~QXmppClientExtension() = default;
 
 /// Returns the discovery features to add to the client.
 ///

--- a/src/client/QXmppClientExtension.h
+++ b/src/client/QXmppClientExtension.h
@@ -9,6 +9,8 @@
 #include "QXmppExtension.h"
 #include "QXmppLogger.h"
 
+#include <memory>
+
 class QDomElement;
 
 class QXmppClient;
@@ -49,7 +51,7 @@ protected:
     bool injectMessage(QXmppMessage &&message);
 
 private:
-    QXmppClientExtensionPrivate *const d;
+    const std::unique_ptr<QXmppClientExtensionPrivate> d;
 
     friend class QXmppClient;
 };

--- a/src/client/QXmppDiscoveryManager.cpp
+++ b/src/client/QXmppDiscoveryManager.cpp
@@ -62,10 +62,7 @@ QXmppDiscoveryManager::QXmppDiscoveryManager()
         d->clientName = QString("%1 %2").arg(qApp->applicationName(), qApp->applicationVersion());
 }
 
-QXmppDiscoveryManager::~QXmppDiscoveryManager()
-{
-    delete d;
-}
+QXmppDiscoveryManager::~QXmppDiscoveryManager() = default;
 
 /// Requests information from the specified XMPP entity.
 ///

--- a/src/client/QXmppDiscoveryManager.h
+++ b/src/client/QXmppDiscoveryManager.h
@@ -67,7 +67,7 @@ Q_SIGNALS:
     void itemsReceived(const QXmppDiscoveryIq &);
 
 private:
-    QXmppDiscoveryManagerPrivate *d;
+    const std::unique_ptr<QXmppDiscoveryManagerPrivate> d;
 };
 
 #endif  // QXMPPDISCOVERYMANAGER_H

--- a/src/client/QXmppMucManager.cpp
+++ b/src/client/QXmppMucManager.cpp
@@ -37,19 +37,15 @@ public:
     QString subject;
 };
 
+///
 /// Constructs a new QXmppMucManager.
-
+///
 QXmppMucManager::QXmppMucManager()
+    : d(std::make_unique<QXmppMucManagerPrivate>())
 {
-    d = new QXmppMucManagerPrivate;
 }
 
-/// Destroys a QXmppMucManager.
-
-QXmppMucManager::~QXmppMucManager()
-{
-    delete d;
-}
+QXmppMucManager::~QXmppMucManager() = default;
 
 /// Adds the given chat room to the set of managed rooms.
 ///
@@ -123,7 +119,6 @@ bool QXmppMucManager::handleStanza(const QDomElement &element)
 
 void QXmppMucManager::setClient(QXmppClient *client)
 {
-
     QXmppClientExtension::setClient(client);
 
     connect(client, &QXmppClient::messageReceived,
@@ -154,10 +149,9 @@ void QXmppMucManager::_q_roomDestroyed(QObject *object)
 /// \param parent
 
 QXmppMucRoom::QXmppMucRoom(QXmppClient *client, const QString &jid, QObject *parent)
-    : QObject(parent)
+    : QObject(parent),
+      d(std::make_unique<QXmppMucRoomPrivate>())
 {
-
-    d = new QXmppMucRoomPrivate;
     d->allowedActions = NoAction;
     d->client = client;
     d->discoManager = client->findExtension<QXmppDiscoveryManager>();
@@ -183,12 +177,7 @@ QXmppMucRoom::QXmppMucRoom(QXmppClient *client, const QString &jid, QObject *par
     connect(this, &QXmppMucRoom::left, this, &QXmppMucRoom::isJoinedChanged);
 }
 
-/// Destroys a QXmppMucRoom.
-
-QXmppMucRoom::~QXmppMucRoom()
-{
-    delete d;
-}
+QXmppMucRoom::~QXmppMucRoom() = default;
 
 QXmppMucRoom::Actions QXmppMucRoom::allowedActions() const
 {

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -75,7 +75,7 @@ private Q_SLOTS:
     void _q_roomDestroyed(QObject *object);
 
 private:
-    QXmppMucManagerPrivate *d;
+    const std::unique_ptr<QXmppMucManagerPrivate> d;
 };
 
 /// \brief The QXmppMucRoom class represents a multi-user chat room
@@ -235,7 +235,7 @@ private Q_SLOTS:
 
 private:
     QXmppMucRoom(QXmppClient *client, const QString &jid, QObject *parent);
-    QXmppMucRoomPrivate *d;
+    const std::unique_ptr<QXmppMucRoomPrivate> d;
     friend class QXmppMucManager;
 };
 

--- a/src/client/QXmppOutgoingClient.cpp
+++ b/src/client/QXmppOutgoingClient.cpp
@@ -161,13 +161,12 @@ void QXmppOutgoingClientPrivate::connectToNextDNSHost()
         dns.serviceRecords().at(curIdx).port());
 }
 
+///
 /// Constructs an outgoing client stream.
 ///
-/// \param parent
-
 QXmppOutgoingClient::QXmppOutgoingClient(QObject *parent)
     : QXmppStream(parent),
-      d(new QXmppOutgoingClientPrivate(this))
+      d(std::make_unique<QXmppOutgoingClientPrivate>(this))
 {
     // initialise socket
     auto *socket = new QSslSocket(this);
@@ -210,12 +209,7 @@ QXmppOutgoingClient::QXmppOutgoingClient(QObject *parent)
     });
 }
 
-/// Destroys an outgoing client stream.
-
-QXmppOutgoingClient::~QXmppOutgoingClient()
-{
-    delete d;
-}
+QXmppOutgoingClient::~QXmppOutgoingClient() = default;
 
 /// Returns a reference to the stream's configuration.
 

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -94,7 +94,7 @@ private:
     friend class QXmppOutgoingClientPrivate;
     friend class tst_QXmppOutgoingClient;
 
-    QXmppOutgoingClientPrivate *const d;
+    const std::unique_ptr<QXmppOutgoingClientPrivate> d;
 };
 
 #endif  // QXMPPOUTGOINGCLIENT_H

--- a/src/client/QXmppRegistrationManager.cpp
+++ b/src/client/QXmppRegistrationManager.cpp
@@ -44,7 +44,7 @@ QXmppRegistrationManagerPrivate::QXmppRegistrationManagerPrivate()
 /// Default constructor.
 ///
 QXmppRegistrationManager::QXmppRegistrationManager()
-    : d(new QXmppRegistrationManagerPrivate)
+    : d(std::make_unique<QXmppRegistrationManagerPrivate>())
 {
 }
 

--- a/src/client/QXmppRegistrationManager.h
+++ b/src/client/QXmppRegistrationManager.h
@@ -9,8 +9,6 @@
 #include "QXmppClientExtension.h"
 #include "QXmppRegisterIq.h"
 
-#include <QScopedPointer>
-
 class QXmppRegistrationManagerPrivate;
 
 ///
@@ -348,7 +346,7 @@ private Q_SLOTS:
 private:
     void setSupportedByServer(bool supportedByServer);
 
-    QScopedPointer<QXmppRegistrationManagerPrivate> d;
+    const std::unique_ptr<QXmppRegistrationManagerPrivate> d;
 };
 
 #endif  // QXMPPREGISTRATIONMANAGER_H

--- a/src/client/QXmppRosterManager.cpp
+++ b/src/client/QXmppRosterManager.cpp
@@ -68,7 +68,7 @@ void QXmppRosterManagerPrivate::clear()
 /// Constructs a roster manager.
 ///
 QXmppRosterManager::QXmppRosterManager(QXmppClient *client)
-    : d(new QXmppRosterManagerPrivate())
+    : d(std::make_unique<QXmppRosterManagerPrivate>())
 {
     connect(client, &QXmppClient::connected,
             this, &QXmppRosterManager::_q_connected);
@@ -80,10 +80,7 @@ QXmppRosterManager::QXmppRosterManager(QXmppClient *client)
             this, &QXmppRosterManager::_q_presenceReceived);
 }
 
-QXmppRosterManager::~QXmppRosterManager()
-{
-    delete d;
-}
+QXmppRosterManager::~QXmppRosterManager() = default;
 
 ///
 /// Accepts an existing subscription request or pre-approves future subscription

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -135,7 +135,7 @@ private Q_SLOTS:
     void _q_presenceReceived(const QXmppPresence &);
 
 private:
-    QXmppRosterManagerPrivate *d;
+    const std::unique_ptr<QXmppRosterManagerPrivate> d;
 };
 
 #endif  // QXMPPROSTER_H

--- a/src/client/QXmppTransferManager.cpp
+++ b/src/client/QXmppTransferManager.cpp
@@ -254,17 +254,14 @@ QXmppTransferJobPrivate::QXmppTransferJobPrivate()
 
 QXmppTransferJob::QXmppTransferJob(const QString &jid, QXmppTransferJob::Direction direction, QXmppClient *client, QObject *parent)
     : QXmppLoggable(parent),
-      d(new QXmppTransferJobPrivate)
+      d(std::make_unique<QXmppTransferJobPrivate>())
 {
     d->client = client;
     d->direction = direction;
     d->jid = jid;
 }
 
-QXmppTransferJob::~QXmppTransferJob()
-{
-    delete d;
-}
+QXmppTransferJob::~QXmppTransferJob() = default;
 
 ///
 /// Call this method if you wish to abort on ongoing transfer job.
@@ -760,7 +757,7 @@ QXmppTransferOutgoingJob *QXmppTransferManagerPrivate::getOutgoingJobByRequestId
 /// file transfers.
 ///
 QXmppTransferManager::QXmppTransferManager()
-    : d(new QXmppTransferManagerPrivate)
+    : d(std::make_unique<QXmppTransferManagerPrivate>())
 {
     // start SOCKS server
     d->socksServer = new QXmppSocksServer(this);
@@ -771,10 +768,7 @@ QXmppTransferManager::QXmppTransferManager()
     }
 }
 
-QXmppTransferManager::~QXmppTransferManager()
-{
-    delete d;
-}
+QXmppTransferManager::~QXmppTransferManager() = default;
 
 void QXmppTransferManager::byteStreamIqReceived(const QXmppByteStreamIq &iq)
 {

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -182,7 +182,7 @@ private:
     void setState(QXmppTransferJob::State state);
     void terminate(QXmppTransferJob::Error error);
 
-    QXmppTransferJobPrivate *const d;
+    const std::unique_ptr<QXmppTransferJobPrivate> d;
     friend class QXmppTransferManager;
     friend class QXmppTransferManagerPrivate;
     friend class QXmppTransferIncomingJob;
@@ -260,7 +260,7 @@ private Q_SLOTS:
     void _q_socksServerConnected(QTcpSocket *socket, const QString &hostName, quint16 port);
 
 private:
-    QXmppTransferManagerPrivate *d;
+    const std::unique_ptr<QXmppTransferManagerPrivate> d;
 
     void byteStreamIqReceived(const QXmppByteStreamIq &);
     void byteStreamResponseReceived(const QXmppIq &);

--- a/src/client/QXmppUploadRequestManager.cpp
+++ b/src/client/QXmppUploadRequestManager.cpp
@@ -88,7 +88,7 @@ public:
 ///
 
 QXmppUploadRequestManager::QXmppUploadRequestManager()
-    : d(new QXmppUploadRequestManagerPrivate)
+    : d(std::make_unique<QXmppUploadRequestManagerPrivate>())
 {
 }
 

--- a/src/client/QXmppUploadRequestManager.h
+++ b/src/client/QXmppUploadRequestManager.h
@@ -132,7 +132,7 @@ protected:
 private:
     void handleDiscoInfo(const QXmppDiscoveryIq &iq);
 
-    QSharedDataPointer<QXmppUploadRequestManagerPrivate> d;
+    const std::unique_ptr<QXmppUploadRequestManagerPrivate> d;
 };
 
 #endif  // QXMPPUPLOADREQUESTMANAGER_H

--- a/src/client/QXmppVCardManager.cpp
+++ b/src/client/QXmppVCardManager.cpp
@@ -17,15 +17,12 @@ public:
 };
 
 QXmppVCardManager::QXmppVCardManager()
-    : d(new QXmppVCardManagerPrivate)
+    : d(std::make_unique<QXmppVCardManagerPrivate>())
 {
     d->isClientVCardReceived = false;
 }
 
-QXmppVCardManager::~QXmppVCardManager()
-{
-    delete d;
-}
+QXmppVCardManager::~QXmppVCardManager() = default;
 
 /// This function requests the server for vCard of the specified jid.
 /// Once received the signal vCardReceived() is emitted.

--- a/src/client/QXmppVCardManager.h
+++ b/src/client/QXmppVCardManager.h
@@ -65,7 +65,7 @@ Q_SIGNALS:
     void clientVCardReceived();
 
 private:
-    QXmppVCardManagerPrivate *d;
+    const std::unique_ptr<QXmppVCardManagerPrivate> d;
 };
 
 #endif  // QXMPPVCARDMANAGER_H

--- a/src/client/QXmppVersionManager.cpp
+++ b/src/client/QXmppVersionManager.cpp
@@ -6,7 +6,6 @@
 
 #include "QXmppClient.h"
 #include "QXmppConstants_p.h"
-#include "QXmppGlobal.h"
 #include "QXmppVersionIq.h"
 
 #include <QCoreApplication>
@@ -22,7 +21,7 @@ public:
 };
 
 QXmppVersionManager::QXmppVersionManager()
-    : d(new QXmppVersionManagerPrivate)
+    : d(std::make_unique<QXmppVersionManagerPrivate>())
 {
     d->clientName = qApp->applicationName();
     if (d->clientName.isEmpty())
@@ -34,10 +33,7 @@ QXmppVersionManager::QXmppVersionManager()
         d->clientVersion = QXmppVersion();
 }
 
-QXmppVersionManager::~QXmppVersionManager()
-{
-    delete d;
-}
+QXmppVersionManager::~QXmppVersionManager() = default;
 
 /// Request version information from the specified XMPP entity.
 ///

--- a/src/client/QXmppVersionManager.h
+++ b/src/client/QXmppVersionManager.h
@@ -48,7 +48,7 @@ Q_SIGNALS:
     void versionReceived(const QXmppVersionIq &);
 
 private:
-    QXmppVersionManagerPrivate *d;
+    const std::unique_ptr<QXmppVersionManagerPrivate> d;
 };
 
 #endif  // QXMPPVERSIONMANAGER_H


### PR DESCRIPTION
- Replace raw pointers by unique_ptr
- RegistrationManager: Replace QScopedPointer with unique_ptr

PR check list:
- [ ] Document your code
- [ ] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [ ] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] Update `doc/xep.doc`
- [ ] Add unit tests
- [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
