### PR TITLE
Fix rule of six macro

### DIFF
--- a/src/base/QXmppFileMetadata.cpp
+++ b/src/base/QXmppFileMetadata.cpp
@@ -45,7 +45,7 @@ QXmppFileMetadata::QXmppFileMetadata()
 {
 }
 
-QXMPP_PRIVATE_DEFINE_ROLE_OF_SIX(QXmppFileMetadata)
+QXMPP_PRIVATE_DEFINE_RULE_OF_SIX(QXmppFileMetadata)
 
 /// \cond
 QVector<QDomElement> allChildElements(const QDomElement &el, const QString &name)

--- a/src/base/QXmppGlobal.h
+++ b/src/base/QXmppGlobal.h
@@ -40,6 +40,8 @@
 #define QT_WARNING_DISABLE_DEPRECATED
 #endif
 
+// Adds constructor and operator declarations to a ".h" file corresponding to the rule of six.
+// A default constructor has to be declared manually.
 #define QXMPP_PRIVATE_DECLARE_RULE_OF_SIX(name) \
     name(const name &);                         \
     name(name &&);                              \
@@ -47,6 +49,8 @@
     name &operator=(const name &);              \
     name &operator=(name &&);
 
+// Adds constructor and operator definitions to a ".cpp" file corresponding to the rule of six.
+// A default constructor has to be defined manually.
 #define QXMPP_PRIVATE_DEFINE_RULE_OF_SIX(name)     \
     name::name(const name &) = default;            \
     name::name(name &&) = default;                 \

--- a/src/base/QXmppGlobal.h
+++ b/src/base/QXmppGlobal.h
@@ -47,7 +47,7 @@
     name &operator=(const name &);              \
     name &operator=(name &&);
 
-#define QXMPP_PRIVATE_DEFINE_ROLE_OF_SIX(name)     \
+#define QXMPP_PRIVATE_DEFINE_RULE_OF_SIX(name)     \
     name::name(const name &) = default;            \
     name::name(name &&) = default;                 \
     name::~name() = default;                       \


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
