### PR TITLE
BitsOfBinaryData: Add fromByteArray() utility function

### DIFF
--- a/src/base/QXmppBitsOfBinaryData.cpp
+++ b/src/base/QXmppBitsOfBinaryData.cpp
@@ -41,6 +41,29 @@ QXmppBitsOfBinaryDataPrivate::QXmppBitsOfBinaryDataPrivate()
 ///
 
 ///
+/// Creates bits of binary data from a QByteArray.
+///
+/// This hashes the data to generate a content ID. The MIME type is not set.
+///
+/// \note This blocks while hashing the data. You may want to run this via QtConcurrent or a
+/// QThreadPool to run this on for large amounts of data.
+///
+/// \since QXmpp 1.5
+///
+QXmppBitsOfBinaryData QXmppBitsOfBinaryData::fromByteArray(QByteArray data)
+{
+    QXmppBitsOfBinaryContentId cid;
+    cid.setHash(QCryptographicHash::hash(data, QCryptographicHash::Sha1));
+    cid.setAlgorithm(QCryptographicHash::Sha1);
+
+    QXmppBitsOfBinaryData bobData;
+    bobData.d->cid = std::move(cid);
+    bobData.d->data = std::move(data);
+
+    return bobData;
+}
+
+///
 /// Default constructor
 ///
 QXmppBitsOfBinaryData::QXmppBitsOfBinaryData()

--- a/src/base/QXmppBitsOfBinaryData.h
+++ b/src/base/QXmppBitsOfBinaryData.h
@@ -18,6 +18,8 @@ class QXmppBitsOfBinaryContentId;
 class QXMPP_EXPORT QXmppBitsOfBinaryData
 {
 public:
+    static QXmppBitsOfBinaryData fromByteArray(QByteArray data);
+
     QXmppBitsOfBinaryData();
     QXmppBitsOfBinaryData(const QXmppBitsOfBinaryData &);
     QXmppBitsOfBinaryData(QXmppBitsOfBinaryData &&);

--- a/tests/qxmppbitsofbinaryiq/tst_qxmppbitsofbinaryiq.cpp
+++ b/tests/qxmppbitsofbinaryiq/tst_qxmppbitsofbinaryiq.cpp
@@ -18,6 +18,7 @@ private slots:
     void testResult();
     void testOtherSubelement();
     void testIsBobIq();
+    Q_SLOT void fromByteArray();
 };
 
 void tst_QXmppBitsOfBinaryIq::testBasic()
@@ -188,6 +189,35 @@ void tst_QXmppBitsOfBinaryIq::testIsBobIq()
         "</iq>");
     QVERIFY(doc.setContent(xmlWithoutBobData, true));
     QCOMPARE(QXmppBitsOfBinaryIq::isBitsOfBinaryIq(doc.documentElement()), false);
