### PR TITLE
FileMetadata: Allow multiple thumbnails

### DIFF
--- a/src/base/QXmppFileMetadata.h
+++ b/src/base/QXmppFileMetadata.h
@@ -55,8 +55,8 @@ public:
     std::optional<uint64_t> size() const;
     void setSize(std::optional<uint64_t> size);
 
-    const std::optional<QXmppThumbnail> &thumbnail() const;
-    void setThumbnail(const std::optional<QXmppThumbnail> &thumbnail);
+    const QVector<QXmppThumbnail> &thumbnails() const;
+    void setThumbnails(const QVector<QXmppThumbnail> &thumbnail);
 
     std::optional<uint32_t> width() const;
     void setWidth(std::optional<uint32_t> width);


### PR DESCRIPTION
The standard actually allows multiple thumbnails.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
