### PR TITLE
Implement XEP-0264: Jingle Content Thumbnails

### DIFF
--- a/doc/xep.doc
+++ b/doc/xep.doc
@@ -49,6 +49,7 @@ Complete:
 - \xep{0237, Roster Versioning} (partially)
 - \xep{0245, The /me Command} (v1.0)
 - \xep{0249, Direct MUC Invitations} (v1.2)
+- \xep{0264, Jingle Content Thumbnails} (v0.4)
 - \xep{0280, Message Carbons}
 - \xep{0300, Use of Cryptographic Hash Functions in XMPP} (v1.0)
 - \xep{0308, Last Message Correction}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,7 @@ set(INSTALL_HEADER_FILES
     base/QXmppStream.h
     base/QXmppStreamFeatures.h
     base/QXmppStun.h
+    base/QXmppThumbnail.h
     base/QXmppTrustMessageElement.h
     base/QXmppTrustMessageKeyOwner.h
     base/QXmppTrustMessages.h
@@ -199,6 +200,7 @@ set(SOURCE_FILES
     base/QXmppStreamInitiationIq.cpp
     base/QXmppStreamManagement.cpp
     base/QXmppStun.cpp
+    base/QXmppThumbnail.cpp
     base/QXmppTrustMessages.cpp
     base/QXmppTuneItem.cpp
     base/QXmppUtils.cpp

--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -125,6 +125,8 @@ const char *ns_attention = "urn:xmpp:attention:0";
 const char *ns_bob = "urn:xmpp:bob";
 // XEP-0249: Direct MUC Invitations
 const char *ns_conference = "jabber:x:conference";
+// XEP-0264: Jingle Content Thumbnails
+const char *ns_thumbs = "urn:xmpp:thumbs:1";
 // XEP-0280: Message Carbons
 const char *ns_carbons = "urn:xmpp:carbons:2";
 // XEP-0297: Stanza Forwarding

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -137,6 +137,8 @@ extern const char *ns_attention;
 extern const char *ns_bob;
 // XEP-0249: Direct MUC Invitations
 extern const char *ns_conference;
+// XEP-0264: Jingle Content Thumbnails
+extern const char *ns_thumbs;
 // XEP-0280: Message Carbons
 extern const char *ns_carbons;
 // XEP-0297: Stanza Forwarding

--- a/src/base/QXmppThumbnail.cpp
+++ b/src/base/QXmppThumbnail.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QXmppThumbnail.h"
+
+#include "QXmppConstants_p.h"
+
+#include <QDomElement>
+#include <QMimeDatabase>
+#include <QMimeType>
+#include <QUrl>
+#include <QXmlStreamWriter>
+
+class QXmppThumbnailPrivate : public QSharedData
+{
+public:
+    QString uri;
+    QMimeType mediaType;
+    std::optional<uint32_t> width;
+    std::optional<uint32_t> height;
+};
+
+///
+/// \class QXmppThumbnail
+///
+/// Thumbnail from \xep{0264, Jingle Content Thumbnails}.
+///
+/// \since QXmpp 1.5
+///
+
+/// Default constructor
+QXmppThumbnail::QXmppThumbnail()
+    : d(new QXmppThumbnailPrivate)
+{
+}
+/// Default copy-constructor
+QXmppThumbnail::QXmppThumbnail(const QXmppThumbnail &) = default;
+/// Default move-constructor
+QXmppThumbnail::QXmppThumbnail(QXmppThumbnail &&) noexcept = default;
+QXmppThumbnail::~QXmppThumbnail() = default;
+/// Default assignment operator
+QXmppThumbnail &QXmppThumbnail::operator=(const QXmppThumbnail &) = default;
+/// Default move-assignment operator
+QXmppThumbnail &QXmppThumbnail::operator=(QXmppThumbnail &&) noexcept = default;
+
+/// Returns the URI with the location for the data (usually a \xep{0231, Bits of Binary} content ID)
+const QString &QXmppThumbnail::uri() const
+{
+    return d->uri;
+}
+
+/// Sets the URI with the location for the data (usually a \xep{0231, Bits of Binary} content ID)
+void QXmppThumbnail::setUri(const QString &newUri)
+{
+    d->uri = newUri;
+}
+
+/// Returns the MIME type of the thumbnail data.
+const QMimeType &QXmppThumbnail::mediaType() const
+{
+    return d->mediaType;
+}
+
+/// Sets the MIME type of the thumbnail data.
+void QXmppThumbnail::setMediaType(const QMimeType &newMediaType)
+{
+    d->mediaType = newMediaType;
+}
+
+/// Returns the width of the thumbnail image.
+std::optional<uint32_t> QXmppThumbnail::width() const
+{
+    return d->width;
+}
+
+/// Sets the width of the thumbnail image.
+void QXmppThumbnail::setWidth(std::optional<uint32_t> newWidth)
+{
+    d->width = newWidth;
+}
+
+/// Returns the height of the thumbnail image.
+std::optional<uint32_t> QXmppThumbnail::height() const
+{
+    return d->height;
+}
+
+/// Sets the height of the thumbnail image.
+void QXmppThumbnail::setHeight(std::optional<uint32_t> newHeight)
+{
+    d->height = newHeight;
+}
+
+/// \cond
+bool QXmppThumbnail::parse(const QDomElement &el)
+{
+    if (el.tagName() == "thumbnail" && el.namespaceURI() == ns_thumbs) {
+        if (!el.hasAttribute("uri")) {
+            return false;
+        }
+
+        d->uri = el.attribute("uri");
+        if (el.hasAttribute("media-type")) {
+            d->mediaType = QMimeDatabase().mimeTypeForName(el.attribute(QStringLiteral("media-type")));
+        }
+
+        bool success = false;
+        if (auto string = el.attribute("width"); !string.isEmpty()) {
+            if (auto parsedInt = string.toUInt(&success); success) {
+                d->width = parsedInt;
+            } else {
+                return false;
+            }
+        }
+        if (auto string = el.attribute("height"); !string.isEmpty()) {
+            if (auto parsedInt = string.toUInt(&success); success) {
+                d->height = parsedInt;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+void QXmppThumbnail::toXml(QXmlStreamWriter *writer) const
+{
+    writer->writeStartElement(QStringLiteral("thumbnail"));
+    writer->writeDefaultNamespace(ns_thumbs);
+    writer->writeAttribute(QStringLiteral("uri"), d->uri);
+    if (d->mediaType.isValid()) {
+        writer->writeAttribute("media-type", d->mediaType.name());
+    }
+    if (d->width) {
+        writer->writeAttribute("width", QString::number(*d->width));
+    }
+    if (d->height) {
+        writer->writeAttribute("height", QString::number(*d->height));
+    }
+    writer->writeEndElement();
+}
+/// \endcond

--- a/src/base/QXmppThumbnail.h
+++ b/src/base/QXmppThumbnail.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPTHUMBNAIL_H
+#define QXMPPTHUMBNAIL_H
+
+#include "QXmppGlobal.h"
+
+#include <optional>
+
+#include <QSharedDataPointer>
+
+class QDomElement;
+class QMimeType;
+class QXmlStreamWriter;
+class QXmppThumbnailPrivate;
+
+class QXMPP_EXPORT QXmppThumbnail
+{
+public:
+    QXmppThumbnail();
+    QXmppThumbnail(const QXmppThumbnail &);
+    QXmppThumbnail(QXmppThumbnail &&) noexcept;
+    ~QXmppThumbnail();
+
+    QXmppThumbnail &operator=(const QXmppThumbnail &);
+    QXmppThumbnail &operator=(QXmppThumbnail &&) noexcept;
+
+    const QString &uri() const;
+    void setUri(const QString &newUri);
+
+    const QMimeType &mediaType() const;
+    void setMediaType(const QMimeType &);
+
+    std::optional<uint32_t> width() const;
+    void setWidth(std::optional<uint32_t>);
+
+    std::optional<uint32_t> height() const;
+    void setHeight(std::optional<uint32_t>);
+
+    /// \cond
+    bool parse(const QDomElement &);
+    void toXml(QXmlStreamWriter *writer) const;
+    /// \endcond
+
+private:
+    QSharedDataPointer<QXmppThumbnailPrivate> d;
+};
+
+#endif  // QXMPPTHUMBNAIL_H


### PR DESCRIPTION
XEP-0264: Jingle Content Thumbnails version 0.4.

https://xmpp.org/extensions/xep-0264.html

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/xep.doc`
- [ ] Add unit tests
- [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
