### PR TITLE
Implement XEP-0448: Encryption for stateless file sharing parsing

### DIFF
--- a/doc/doap.xml
+++ b/doc/doap.xml
@@ -579,6 +579,13 @@ SPDX-License-Identifier: CC0-1.0
     </implements>
     <implements>
       <xmpp:SupportedXep>
+        <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0448.html'/>
+        <xmpp:status>partial</xmpp:status>
+        <xmpp:version>0.2</xmpp:version>
+        <xmpp:since>1.5</xmpp:since>
+    </implements>
+    <implements>
+      <xmpp:SupportedXep>
         <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0450.html'/>
         <xmpp:status>complete</xmpp:status>
         <xmpp:version>0.4</xmpp:version>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ set(INSTALL_HEADER_FILES
     base/QXmppDiscoveryIq.h
     base/QXmppE2eeMetadata.h
     base/QXmppElement.h
+    base/QXmppEncryptedFileSource.h
     base/QXmppEntityTimeIq.h
     base/QXmppError.h
     base/QXmppExtension.h
@@ -161,6 +162,7 @@ set(SOURCE_FILES
     base/QXmppDataFormBase.cpp
     base/QXmppDiscoveryIq.cpp
     base/QXmppElement.cpp
+    base/QXmppEncryptedFileSource.cpp
     base/QXmppEntityTimeIq.cpp
     base/QXmppError.cpp
     base/QXmppFileMetadata.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,6 @@ set(INSTALL_HEADER_FILES
     base/QXmppDiscoveryIq.h
     base/QXmppE2eeMetadata.h
     base/QXmppElement.h
-    base/QXmppEncryptedFileSource.h
     base/QXmppEntityTimeIq.h
     base/QXmppError.h
     base/QXmppExtension.h

--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -192,5 +192,7 @@ const char *ns_tm = "urn:xmpp:tm:1";
 const char *ns_file_metadata = "urn:xmpp:file:metadata:0";
 // XEP-0447: Stateless file sharing
 const char *ns_sfs = "urn:xmpp:sfs:0";
+// XEP-0448: Encryption for stateless file sharing
+const char *ns_esfs = "urn:xmpp:esfs:0";
 // XEP-0450: Automatic Trust Management (ATM)
 const char *ns_atm = "urn:xmpp:atm:1";

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -204,6 +204,8 @@ extern const char *ns_tm;
 extern const char *ns_file_metadata;
 // XEP-0447: Stateless file sharing
 extern const char *ns_sfs;
+// XEP-0448: Encryption for stateless file sharing
+extern const char *ns_esfs;
 // XEP-0450: Automatic Trust Management (ATM)
 extern const char *ns_atm;
 

--- a/src/base/QXmppEncryptedFileSource.cpp
+++ b/src/base/QXmppEncryptedFileSource.cpp
@@ -24,6 +24,8 @@ QXmppEncryptedFileSource::QXmppEncryptedFileSource()
 {
 }
 
+QXMPP_PRIVATE_DEFINE_RULE_OF_SIX(QXmppEncryptedFileSource);
+
 QXmppEncryptedFileSource::Cipher QXmppEncryptedFileSource::cipher() const
 {
     return d->cipher;

--- a/src/base/QXmppEncryptedFileSource.cpp
+++ b/src/base/QXmppEncryptedFileSource.cpp
@@ -38,11 +38,6 @@ static std::optional<QXmppEncryptedFileSource::Cipher> cipherFromString(const QS
     return {};
 }
 
-class QXmppEncryptedFileSourcePrivate : public QSharedData
-{
-public:
-};
-
 QXmppEncryptedFileSource::QXmppEncryptedFileSource() = default;
 
 QXmppEncryptedFileSource::Cipher QXmppEncryptedFileSource::cipher() const

--- a/src/base/QXmppEncryptedFileSource.cpp
+++ b/src/base/QXmppEncryptedFileSource.cpp
@@ -1,0 +1,56 @@
+#include "QXmppEncryptedFileSource.h"
+
+QXmppEncryptedFileSource::QXmppEncryptedFileSource()
+{
+    
+}
+
+QXmppEncryptedFileSource::Cipher QXmppEncryptedFileSource::cipher() const
+{
+    return m_cipher;
+}
+
+void QXmppEncryptedFileSource::setCipher(Cipher newCipher)
+{
+    m_cipher = newCipher;
+}
+
+const QByteArray &QXmppEncryptedFileSource::key() const
+{
+    return m_key;
+}
+
+void QXmppEncryptedFileSource::setKey(const QByteArray &newKey)
+{
+    m_key = newKey;
+}
+
+const QByteArray &QXmppEncryptedFileSource::iv() const
+{
+    return m_iv;
+}
+
+void QXmppEncryptedFileSource::setIv(const QByteArray &newIv)
+{
+    m_iv = newIv;
+}
+
+const QVector<QXmppHash> &QXmppEncryptedFileSource::hashes() const
+{
+    return m_hashes;
+}
+
+void QXmppEncryptedFileSource::setHashes(const QVector<QXmppHash> &newHashes)
+{
+    m_hashes = newHashes;
+}
+
+const QVector<QUrl> &QXmppEncryptedFileSource::httpSources() const
+{
+    return m_httpSources;
+}
+
+void QXmppEncryptedFileSource::setHttpSources(const QVector<QUrl> &newHttpSources)
+{
+    m_httpSources = newHttpSources;
+}

--- a/src/base/QXmppEncryptedFileSource.cpp
+++ b/src/base/QXmppEncryptedFileSource.cpp
@@ -1,56 +1,109 @@
 #include "QXmppEncryptedFileSource.h"
 
+#include <QDomElement>
+
+class QXmppEncryptedFileSourcePrivate : public QSharedData {
+public:
+    QXmppEncryptedFileSource::Cipher cipher = QXmppEncryptedFileSource::Aes128GcmNopadding;
+    QByteArray key;
+    QByteArray iv;
+    QVector<QXmppHash> hashes;
+    QVector<QUrl> httpSources;
+};
+
 QXmppEncryptedFileSource::QXmppEncryptedFileSource()
+    : d(new QXmppEncryptedFileSourcePrivate())
 {
-    
 }
 
 QXmppEncryptedFileSource::Cipher QXmppEncryptedFileSource::cipher() const
 {
-    return m_cipher;
+    return d->cipher;
 }
 
 void QXmppEncryptedFileSource::setCipher(Cipher newCipher)
 {
-    m_cipher = newCipher;
+    d->cipher = newCipher;
 }
 
 const QByteArray &QXmppEncryptedFileSource::key() const
 {
-    return m_key;
+    return d->key;
 }
 
 void QXmppEncryptedFileSource::setKey(const QByteArray &newKey)
 {
-    m_key = newKey;
+    d->key = newKey;
 }
 
 const QByteArray &QXmppEncryptedFileSource::iv() const
 {
-    return m_iv;
+    return d->iv;
 }
 
 void QXmppEncryptedFileSource::setIv(const QByteArray &newIv)
 {
-    m_iv = newIv;
+    d->iv = newIv;
 }
 
 const QVector<QXmppHash> &QXmppEncryptedFileSource::hashes() const
 {
-    return m_hashes;
+    return d->hashes;
 }
 
 void QXmppEncryptedFileSource::setHashes(const QVector<QXmppHash> &newHashes)
 {
-    m_hashes = newHashes;
+    d->hashes = newHashes;
 }
 
 const QVector<QUrl> &QXmppEncryptedFileSource::httpSources() const
 {
-    return m_httpSources;
+    return d->httpSources;
 }
 
 void QXmppEncryptedFileSource::setHttpSources(const QVector<QUrl> &newHttpSources)
 {
-    m_httpSources = newHttpSources;
+    d->httpSources = newHttpSources;
+}
+
+bool QXmppEncryptedFileSource::parse(const QDomElement &el)
+{
+    auto keyEl = el.firstChildElement(QStringLiteral("key"));
+    if (keyEl.isNull()) {
+        return false;
+    }
+    d->key = QByteArray::fromBase64(keyEl.text().toUtf8());
+
+    auto ivEl = el.firstChildElement(QStringLiteral("iv"));
+    if (ivEl.isNull()) {
+        return false;
+    }
+    d->iv = QByteArray::fromBase64(ivEl.text().toUtf8());
+
+    for (auto childEl = el.firstChildElement(QStringLiteral("hash"));
+         !childEl.isNull();
+         childEl = childEl.nextSiblingElement(QStringLiteral("hash"))) {
+        QXmppHash hash;
+        if (!hash.parse(childEl)) {
+            return false;
+        }
+        d->hashes.push_back(std::move(hash));
+    }
+
+    auto sourcesEl = el.firstChildElement(QStringLiteral("sources"));
+    if (sourcesEl.isNull()) {
+        return false;
+    }
+    for (auto childEl = el.firstChildElement(QStringLiteral("url-data"));
+         !childEl.isNull();
+         childEl = childEl.nextSiblingElement(QStringLiteral("url-data"))) {
+        d->httpSources.push_back(QUrl(childEl.text()));
+    }
+
+    return true;
+}
+
+void QXmppEncryptedFileSource::toXml(QXmlStreamWriter *writer) const
+{
+
 }

--- a/src/base/QXmppEncryptedFileSource.cpp
+++ b/src/base/QXmppEncryptedFileSource.cpp
@@ -12,7 +12,8 @@
 #include <QDomElement>
 #include <QXmlStreamWriter>
 
-QString cipherToString(QXmppEncryptedFileSource::Cipher cipher)
+/// \cond
+static QString cipherToString(QXmppEncryptedFileSource::Cipher cipher)
 {
     switch (cipher) {
     case QXmppEncryptedFileSource::Aes128GcmNopadding:
@@ -22,11 +23,10 @@ QString cipherToString(QXmppEncryptedFileSource::Cipher cipher)
     case QXmppEncryptedFileSource::Aes256CbcPkcs7:
         return "urn:xmpp:ciphers:aes-256-cbc-pkcs7:0";
     }
-
     Q_UNREACHABLE();
 }
 
-std::optional<QXmppEncryptedFileSource::Cipher> cipherFromString(const QString &cipher)
+static std::optional<QXmppEncryptedFileSource::Cipher> cipherFromString(const QString &cipher)
 {
     if (cipher == "urn:xmpp:ciphers:aes-128-gcm-nopadding:0") {
         return QXmppEncryptedFileSource::Aes128GcmNopadding;
@@ -35,7 +35,6 @@ std::optional<QXmppEncryptedFileSource::Cipher> cipherFromString(const QString &
     } else if (cipher == "urn:xmpp:ciphers:aes-256-cbc-pkcs7:0") {
         return QXmppEncryptedFileSource::Aes256CbcPkcs7;
     }
-
     return {};
 }
 
@@ -170,3 +169,4 @@ void QXmppEncryptedFileSource::toXml(QXmlStreamWriter *writer) const
     writer->writeEndElement();
     writer->writeEndElement();
 }
+/// \endcond

--- a/src/base/QXmppEncryptedFileSource.h
+++ b/src/base/QXmppEncryptedFileSource.h
@@ -1,7 +1,13 @@
+// SPDX-FileCopyrightText: 2022 <lnj@kaidan.im>
+// SPDX-FileCopyrightText: 2022 <jbb@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 #ifndef QXMPPENCRYPTEDFILESOURCE_H
 #define QXMPPENCRYPTEDFILESOURCE_H
 
 #include "QXmppGlobal.h"
+#include "QXmppHttpFileSource.h"
 
 #include <QSharedDataPointer>
 #include <QVector>
@@ -34,8 +40,8 @@ public:
     const QVector<QXmppHash> &hashes() const;
     void setHashes(const QVector<QXmppHash> &newHashes);
     
-    const QVector<QUrl> &httpSources() const;
-    void setHttpSources(const QVector<QUrl> &newHttpSources);
+    const QVector<QXmppHttpFileSource> &httpSources() const;
+    void setHttpSources(const QVector<QXmppHttpFileSource> &newHttpSources);
 
     /// \cond
     bool parse(const QDomElement &el);

--- a/src/base/QXmppEncryptedFileSource.h
+++ b/src/base/QXmppEncryptedFileSource.h
@@ -4,8 +4,11 @@
 #include "QXmppGlobal.h"
 
 #include <QSharedDataPointer>
+#include <QVector>
+#include <QUrl>
 
-class QXmppHash;
+#include "QXmppHash.h"
+
 class QXmppEncryptedFileSourcePrivate;
 
 class QXMPP_EXPORT QXmppEncryptedFileSource
@@ -33,14 +36,14 @@ public:
     
     const QVector<QUrl> &httpSources() const;
     void setHttpSources(const QVector<QUrl> &newHttpSources);
+
+    /// \cond
+    bool parse(const QDomElement &el);
+    void toXml(QXmlStreamWriter *writer) const;
+    /// \endcond
     
 private:
     QSharedDataPointer<QXmppEncryptedFileSourcePrivate> d;
-    Cipher m_cipher;
-    QByteArray m_key;
-    QByteArray m_iv;
-    QVector<QXmppHash> m_hashes;
-    QVector<QUrl> m_httpSources;
 };
 
 #endif // QXMPPENCRYPTEDFILESOURCE_H

--- a/src/base/QXmppEncryptedFileSource.h
+++ b/src/base/QXmppEncryptedFileSource.h
@@ -27,6 +27,7 @@ public:
     };
 
     QXmppEncryptedFileSource();
+    QXMPP_PRIVATE_DECLARE_RULE_OF_SIX(QXmppEncryptedFileSource);
     
     Cipher cipher() const;
     void setCipher(Cipher newCipher);

--- a/src/base/QXmppEncryptedFileSource.h
+++ b/src/base/QXmppEncryptedFileSource.h
@@ -1,0 +1,46 @@
+#ifndef QXMPPENCRYPTEDFILESOURCE_H
+#define QXMPPENCRYPTEDFILESOURCE_H
+
+#include "QXmppGlobal.h"
+
+#include <QSharedDataPointer>
+
+class QXmppHash;
+class QXmppEncryptedFileSourcePrivate;
+
+class QXMPP_EXPORT QXmppEncryptedFileSource
+{
+public:
+    enum Cipher {
+        Aes128GcmNopadding,
+        Aes256GcmNopadding,
+        Aes256CbcPkcs7,
+    };
+
+    QXmppEncryptedFileSource();
+    
+    Cipher cipher() const;
+    void setCipher(Cipher newCipher);
+    
+    const QByteArray &key() const;
+    void setKey(const QByteArray &newKey);
+    
+    const QByteArray &iv() const;
+    void setIv(const QByteArray &newIv);
+    
+    const QVector<QXmppHash> &hashes() const;
+    void setHashes(const QVector<QXmppHash> &newHashes);
+    
+    const QVector<QUrl> &httpSources() const;
+    void setHttpSources(const QVector<QUrl> &newHttpSources);
+    
+private:
+    QSharedDataPointer<QXmppEncryptedFileSourcePrivate> d;
+    Cipher m_cipher;
+    QByteArray m_key;
+    QByteArray m_iv;
+    QVector<QXmppHash> m_hashes;
+    QVector<QUrl> m_httpSources;
+};
+
+#endif // QXMPPENCRYPTEDFILESOURCE_H

--- a/src/base/QXmppEncryptedFileSource_p.h
+++ b/src/base/QXmppEncryptedFileSource_p.h
@@ -7,13 +7,12 @@
 #define QXMPPENCRYPTEDFILESOURCE_H
 
 #include "QXmppGlobal.h"
+#include "QXmppHash.h"
 #include "QXmppHttpFileSource.h"
 
 #include <QSharedDataPointer>
-#include <QVector>
 #include <QUrl>
-
-#include "QXmppHash.h"
+#include <QVector>
 
 class QXmppEncryptedFileSourcePrivate;
 
@@ -28,19 +27,19 @@ public:
 
     QXmppEncryptedFileSource();
     QXMPP_PRIVATE_DECLARE_RULE_OF_SIX(QXmppEncryptedFileSource);
-    
+
     Cipher cipher() const;
     void setCipher(Cipher newCipher);
-    
+
     const QByteArray &key() const;
     void setKey(const QByteArray &newKey);
-    
+
     const QByteArray &iv() const;
     void setIv(const QByteArray &newIv);
-    
+
     const QVector<QXmppHash> &hashes() const;
     void setHashes(const QVector<QXmppHash> &newHashes);
-    
+
     const QVector<QXmppHttpFileSource> &httpSources() const;
     void setHttpSources(const QVector<QXmppHttpFileSource> &newHttpSources);
 
@@ -48,9 +47,9 @@ public:
     bool parse(const QDomElement &el);
     void toXml(QXmlStreamWriter *writer) const;
     /// \endcond
-    
+
 private:
     QSharedDataPointer<QXmppEncryptedFileSourcePrivate> d;
 };
 
-#endif // QXMPPENCRYPTEDFILESOURCE_H
+#endif  // QXMPPENCRYPTEDFILESOURCE_H

--- a/src/base/QXmppEncryptedFileSource_p.h
+++ b/src/base/QXmppEncryptedFileSource_p.h
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 <lnj@kaidan.im>
-// SPDX-FileCopyrightText: 2022 <jbb@kaidan.im>
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
+// SPDX-FileCopyrightText: 2022 Jonah Brüchert <jbb@kaidan.im>
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -16,6 +16,7 @@
 
 class QXmppEncryptedFileSourcePrivate;
 
+// exported for tests
 class QXMPP_EXPORT QXmppEncryptedFileSource
 {
 public:
@@ -26,7 +27,6 @@ public:
     };
 
     QXmppEncryptedFileSource();
-    QXMPP_PRIVATE_DECLARE_RULE_OF_SIX(QXmppEncryptedFileSource);
 
     Cipher cipher() const;
     void setCipher(Cipher newCipher);
@@ -49,7 +49,11 @@ public:
     /// \endcond
 
 private:
-    QSharedDataPointer<QXmppEncryptedFileSourcePrivate> d;
+    Cipher m_cipher = Aes128GcmNopadding;
+    QByteArray m_key;
+    QByteArray m_iv;
+    QVector<QXmppHash> m_hashes;
+    QVector<QXmppHttpFileSource> m_httpSources;
 };
 
 #endif  // QXMPPENCRYPTEDFILESOURCE_H

