### PR TITLE
QXmppHttpFileSharingProvider: keep original filename when known

### DIFF
--- a/src/client/QXmppHttpFileSharingProvider.cpp
+++ b/src/client/QXmppHttpFileSharingProvider.cpp
@@ -195,9 +195,10 @@ auto QXmppHttpFileSharingProvider::uploadFile(std::unique_ptr<QIODevice> data,
     -> std::shared_ptr<QXmppUpload>
 {
     Q_ASSERT(d->manager);
+
     auto upload = d->manager->uploadFile(
         std::move(data),
-        QXmppUtils::generateStanzaHash(10),
+        info.filename().value_or(QXmppUtils::generateStanzaHash(10)),
         info.mediaType().value_or(QMimeDatabase().mimeTypeForName("application/octet-stream")),
         info.size() ? info.size().value() : -1);
 


### PR DESCRIPTION
This is unfortunatly required for compatiblity with legacy clients, because they rely on the url to figure out the file type.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
