### PR TITLE
Implement XEP-0447: Stateless file sharing: File sharing element

### DIFF
--- a/doc/doap.xml
+++ b/doc/doap.xml
@@ -572,6 +572,14 @@ SPDX-License-Identifier: CC0-1.0
     </implements>
     <implements>
       <xmpp:SupportedXep>
+        <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0447.html'/>
+        <xmpp:status>partial</xmpp:status>
+        <xmpp:version>0.2</xmpp:version>
+        <xmpp:since>1.5</xmpp:since>
+      </xmpp:SupportedXep>
+    </implements>
+    <implements>
+      <xmpp:SupportedXep>
         <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0450.html'/>
         <xmpp:status>complete</xmpp:status>
         <xmpp:version>0.4</xmpp:version>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,8 +39,9 @@ set(INSTALL_HEADER_FILES
     base/QXmppEntityTimeIq.h
     base/QXmppError.h
     base/QXmppExtension.h
-    base/QXmppFutureUtils_p.h
     base/QXmppFileMetadata.h
+    base/QXmppFileShare.h
+    base/QXmppFutureUtils_p.h
     base/QXmppGeolocItem.h
     base/QXmppGlobal.h
     base/QXmppHash.h
@@ -162,6 +163,7 @@ set(SOURCE_FILES
     base/QXmppEntityTimeIq.cpp
     base/QXmppError.cpp
     base/QXmppFileMetadata.cpp
+    base/QXmppFileShare.cpp
     base/QXmppGeolocItem.cpp
     base/QXmppGlobal.cpp
     base/QXmppHash.cpp

--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -80,6 +80,8 @@ const char *ns_data = "jabber:x:data";
 // XEP-0095: Stream Initiation
 const char *ns_stream_initiation = "http://jabber.org/protocol/si";
 const char *ns_stream_initiation_file_transfer = "http://jabber.org/protocol/si/profile/file-transfer";
+// XEP-0103: URL Address Information
+const char *ns_url_data = "http://jabber.org/protocol/url-data";
 // XEP-0108: User Activity
 const char *ns_activity = "http://jabber.org/protocol/activity";
 // XEP-0115: Entity Capabilities
@@ -188,5 +190,7 @@ const char *ns_fallback_indication = "urn:xmpp:fallback:0";
 const char *ns_tm = "urn:xmpp:tm:1";
 // XEP-0446: File metadata element
 const char *ns_file_metadata = "urn:xmpp:file:metadata:0";
+// XEP-0447: Stateless file sharing
+const char *ns_sfs = "urn:xmpp:sfs:0";
 // XEP-0450: Automatic Trust Management (ATM)
 const char *ns_atm = "urn:xmpp:atm:1";

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -92,6 +92,8 @@ extern const char *ns_data;
 // XEP-0095: Stream Initiation
 extern const char *ns_stream_initiation;
 extern const char *ns_stream_initiation_file_transfer;
+// XEP-0103: URL Address Information
+extern const char *ns_url_data;
 // XEP-0108: User Activity
 extern const char *ns_activity;
 // XEP-0115: Entity Capabilities
@@ -200,6 +202,8 @@ extern const char *ns_fallback_indication;
 extern const char *ns_tm;
 // XEP-0446: File metadata element
 extern const char *ns_file_metadata;
+// XEP-0447: Stateless file sharing
+extern const char *ns_sfs;
 // XEP-0450: Automatic Trust Management (ATM)
 extern const char *ns_atm;
 

--- a/src/base/QXmppFileShare.cpp
+++ b/src/base/QXmppFileShare.cpp
@@ -10,6 +10,7 @@
 #include <optional>
 
 #include <QDomElement>
+#include <QUrl>
 #include <QXmlStreamWriter>
 
 using Disposition = QXmppFileShare::Disposition;

--- a/src/base/QXmppFileShare.cpp
+++ b/src/base/QXmppFileShare.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QXmppFileShare.h"
+
+#include <optional>
+#include <QDomElement>
+#include <QXmlStreamWriter>
+#include "QXmppConstants_p.h"
+
+using Disposition = QXmppFileShare::Disposition;
+
+static std::optional<Disposition> dispositionFromString(const QString &str)
+{
+    if (str == "inline") {
+        return Disposition::Inline;
+    }
+    if (str == "attachment") {
+        return Disposition::Attachment;
+    }
+    return {};
+}
+
+static QString dispositionToString(Disposition value)
+{
+    switch (value) {
+    case Disposition::Inline:
+        return QStringLiteral("inline");
+    case Disposition::Attachment:
+        return QStringLiteral("attachment");
+    }
+    Q_UNREACHABLE();
+}
+
+/// \cond
+class QXmppFileSharePrivate : public QSharedData
+{
+public:
+    QXmppFileMetadata metadata;
+    QVector<QUrl> httpSources;
+    QXmppFileShare::Disposition disposition = Disposition::Inline;
+};
+/// \endcond
+
+///
+/// \class QXmppFileSharePrivate
+///
+/// File sharing element from \xep{0447, Stateless file sharing}. Contains
+/// metadata and source URLs.
+///
+/// \note jinglepub references are currently missing
+///
+/// \since QXmpp 1.5
+///
+
+/// Default constructor
+QXmppFileShare::QXmppFileShare()
+    : d(new QXmppFileSharePrivate)
+{
+}
+
+QXmppFileShare::QXmppFileShare(const QXmppFileShare &) = default;
+QXmppFileShare::QXmppFileShare(QXmppFileShare &&) noexcept = default;
+QXmppFileShare::~QXmppFileShare() = default;
+QXmppFileShare &QXmppFileShare::operator=(const QXmppFileShare &) = default;
+QXmppFileShare &QXmppFileShare::operator=(QXmppFileShare &&) noexcept = default;
+
+/// Returns the disposition setting for this file.
+QXmppFileShare::Disposition QXmppFileShare::disposition() const
+{
+    return d->disposition;
+}
+
+/// Sets the disposition setting for this file.
+void QXmppFileShare::setDisposition(Disposition disp)
+{
+    d->disposition = disp;
+}
+
+const QXmppFileMetadata &QXmppFileShare::metadata() const
+{
+    return d->metadata;
+}
+
+void QXmppFileShare::setMetadata(const QXmppFileMetadata &metadata)
+{
+    d->metadata = metadata;
+}
+
+const QVector<QUrl> &QXmppFileShare::httpSources() const
+{
+    return d->httpSources;
+}
+
+void QXmppFileShare::setHttpSources(const QVector<QUrl> &newHttpSources)
+{
+    d->httpSources = newHttpSources;
+}
+
+/// \cond
+bool QXmppFileShare::parse(const QDomElement &el)
+{
+    if (el.tagName() == "file-sharing" && el.namespaceURI() == ns_sfs) {
+        // disposition
+        d->disposition = dispositionFromString(el.attribute("disposition"))
+                .value_or(Disposition::Inline);
+
+        // file metadata
+        auto fileEl = el.firstChildElement("file");
+        d->metadata = QXmppFileMetadata();
+        if (!d->metadata.parse(fileEl)) {
+            return false;
+        }
+
+        // sources:
+        // expect that there's only one sources element with the correct namespace
+        auto sources = el.firstChildElement("sources");
+        for (auto urlEl = sources.firstChildElement("url-data");
+             !urlEl.isNull();
+             urlEl = urlEl.nextSiblingElement("url-data")) {
+            if (urlEl.namespaceURI() == "http://jabber.org/protocol/url-data") {
+                d->httpSources.append(QUrl(urlEl.attribute("target")));
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+void QXmppFileShare::toXml(QXmlStreamWriter *writer) const
+{
+    writer->writeStartElement("file-sharing");
+    writer->writeDefaultNamespace(ns_sfs);
+    writer->writeAttribute("disposition", dispositionToString(d->disposition));
+    d->metadata.toXml(writer);
+    writer->writeStartElement("sources");
+    for (const auto &source : d->httpSources) {
+        writer->writeStartElement("url-data");
+        writer->writeDefaultNamespace(ns_url_data);
+        writer->writeAttribute("target", source.toString());
+        writer->writeEndElement();
+    }
+    writer->writeEndElement();
+    writer->writeEndElement();
+}
+/// \endcond

--- a/src/base/QXmppFileShare.cpp
+++ b/src/base/QXmppFileShare.cpp
@@ -8,6 +8,7 @@
 #include <QDomElement>
 #include <QXmlStreamWriter>
 #include "QXmppConstants_p.h"
+#include "QXmppFileMetadata.h"
 
 using Disposition = QXmppFileShare::Disposition;
 

--- a/src/base/QXmppFileShare.cpp
+++ b/src/base/QXmppFileShare.cpp
@@ -4,11 +4,13 @@
 
 #include "QXmppFileShare.h"
 
-#include <optional>
-#include <QDomElement>
-#include <QXmlStreamWriter>
 #include "QXmppConstants_p.h"
 #include "QXmppFileMetadata.h"
+
+#include <optional>
+
+#include <QDomElement>
+#include <QXmlStreamWriter>
 
 using Disposition = QXmppFileShare::Disposition;
 
@@ -105,7 +107,7 @@ bool QXmppFileShare::parse(const QDomElement &el)
     if (el.tagName() == "file-sharing" && el.namespaceURI() == ns_sfs) {
         // disposition
         d->disposition = dispositionFromString(el.attribute("disposition"))
-                .value_or(Disposition::Inline);
+                             .value_or(Disposition::Inline);
 
         // file metadata
         auto fileEl = el.firstChildElement("file");

--- a/src/base/QXmppFileShare.h
+++ b/src/base/QXmppFileShare.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPFILESHARE_H
+#define QXMPPFILESHARE_H
+
+#include <QUrl>
+#include <QSharedDataPointer>
+
+class QDomElement;
+class QXmlStreamWriter;
+class QXmppFileSharePrivate;
+class QXmppFileMetadata;
+
+class QXmppFileShare
+{
+public:
+    enum Disposition {
+        Inline,
+        Attachment,
+    };
+
+    QXmppFileShare();
+    QXmppFileShare(const QXmppFileShare &);
+    QXmppFileShare(QXmppFileShare &&) noexcept;
+    ~QXmppFileShare();
+
+    QXmppFileShare &operator=(const QXmppFileShare &);
+    QXmppFileShare &operator=(QXmppFileShare &&) noexcept;
+
+    Disposition disposition() const;
+    void setDisposition(Disposition);
+
+    const QXmppFileMetadata &metadata() const;
+    void setMetadata(const QXmppFileMetadata &);
+
+    const QVector<QUrl> &httpSources() const;
+    void setHttpSources(const QVector<QUrl> &newHttpSources);
+
+    /// \cond
+    bool parse(const QDomElement &el);
+    void toXml(QXmlStreamWriter *writer) const;
+    /// \endcond
+    
+private:
+    QSharedDataPointer<QXmppFileSharePrivate> d;
+};
+
+#endif // QXMPPFILESHARE_H

--- a/src/base/QXmppFileShare.h
+++ b/src/base/QXmppFileShare.h
@@ -5,8 +5,8 @@
 #ifndef QXMPPFILESHARE_H
 #define QXMPPFILESHARE_H
 
-#include <QUrl>
 #include <QSharedDataPointer>
+#include <QUrl>
 
 class QDomElement;
 class QXmlStreamWriter;
@@ -42,9 +42,9 @@ public:
     bool parse(const QDomElement &el);
     void toXml(QXmlStreamWriter *writer) const;
     /// \endcond
-    
+
 private:
     QSharedDataPointer<QXmppFileSharePrivate> d;
 };
 
-#endif // QXMPPFILESHARE_H
+#endif  // QXMPPFILESHARE_H

--- a/src/base/QXmppFileShare.h
+++ b/src/base/QXmppFileShare.h
@@ -5,10 +5,12 @@
 #ifndef QXMPPFILESHARE_H
 #define QXMPPFILESHARE_H
 
+#include "QXmppGlobal.h"
+
 #include <QSharedDataPointer>
-#include <QUrl>
 
 class QDomElement;
+class QUrl;
 class QXmlStreamWriter;
 class QXmppFileSharePrivate;
 class QXmppFileMetadata;

--- a/src/base/QXmppFileShare.h
+++ b/src/base/QXmppFileShare.h
@@ -13,7 +13,7 @@ class QXmlStreamWriter;
 class QXmppFileSharePrivate;
 class QXmppFileMetadata;
 
-class QXmppFileShare
+class QXMPP_EXPORT QXmppFileShare
 {
 public:
     enum Disposition {

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -1210,7 +1210,7 @@ void QXmppMessage::setTrustMessageElement(const std::optional<QXmppTrustMessageE
 }
 
 ///
-/// Returns the via \xep{0447, Stateless file sharing} shared files included in this message.
+/// Returns the via \xep{0447, Stateless file sharing} shared files attached to this message.
 ///
 /// \since QXmpp 1.5
 ///
@@ -1220,7 +1220,7 @@ const QVector<QXmppFileShare> &QXmppMessage::sharedFiles() const
 }
 
 ///
-/// Sets the via \xep{0447, Stateless file sharing} shared files in this message.
+/// Sets the via \xep{0447, Stateless file sharing} shared files attached to this message.
 ///
 /// \since QXmpp 1.5
 ///

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -1514,7 +1514,7 @@ bool QXmppMessage::parseExtension(const QDomElement &element, QXmpp::SceMode sce
             return true;
         }
         // XEP-0448: Stateless file sharing
-        if (checkElement(element, QStringLiteral("file-sharing"), ns_file_metadata)) {
+        if (checkElement(element, QStringLiteral("file-sharing"), ns_sfs)) {
             QXmppFileShare share;
             if (share.parse(element)) {
                 d->sharedFiles.push_back(std::move(share));

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -9,6 +9,7 @@
 
 #include "QXmppBitsOfBinaryDataList.h"
 #include "QXmppConstants_p.h"
+#include "QXmppFileShare.h"
 #include "QXmppGlobal_p.h"
 #include "QXmppMixInvitation.h"
 #ifdef BUILD_OMEMO
@@ -151,6 +152,9 @@ public:
 
     // XEP-0434: Trust Messages (TM)
     std::optional<QXmppTrustMessageElement> trustMessageElement;
+
+    // XEP-0448: Encryption for stateless file sharing
+    QVector<QXmppFileShare> sharedFiles;
 };
 
 QXmppMessagePrivate::QXmppMessagePrivate()
@@ -1205,6 +1209,26 @@ void QXmppMessage::setTrustMessageElement(const std::optional<QXmppTrustMessageE
     d->trustMessageElement = trustMessageElement;
 }
 
+///
+/// Returns the via \xep{0447, Stateless file sharing} shared files included in this message.
+///
+/// \since QXmpp 1.5
+///
+const QVector<QXmppFileShare> &QXmppMessage::sharedFiles() const
+{
+    return d->sharedFiles;
+}
+
+///
+/// Sets the via \xep{0447, Stateless file sharing} shared files in this message.
+///
+/// \since QXmpp 1.5
+///
+void QXmppMessage::setSharedFiles(const QVector<QXmppFileShare> &sharedFiles)
+{
+    d->sharedFiles = sharedFiles;
+}
+
 /// \cond
 void QXmppMessage::parse(const QDomElement &element)
 {
@@ -1489,6 +1513,14 @@ bool QXmppMessage::parseExtension(const QDomElement &element, QXmpp::SceMode sce
             d->trustMessageElement = trustMessageElement;
             return true;
         }
+        // XEP-0448: Stateless file sharing
+        if (checkElement(element, QStringLiteral("file-sharing"), ns_file_metadata)) {
+            QXmppFileShare share;
+            if (share.parse(element)) {
+                d->sharedFiles.push_back(std::move(share));
+            }
+            return true;
+        }
     }
     return false;
 }
@@ -1738,6 +1770,11 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
         // XEP-0434: Trust Messages (TM)
         if (d->trustMessageElement) {
             d->trustMessageElement->toXml(writer);
+        }
+
+        // XEP-0448: Stateless file sharing
+        for (const auto &fileShare : d->sharedFiles) {
+            fileShare.toXml(writer);
         }
     }
 }

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -8,6 +8,7 @@
 #ifndef QXMPPMESSAGE_H
 #define QXMPPMESSAGE_H
 
+#include "QXmppFileShare.h"
 #include "QXmppStanza.h"
 
 #include <optional>
@@ -247,6 +248,10 @@ public:
     // XEP-0434: Trust Messages (TM)
     std::optional<QXmppTrustMessageElement> trustMessageElement() const;
     void setTrustMessageElement(const std::optional<QXmppTrustMessageElement> &trustMessageElement);
+
+    // XEP-0447: Stateless file sharing
+    const QVector<QXmppFileShare> &sharedFiles() const;
+    void setSharedFiles(const QVector<QXmppFileShare> &sharedFiles);
 
     /// \cond
 #ifdef BUILD_OMEMO

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -52,6 +52,7 @@ private slots:
     void testMixInvitation();
     void testTrustMessageElement();
     void testE2eeFallbackBody();
+    void testFileSharing();
 };
 
 void tst_QXmppMessage::testBasic_data()
@@ -1157,6 +1158,32 @@ void tst_QXmppMessage::testE2eeFallbackBody()
     QXmppMessage message2;
     message2.setE2eeFallbackBody(QStringLiteral("This message is encrypted with OMEMO 2 but could not be decrypted"));
     serializePacket(message2, xml);
+}
+
+void tst_QXmppMessage::testFileSharing()
+{
+    const QByteArray xml(
+        "<message id='sharing-a-file' to='juliet@shakespeare.lit' from='romeo@montague.lit/resource' type='normal'>"
+        "<file-sharing xmlns='urn:xmpp:sfs:0' disposition='inline'>"
+        "<file xmlns='urn:xmpp:file:metadata:0'>"
+        "<desc>Photo from the summit.</desc>"
+        "<hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>2XarmwTlNxDAMkvymloX3S5+VbylNrJt/l5QyPa+YoU=</hash>"
+        "<hash xmlns='urn:xmpp:hashes:2' algo='blake2b-256'>2AfMGH8O7UNPTvUVAM9aK13mpCY=</hash>"
+        "<media-type>image/jpeg</media-type>"
+        "<name>summit.jpg</name>"
+        "<size>3032449</size>"
+        "<thumbnail xmlns='urn:xmpp:thumbs:1' uri='cid:sha1+ffd7c8d28e9c5e82afea41f97108c6b4@bob.xmpp.org' media-type='image/png' width='128' height='96'/>"
+        "</file>"
+        "<sources>"
+        "<url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/summit.jpg'/>"
+        "</sources>"
+        "</file-sharing>"
+        "</message>");
+
+    QXmppMessage message1;
+    parsePacket(message1, xml);
+    QVERIFY(!message1.sharedFiles().empty());
+    serializePacket(message1, xml);
 }
 
 QTEST_MAIN(tst_QXmppMessage)


### PR DESCRIPTION
Implements parsing for the file sharing element from XEP-0447:
Stateless files sharing version 0.2.

https://xmpp.org/extensions/xep-0447.html

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/xep.doc`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
