### PR TITLE
Clean up Jingle namespaces

### DIFF
--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -104,9 +104,11 @@ const char *ns_captcha = "urn:xmpp:captcha";
 const char *ns_jingle = "urn:xmpp:jingle:1";
 const char *ns_jingle_raw_udp = "urn:xmpp:jingle:transports:raw-udp:1";
 const char *ns_jingle_ice_udp = "urn:xmpp:jingle:transports:ice-udp:1";
+// XEP-0167: Jingle RTP Sessions
 const char *ns_jingle_rtp = "urn:xmpp:jingle:apps:rtp:1";
 const char *ns_jingle_rtp_audio = "urn:xmpp:jingle:apps:rtp:audio";
 const char *ns_jingle_rtp_video = "urn:xmpp:jingle:apps:rtp:video";
+const char *ns_jingle_rtp_info = "urn:xmpp:jingle:apps:rtp:info:1";
 // XEP-0184: Message Receipts
 const char *ns_message_receipts = "urn:xmpp:receipts";
 // XEP-0198: Stream Management
@@ -147,6 +149,8 @@ const char *ns_message_correct = "urn:xmpp:message-correct:0";
 const char *ns_mam = "urn:xmpp:mam:2";
 // XEP-0319: Last User Interaction in Presence
 const char *ns_idle = "urn:xmpp:idle:1";
+// XEP-0320: Use of DTLS-SRTP in Jingle Sessions
+const char *ns_jingle_dtls = "urn:xmpp:jingle:apps:dtls:0";
 // XEP-0333: Chat Markers
 const char *ns_chat_markers = "urn:xmpp:chat-markers:0";
 // XEP-0334: Message Processing Hints

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -116,9 +116,11 @@ extern const char *ns_captcha;
 extern const char *ns_jingle;
 extern const char *ns_jingle_ice_udp;
 extern const char *ns_jingle_raw_udp;
+// XEP-0167: Jingle RTP Sessions
 extern const char *ns_jingle_rtp;
 extern const char *ns_jingle_rtp_audio;
 extern const char *ns_jingle_rtp_video;
+extern const char *ns_jingle_rtp_info;
 // XEP-0184: Message Receipts
 extern const char *ns_message_receipts;
 // XEP-0198: Stream Management
@@ -159,6 +161,8 @@ extern const char *ns_message_correct;
 extern const char *ns_mam;
 // XEP-0319: Last User Interaction in Presence
 extern const char *ns_idle;
+// XEP-0320: Use of DTLS-SRTP in Jingle Sessions
+extern const char *ns_jingle_dtls;
 // XEP-0333: Char Markers
 extern const char *ns_chat_markers;
 // XEP-0334: Message Processing Hints:

--- a/src/base/QXmppJingleIq.cpp
+++ b/src/base/QXmppJingleIq.cpp
@@ -15,9 +15,6 @@
 
 static const int RTP_COMPONENT = 1;
 
-static const char *ns_jingle_rtp_info = "urn:xmpp:jingle:apps:rtp:info:1";
-static const char *ns_jingle_dtls = "urn:xmpp:jingle:apps:dtls:0";
-
 static const char *jingle_actions[] = {
     "content-accept",
     "content-add",
@@ -740,7 +737,7 @@ void QXmppJingleIq::Content::toXml(QXmlStreamWriter *writer) const
             candidate.toXml(writer);
         }
 
-        // XEP-0320
+        // XEP-0320: Use of DTLS-SRTP in Jingle Sessions
         if (!d->transportFingerprint.isEmpty() && !d->transportFingerprintHash.isEmpty()) {
             writer->writeStartElement(QStringLiteral("fingerprint"));
             writer->writeDefaultNamespace(ns_jingle_dtls);


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
