### PR TITLE
Add extra class for HttpFileSource instead of using QUrl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set(INSTALL_HEADER_FILES
     base/QXmppGeolocItem.h
     base/QXmppGlobal.h
     base/QXmppHash.h
+    base/QXmppHttpFileSource.h
     base/QXmppHttpUploadIq.h
     base/QXmppIbbIq.h
     base/QXmppIq.h
@@ -167,6 +168,7 @@ set(SOURCE_FILES
     base/QXmppGeolocItem.cpp
     base/QXmppGlobal.cpp
     base/QXmppHash.cpp
+    base/QXmppHttpFileSource.cpp
     base/QXmppHttpUploadIq.cpp
     base/QXmppIbbIq.cpp
     base/QXmppIq.cpp

--- a/src/base/QXmppFileShare.h
+++ b/src/base/QXmppFileShare.h
@@ -14,6 +14,7 @@ class QUrl;
 class QXmlStreamWriter;
 class QXmppFileSharePrivate;
 class QXmppFileMetadata;
+class QXmppHttpFileSource;
 
 class QXMPP_EXPORT QXmppFileShare
 {
@@ -37,8 +38,8 @@ public:
     const QXmppFileMetadata &metadata() const;
     void setMetadata(const QXmppFileMetadata &);
 
-    const QVector<QUrl> &httpSources() const;
-    void setHttpSources(const QVector<QUrl> &newHttpSources);
+    const QVector<QXmppHttpFileSource> &httpSources() const;
+    void setHttpSources(const QVector<QXmppHttpFileSource> &newHttpSources);
 
     /// \cond
     bool parse(const QDomElement &el);

--- a/src/base/QXmppHttpFileSource.cpp
+++ b/src/base/QXmppHttpFileSource.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QXmppHttpFileSource.h"
+
+#include "QXmppConstants_p.h"
+
+#include <QDomElement>
+#include <QXmlStreamWriter>
+
+///
+/// \class QXmppHttpFileSource
+///
+/// Represents an HTTP File source for file sharing.
+///
+/// \since QXmpp 1.5
+///
+
+/// Default constructor.
+QXmppHttpFileSource::QXmppHttpFileSource()
+{
+}
+
+/// Default constructor.
+QXmppHttpFileSource::QXmppHttpFileSource(QUrl url)
+    : m_url(std::move(url))
+{
+}
+
+QXMPP_PRIVATE_DEFINE_RULE_OF_SIX(QXmppHttpFileSource)
+
+///
+/// Returns the HTTP url.
+///
+const QUrl &QXmppHttpFileSource::url() const
+{
+    return m_url;
+}
+
+///
+/// Sets the HTTP url.
+///
+void QXmppHttpFileSource::setUrl(QUrl url)
+{
+    m_url = std::move(url);
+}
+
+/// \cond
+bool QXmppHttpFileSource::parse(const QDomElement &el)
+{
+    if (el.tagName() == "url-data" && el.namespaceURI() == ns_url_data) {
+        m_url = QUrl(el.attribute("target"));
+        return true;
+    }
+    return false;
+}
+
+void QXmppHttpFileSource::toXml(QXmlStreamWriter *writer) const
+{
+    writer->writeStartElement("url-data");
+    writer->writeDefaultNamespace(ns_url_data);
+    writer->writeAttribute("target", m_url.toString());
+    writer->writeEndElement();
+}
+/// \endcond

--- a/src/base/QXmppHttpFileSource.h
+++ b/src/base/QXmppHttpFileSource.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPHTTPFILESOURCE_H
+#define QXMPPHTTPFILESOURCE_H
+
+#include "QXmppGlobal.h"
+
+#include <QUrl>
+
+class QDomElement;
+class QXmlStreamWriter;
+
+class QXMPP_EXPORT QXmppHttpFileSource
+{
+public:
+    QXmppHttpFileSource();
+    QXmppHttpFileSource(QUrl url);
+    QXMPP_PRIVATE_DECLARE_RULE_OF_SIX(QXmppHttpFileSource)
+
+    const QUrl &url() const;
+    void setUrl(QUrl url);
+
+    /// \cond
+    bool parse(const QDomElement &el);
+    void toXml(QXmlStreamWriter *writer) const;
+    /// \endcond
+
+private:
+    static_assert(sizeof(QUrl) == sizeof(void *));
+    QUrl m_url;
+};
+
+#endif  // QXMPPHTTPFILESOURCE_H


### PR DESCRIPTION
Before just QUrl was used, which was okay. This should make it better
recognizable and it makes clear it is only used for HTTP urls.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