+}
+
+void tst_QXmppBitsOfBinaryIq::fromByteArray()
+{
+    auto data = QByteArray::fromBase64(
+        "iVBORw0KGgoAAAANSUhEUgAAALQAAAA8BAMAAAA9AI20AAAAG1BMVEX///8AAADf39+"
+        "/v79/f39fX1+fn58/Pz8fHx/8ACGJAAAACXBIWXMAAA7EAAAOxAGVKw4bAAADS0lEQV"
+        "RYhe2WS3MSQRCAYTf7OKY1kT0CxsRjHmh5BENIjqEk6pHVhFzdikqO7CGyP9t59Ox2z"
+        "y6UeWBVqugLzM70Nz39mqnV1lIWgBWiYXV0BYfNZ0mvwypds1r62vH/gf76ZL/88Qlc"
+        "41zeAnQrpx5H3z1Npfr5ovmHusa9SpRiNNIOcdrto6PJ5LLfb5bp9zM+VDq/vptxDEa"
+        "a1sql9I3R5KhtfQsA5gNCWYyulV3TyTUDdfL56BvdDl4x7RiybDq9uBgxh1TTPUHDvA"
+        "qNQb+LpT5sWehxJZKKcU2MZ6sDE7PMgW2mdlBGdy6ODe6fJFdMI+us95dNqftDMdwU6"
+        "+MhpuTS9slcy5TFAcwq0Jt6qssJMTQGp4BGURlmSsNoo5oHL4kqc66NdkDO75mIfCxm"
+        "RAlvHxMLdcb7JONavMJbttXXKoMSneYu3OQTlwkUh4mNayi6js55/2VcsZOQfXIYelz"
+        "xLcntEGc3WVCsCORJVCc5r0ajAcq+EO1Q0oPm7n7+X/3jEReGdL6qT7Ml6FCjY+quJC"
+        "r+D01f6BG0SaHG56ZG32DnY2jcEV1+pU0kxTaEwaGcekN7jyu50U/TV4q6YeieyiNTu"
+        "klDKZLukyjKVNwotCUB3B0XO1WjHT3c0DHSO2zACwut8GOiljJIHaJsrlof/fpWNzGM"
+        "os6TgIY0hZNpJshzSi4igOhy3cl4qK+YgnqHkAYcZEgdW6/HyrEK7afoY7RCFzArLl2"
+        "LLDdrdmmHZfROajwIDfWj8yQG+rzwlA3WvdJiMHtjUekiNrp1oCbmyZDEyKROGjFVDr"
+        "PRzlkR9UAfG/OErnPxrop5BwpoEpXQorq2zcGxbnBJndx8Bh0yljGiGv0B4E8+YP3Xp"
+        "2rGydZNy4csW8W2pIvWhvijoujRJ0luXsoymV+8AXvE9HjII72+oReS6OfomHe3xWg/"
+        "f2coSbDa1XZ1CvGMjy1nH9KBl83oPnQKi+vAXKLjCrRvvT2WCMkPmSFbquiVuTH1qjv"
+        "p4j/u7CWyI5/Hn3KAaJJ90eP0Zp1Kjets4WPaElkxheF7cpBESzXuIdLwyFjSub07tB"
+        "6JjxH3DGiu+zwHHimdtFsMvKqG/nBxm2TwbvyU6LWs5RnJX4dSldg3QhDLAAAAAElFT"
+        "kSuQmCC");
+    auto size = data.size();
+    auto bobData = QXmppBitsOfBinaryData::fromByteArray(std::move(data));
+    QCOMPARE(bobData.cid().toContentId(), QStringLiteral("sha1+5a4c38d44fc64805cbb2d92d8b208be13ff40c0f@bob.xmpp.org"));
+    QCOMPARE(bobData.data().size(), size);
 }
 
 QTEST_MAIN(tst_QXmppBitsOfBinaryIq)

--- a/tests/qxmpphttpuploadmanager/tst_qxmpphttpuploadmanager.cpp
+++ b/tests/qxmpphttpuploadmanager/tst_qxmpphttpuploadmanager.cpp
@@ -210,7 +210,7 @@ void tst_QXmppHttpUploadManager::testDiscoveryService()
 
     if (manager->serviceFound()) {
         QCOMPARE(manager->uploadServices().at(0).jid(), UPLOAD_SERVICE_NAME);
-        QCOMPARE(manager->uploadServices().at(0).sizeLimit(), MAX_FILE_SIZE);
+        QCOMPARE(manager->uploadServices().at(0).sizeLimit(), qint64(MAX_FILE_SIZE));
     }
 }
 
@@ -408,8 +408,8 @@ void tst_QXmppHttpUploadManager::testUpload()
         QXmppHttpUploadRequestIq iq;
         parsePacket(iq, test.takeLastPacket().toUtf8());
 
-        QCOMPARE(iq.contentType().name(), "image/svg+xml");
-        QCOMPARE(iq.fileName(), "test_renamed.png");
+        QCOMPARE(iq.contentType().name(), QStringLiteral("image/svg+xml"));
+        QCOMPARE(iq.fileName(), QStringLiteral("test_renamed.png"));
         QCOMPARE(iq.size(), 2280LL);
     }
 
@@ -428,8 +428,8 @@ void tst_QXmppHttpUploadManager::testUpload()
     }
 
     auto url = expectVariant<QUrl>(std::move(result));
-    QCOMPARE(upload->bytesSent(), 2280LL);
-    QCOMPARE(upload->bytesTotal(), 2280LL);
+    QCOMPARE(upload->bytesSent(), 2280ULL);
+    QCOMPARE(upload->bytesTotal(), 2280ULL);
     QCOMPARE(upload->progress(), 1.0);
 
     qDebug() << "Uploaded file to" << url.toDisplayString();

--- a/tests/util.h
+++ b/tests/util.h
@@ -9,6 +9,7 @@
 
 #include "QXmppPasswordChecker.h"
 
+#include <memory>
 #include <variant>
 
 #include <QDomDocument>


### PR DESCRIPTION
It automatically hashes the data and creates a content ID.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
