### PR TITLE
Fix installing the headers that are dependent on QCA

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -349,7 +349,7 @@ endif()
 
 if(WITH_QCA)
     target_sources(qxmpp PRIVATE client/QXmppEncryptedHttpFileSharingProvider.cpp client/QXmppFileEncryption.cpp client/QcaInitializer.cpp)
-    set(HEADER_FILES ${HEADER_FILES} client/QXmppEncryptedHttpFileSharingProvider.h)
+    set(INSTALL_HEADER_FILES ${INSTALL_HEADER_FILES} client/QXmppEncryptedHttpFileSharingProvider.h)
     target_link_libraries(qxmpp PRIVATE qca-qt${QT_VERSION_MAJOR})
     target_compile_definitions(qxmpp PRIVATE -DWITH_QCA)
 endif()


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
