### PR TITLE
QXmppHttpUploadManager: Only allow https urls

### DIFF
--- a/src/client/QXmppHttpUploadManager.cpp
+++ b/src/client/QXmppHttpUploadManager.cpp
@@ -316,6 +316,14 @@ std::shared_ptr<QXmppHttpUpload> QXmppHttpUploadManager::uploadFile(QIODevice *d
             upload->d->reportFinished();
         } else {
             auto slot = std::get<QXmppHttpUploadSlotIq>(std::move(result));
+
+            if (slot.getUrl().scheme() != "https" || slot.putUrl().scheme() != "https") {
+                auto message = QStringLiteral("The server replied with an insecure non-https url. This is forbidden by XEP-0363.");
+                upload->d->reportError(QXmppError { message, {} });
+                upload->d->reportFinished();
+                return;
+            }
+
             upload->d->getUrl = slot.getUrl();
 
             QNetworkRequest request(slot.putUrl());


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
