### PR TITLE
QXmppHttpUploadManager: Also use unique_ptr for data device

### DIFF
--- a/src/client/QXmppHttpUploadManager.h
+++ b/src/client/QXmppHttpUploadManager.h
@@ -58,7 +58,7 @@ public:
     explicit QXmppHttpUploadManager(QNetworkAccessManager *netManager);
     ~QXmppHttpUploadManager();
 
-    std::shared_ptr<QXmppHttpUpload> uploadFile(QIODevice *data, const QString &filename, const QMimeType &mimeType, qint64 fileSize = -1, const QString &uploadServiceJid = {});
+    std::shared_ptr<QXmppHttpUpload> uploadFile(std::unique_ptr<QIODevice> data, const QString &filename, const QMimeType &mimeType, qint64 fileSize = -1, const QString &uploadServiceJid = {});
     std::shared_ptr<QXmppHttpUpload> uploadFile(const QFileInfo &fileInfo, const QString &filename = {}, const QString &uploadServiceJid = {});
 
 private:


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