--- a/src/base/QXmppHash.cpp
+++ b/src/base/QXmppHash.cpp
@@ -123,6 +123,7 @@ bool QXmppHash::parse(const QDomElement &el)
 #else
         m_hash = QByteArray::fromBase64(el.text().toUtf8());
 #endif
+        return true;
     }
     return false;
 }

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -6,6 +6,7 @@
 
 #include "QXmppBitsOfBinaryContentId.h"
 #include "QXmppBitsOfBinaryDataList.h"
+#include "QXmppEncryptedFileSource_p.h"
 #include "QXmppMessage.h"
 #include "QXmppMixInvitation.h"
 #include "QXmppTrustMessageElement.h"
@@ -53,6 +54,7 @@ private slots:
     void testTrustMessageElement();
     void testE2eeFallbackBody();
     void testFileSharing();
+    void testEncryptedFileSource();
 };
 
 void tst_QXmppMessage::testBasic_data()
@@ -1184,6 +1186,28 @@ void tst_QXmppMessage::testFileSharing()
     parsePacket(message1, xml);
     QVERIFY(!message1.sharedFiles().empty());
     serializePacket(message1, xml);
+}
+
+void tst_QXmppMessage::testEncryptedFileSource()
+{
+    const QByteArray xml(
+        "<encrypted xmlns='urn:xmpp:esfs:0' cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>"
+        "<key>SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ=</key>"
+        "<iv>T8RDMBaiqn6Ci4Nw</iv>"
+        "<hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>BgKI2gp2kNCRsARNvhFmw5kFf9BBo2pTbV2D8XHTMWI=</hash>"
+        "<hash xmlns='urn:xmpp:hashes:2' algo='blake2b-256'>id4cnqqy9/ssfCkM4vYSkiXXrlE=</hash>"
+        "<sources xmlns='urn:xmpp:sfs:0'>"
+        "<url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg'/>"
+        "</sources>"
+        "</encrypted>");
+
+    QXmppEncryptedFileSource encryptedSource;
+    parsePacket(encryptedSource, xml);
+    QCOMPARE(encryptedSource.key(), QByteArray::fromBase64("SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ="));
+    QCOMPARE(encryptedSource.iv(), QByteArray::fromBase64("T8RDMBaiqn6Ci4Nw"));
+    QCOMPARE(encryptedSource.httpSources().front().url(), QUrl("https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg"));
+    QVERIFY(!encryptedSource.hashes().empty());
+    serializePacket(encryptedSource, xml);
 }
 
 QTEST_MAIN(tst_QXmppMessage)

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -1190,24 +1190,61 @@ void tst_QXmppMessage::testFileSharing()
 
 void tst_QXmppMessage::testEncryptedFileSource()
 {
-    const QByteArray xml(
-        "<encrypted xmlns='urn:xmpp:esfs:0' cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>"
-        "<key>SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ=</key>"
-        "<iv>T8RDMBaiqn6Ci4Nw</iv>"
-        "<hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>BgKI2gp2kNCRsARNvhFmw5kFf9BBo2pTbV2D8XHTMWI=</hash>"
-        "<hash xmlns='urn:xmpp:hashes:2' algo='blake2b-256'>id4cnqqy9/ssfCkM4vYSkiXXrlE=</hash>"
-        "<sources xmlns='urn:xmpp:sfs:0'>"
-        "<url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg'/>"
-        "</sources>"
-        "</encrypted>");
+    {
+        QByteArray xml(
+            "<encrypted xmlns='urn:xmpp:esfs:0' cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>"
+            "<key>SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ=</key>"
+            "<iv>T8RDMBaiqn6Ci4Nw</iv>"
+            "<hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>BgKI2gp2kNCRsARNvhFmw5kFf9BBo2pTbV2D8XHTMWI=</hash>"
+            "<hash xmlns='urn:xmpp:hashes:2' algo='blake2b-256'>id4cnqqy9/ssfCkM4vYSkiXXrlE=</hash>"
+            "<sources xmlns='urn:xmpp:sfs:0'>"
+            "<url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg'/>"
+            "</sources>"
+            "</encrypted>");
 
-    QXmppEncryptedFileSource encryptedSource;
-    parsePacket(encryptedSource, xml);
-    QCOMPARE(encryptedSource.key(), QByteArray::fromBase64("SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ="));
-    QCOMPARE(encryptedSource.iv(), QByteArray::fromBase64("T8RDMBaiqn6Ci4Nw"));
-    QCOMPARE(encryptedSource.httpSources().front().url(), QUrl("https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg"));
-    QVERIFY(!encryptedSource.hashes().empty());
-    serializePacket(encryptedSource, xml);
+        QXmppEncryptedFileSource encryptedSource;
+        parsePacket(encryptedSource, xml);
+        QCOMPARE(encryptedSource.key(), QByteArray::fromBase64("SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ="));
+        QCOMPARE(encryptedSource.iv(), QByteArray::fromBase64("T8RDMBaiqn6Ci4Nw"));
+        QCOMPARE(encryptedSource.httpSources().front().url(), QUrl("https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg"));
+        QCOMPARE(encryptedSource.cipher(), QXmppEncryptedFileSource::Aes256GcmNopadding);
+        QVERIFY(!encryptedSource.hashes().empty());
+        serializePacket(encryptedSource, xml);
+    }
+
+    {
+        QByteArray xml(
+            "<encrypted xmlns='urn:xmpp:esfs:0' cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding:0'>"
+            "<key>SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ=</key>"
+            "<iv>T8RDMBaiqn6Ci4Nw</iv>"
+            "<hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>BgKI2gp2kNCRsARNvhFmw5kFf9BBo2pTbV2D8XHTMWI=</hash>"
+            "<hash xmlns='urn:xmpp:hashes:2' algo='blake2b-256'>id4cnqqy9/ssfCkM4vYSkiXXrlE=</hash>"
+            "<sources xmlns='urn:xmpp:sfs:0'>"
+            "<url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg'/>"
+            "</sources>"
+            "</encrypted>");
+
+        QXmppEncryptedFileSource encryptedSource;
+        parsePacket(encryptedSource, xml);
+        serializePacket(encryptedSource, xml);
+    }
+
+    {
+        QByteArray xml(
+            "<encrypted xmlns='urn:xmpp:esfs:0' cipher='urn:xmpp:ciphers:aes-256-cbc-pkcs7:0'>"
+            "<key>SuRJ2agVm/pQbJQlPq/B23Xt1YOOJCcEGJA5HrcYOGQ=</key>"
+            "<iv>T8RDMBaiqn6Ci4Nw</iv>"
+            "<hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>BgKI2gp2kNCRsARNvhFmw5kFf9BBo2pTbV2D8XHTMWI=</hash>"
+            "<hash xmlns='urn:xmpp:hashes:2' algo='blake2b-256'>id4cnqqy9/ssfCkM4vYSkiXXrlE=</hash>"
+            "<sources xmlns='urn:xmpp:sfs:0'>"
+            "<url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/encrypted.jpg'/>"
+            "</sources>"
+            "</encrypted>");
+
+        QXmppEncryptedFileSource encryptedSource;
+        parsePacket(encryptedSource, xml);
+        serializePacket(encryptedSource, xml);
+    }
 }
 
 QTEST_MAIN(tst_QXmppMessage)


### PR DESCRIPTION
- esfs
- esfs: Implement parsing
- Implement serialization
- Add rule of six constructor

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
