### PR TITLE
Rename OmemoEnvelope's 'setIsUsedForKeyExchange()' to 'setUsedForKeyExchange()'

### DIFF
--- a/src/base/QXmppOmemoDataBase.cpp
+++ b/src/base/QXmppOmemoDataBase.cpp
@@ -60,7 +60,7 @@ bool QXmppOmemoEnvelope::isUsedForKeyExchange() const
 ///
 /// \param isUsed whether a pre-key was used to prepare this envelope
 ///
-void QXmppOmemoEnvelope::setIsUsedForKeyExchange(bool isUsed)
+void QXmppOmemoEnvelope::setUsedForKeyExchange(bool isUsed)
 {
     m_isUsedForKeyExchange = isUsed;
 }

--- a/src/base/QXmppOmemoEnvelope_p.h
+++ b/src/base/QXmppOmemoEnvelope_p.h
@@ -18,7 +18,7 @@ public:
     void setRecipientDeviceId(uint32_t id);
 
     bool isUsedForKeyExchange() const;
-    void setIsUsedForKeyExchange(bool isUsed);
+    void setUsedForKeyExchange(bool isUsed);
 
     QByteArray data() const;
     void setData(const QByteArray &data);

--- a/src/omemo/QXmppOmemoManager_p.cpp
+++ b/src/omemo/QXmppOmemoManager_p.cpp
@@ -1155,7 +1155,7 @@ QFuture<std::optional<QXmppOmemoElement>> ManagerPrivate::encryptStanza(const T 
                             QXmppOmemoEnvelope omemoEnvelope;
                             omemoEnvelope.setRecipientDeviceId(deviceId);
                             if (isKeyExchange) {
-                                omemoEnvelope.setIsUsedForKeyExchange(true);
+                                omemoEnvelope.setUsedForKeyExchange(true);
                             }
                             omemoEnvelope.setData(data);
                             omemoElement->addEnvelope(jid, omemoEnvelope);
@@ -3554,7 +3554,7 @@ QFuture<QXmpp::SendResult> ManagerPrivate::sendEmptyMessage(const QString &recip
         QXmppOmemoEnvelope omemoEnvelope;
         omemoEnvelope.setRecipientDeviceId(recipientDeviceId);
         if (isKeyExchange) {
-            omemoEnvelope.setIsUsedForKeyExchange(true);
+            omemoEnvelope.setUsedForKeyExchange(true);
         }
         omemoEnvelope.setData(data);
 

--- a/tests/qxmppomemodata/tst_qxmppomemodata.cpp
+++ b/tests/qxmppomemodata/tst_qxmppomemodata.cpp
@@ -349,7 +349,7 @@ void tst_QXmppOmemoData::testOmemoEnvelope()
 
     QXmppOmemoEnvelope omemoEnvelope2;
     omemoEnvelope2.setRecipientDeviceId(recipientDeviceId);
-    omemoEnvelope2.setIsUsedForKeyExchange(isUsedForKeyExchange);
+    omemoEnvelope2.setUsedForKeyExchange(isUsedForKeyExchange);
     omemoEnvelope2.setData(QByteArray::fromBase64(data));
     QCOMPARE(omemoEnvelope2.recipientDeviceId(), recipientDeviceId);
     QCOMPARE(omemoEnvelope2.isUsedForKeyExchange(), isUsedForKeyExchange);
@@ -500,7 +500,7 @@ void tst_QXmppOmemoData::testOmemoElement()
 
     QXmppOmemoEnvelope omemoEnvelope5;
     omemoEnvelope5.setRecipientDeviceId(12321);
-    omemoEnvelope5.setIsUsedForKeyExchange(true);
+    omemoEnvelope5.setUsedForKeyExchange(true);
     omemoEnvelope5.setData(QByteArray::fromBase64("a012U0R9WixWKUYhYipucnZOWG06akFOR3Q1NGNOOmUK"));
     omemoElement2.addEnvelope(QStringLiteral("romeo@montague.lit"), omemoEnvelope5);
 


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
