### PR TITLE
Implement XEP-0167: Jingle RTP Sessions error conditions

### DIFF
--- a/src/base/QXmppConstants.cpp
+++ b/src/base/QXmppConstants.cpp
@@ -109,6 +109,7 @@ const char *ns_jingle_rtp = "urn:xmpp:jingle:apps:rtp:1";
 const char *ns_jingle_rtp_audio = "urn:xmpp:jingle:apps:rtp:audio";
 const char *ns_jingle_rtp_video = "urn:xmpp:jingle:apps:rtp:video";
 const char *ns_jingle_rtp_info = "urn:xmpp:jingle:apps:rtp:info:1";
+const char *ns_jingle_rtp_errors = "urn:xmpp:jingle:apps:rtp:errors:1";
 // XEP-0184: Message Receipts
 const char *ns_message_receipts = "urn:xmpp:receipts";
 // XEP-0198: Stream Management

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -121,6 +121,7 @@ extern const char *ns_jingle_rtp;
 extern const char *ns_jingle_rtp_audio;
 extern const char *ns_jingle_rtp_video;
 extern const char *ns_jingle_rtp_info;
+extern const char *ns_jingle_rtp_errors;
 // XEP-0184: Message Receipts
 extern const char *ns_message_receipts;
 // XEP-0198: Stream Management

--- a/src/base/QXmppJingleIq.cpp
+++ b/src/base/QXmppJingleIq.cpp
@@ -56,8 +56,8 @@ static const char *jingle_reasons[] = {
 
 static const QStringList JINGLE_RTP_ERROR_CONDITIONS = {
     {},
-    "invalid-crypto",
-    "crypto-required"
+    QStringLiteral("invalid-crypto"),
+    QStringLiteral("crypto-required")
 };
 
 static const QStringList JINGLE_RTP_HEADER_EXTENSIONS_SENDERS = {

--- a/src/base/QXmppJingleIq.cpp
+++ b/src/base/QXmppJingleIq.cpp
@@ -1033,8 +1033,9 @@ void QXmppJingleIq::Reason::parse(const QDomElement &element)
          !child.isNull();
          child = child.nextSiblingElement()) {
         if (child.namespaceURI() == ns_jingle_rtp_errors) {
-            if (const auto rtpErrorConditionIndex = JINGLE_RTP_ERROR_CONDITIONS.indexOf(child.tagName()); rtpErrorConditionIndex != -1) {
-                m_rtpErrorCondition = RtpErrorCondition(rtpErrorConditionIndex);
+            if (const auto index = JINGLE_RTP_ERROR_CONDITIONS.indexOf(child.tagName());
+                rtpErrorConditionIndex != -1) {
+                m_rtpErrorCondition = RtpErrorCondition(index);
             }
             break;
         }

--- a/src/base/QXmppJingleIq.cpp
+++ b/src/base/QXmppJingleIq.cpp
@@ -1029,9 +1029,13 @@ void QXmppJingleIq::Reason::parse(const QDomElement &element)
         }
     }
 
-    for (int i = NoErrorCondition + 1; i < JINGLE_RTP_ERROR_CONDITIONS.size(); i++) {
-        if (!element.firstChildElement(JINGLE_RTP_ERROR_CONDITIONS.at(i)).isNull()) {
-            m_rtpErrorCondition = RtpErrorCondition(i);
+    for (auto child = element.firstChildElement();
+         !child.isNull();
+         child = child.nextSiblingElement()) {
+        if (child.namespaceURI() == ns_jingle_rtp_errors) {
+            if (const auto rtpErrorConditionIndex = JINGLE_RTP_ERROR_CONDITIONS.indexOf(child.tagName()); rtpErrorConditionIndex != -1) {
+                m_rtpErrorCondition = RtpErrorCondition(rtpErrorConditionIndex);
+            }
             break;
         }
     }

--- a/src/base/QXmppJingleIq.h
+++ b/src/base/QXmppJingleIq.h
@@ -428,6 +428,15 @@ public:
             UnsupportedTransports
         };
 
+        enum RtpErrorCondition {
+            /// There is no error condition.
+            NoErrorCondition,
+            /// The encryption offer is rejected.
+            InvalidCrypto,
+            /// Encryption is required but not offered.
+            CryptoRequired
+        };
+
         Reason();
 
         QString text() const;
@@ -435,6 +444,9 @@ public:
 
         Type type() const;
         void setType(Type type);
+
+        RtpErrorCondition rtpErrorCondition() const;
+        void setRtpErrorCondition(RtpErrorCondition rtpErrorCondition);
 
         /// \cond
         void parse(const QDomElement &element);
@@ -444,6 +456,7 @@ public:
     private:
         QString m_text;
         Type m_type;
+        RtpErrorCondition m_rtpErrorCondition = NoErrorCondition;
     };
 
     QXmppJingleIq();
@@ -499,5 +512,7 @@ protected:
 private:
     QSharedDataPointer<QXmppJingleIqPrivate> d;
 };
+
+Q_DECLARE_METATYPE(QXmppJingleIq::Reason::RtpErrorCondition)
 
 #endif

--- a/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
+++ b/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
@@ -1155,6 +1155,7 @@ void tst_QXmppJingleIq::testRtpErrorCondition()
         break;
     case QXmppJingleIq::Reason::CryptoRequired:
         QVERIFY(rtpErrorCondition1 == QXmppJingleIq::Reason::CryptoRequired);
+        break;
     }
 
     serializePacket(iq1, xml);

--- a/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
+++ b/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
@@ -1189,6 +1189,7 @@ void tst_QXmppJingleIq::testRtpErrorCondition()
         break;
     case QXmppJingleIq::Reason::CryptoRequired:
         QVERIFY(rtpErrorCondition2 == QXmppJingleIq::Reason::CryptoRequired);
+        break;
     }
 
     serializePacket(iq2, xml);

--- a/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
+++ b/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
@@ -45,6 +45,8 @@ private slots:
     void testAudioPayloadType();
     void testVideoPayloadType();
     void testPayloadTypeRtpFeedbackNegotiation();
+    void testRtpErrorCondition_data();
+    void testRtpErrorCondition();
 };
 
 void tst_QXmppJingleIq::testIsSdpParameter_data()
@@ -790,7 +792,6 @@ void tst_QXmppJingleIq::testContentRtpHeaderExtensionsNegotiation()
     rtpHeaderExtensionProperty2.setId(2);
     rtpHeaderExtensionProperty2.setUri(QStringLiteral("urn:ietf:params:rtp-hdrext:ntp-64"));
 
-
     QXmppJinglePayloadType payloadType;
     payloadType.setId(96);
     payloadType.setName(QStringLiteral("speex"));
@@ -1097,6 +1098,98 @@ void tst_QXmppJingleIq::testPayloadTypeRtpFeedbackNegotiation()
     QCOMPARE(rtpFeedbackIntervals2[1].value(), uint64_t(80));
 
     serializePacket(payload2, xml);
+}
+
+void tst_QXmppJingleIq::testRtpErrorCondition_data()
+{
+    QTest::addColumn<QByteArray>("xml");
+    QTest::addColumn<QXmppJingleIq::Reason::RtpErrorCondition>("condition");
+
+    QTest::newRow("NoErrorCondition")
+        << QByteArrayLiteral("<iq type=\"set\">"
+                             "<jingle xmlns=\"urn:xmpp:jingle:1\" action=\"session-terminate\">"
+                             "<reason>"
+                             "<security-error/>"
+                             "</reason>"
+                             "</jingle>"
+                             "</iq>")
+        << QXmppJingleIq::Reason::NoErrorCondition;
+    QTest::newRow("InvalidCrypto")
+        << QByteArrayLiteral("<iq type=\"set\">"
+                             "<jingle xmlns=\"urn:xmpp:jingle:1\" action=\"session-terminate\">"
+                             "<reason>"
+                             "<security-error/>"
+                             "<invalid-crypto xmlns=\"urn:xmpp:jingle:apps:rtp:errors:1\"/>"
+                             "</reason>"
+                             "</jingle>"
+                             "</iq>")
+        << QXmppJingleIq::Reason::InvalidCrypto;
+    QTest::newRow("CryptoRequired")
+        << QByteArrayLiteral("<iq type=\"set\">"
+                             "<jingle xmlns=\"urn:xmpp:jingle:1\" action=\"session-terminate\">"
+                             "<reason>"
+                             "<security-error/>"
+                             "<crypto-required xmlns=\"urn:xmpp:jingle:apps:rtp:errors:1\"/>"
+                             "</reason>"
+                             "</jingle>"
+                             "</iq>")
+        << QXmppJingleIq::Reason::CryptoRequired;
+}
+
+void tst_QXmppJingleIq::testRtpErrorCondition()
+{
+    QFETCH(QByteArray, xml);
+    QFETCH(QXmppJingleIq::Reason::RtpErrorCondition, condition);
+
+    QXmppJingleIq iq1;
+    QCOMPARE(iq1.reason().rtpErrorCondition(), QXmppJingleIq::Reason::NoErrorCondition);
+    parsePacket(iq1, xml);
+
+    const auto rtpErrorCondition1 = iq1.reason().rtpErrorCondition();
+    switch (condition) {
+    case QXmppJingleIq::Reason::NoErrorCondition:
+        QVERIFY(rtpErrorCondition1 == QXmppJingleIq::Reason::NoErrorCondition);
+        break;
+    case QXmppJingleIq::Reason::InvalidCrypto:
+        QVERIFY(rtpErrorCondition1 == QXmppJingleIq::Reason::InvalidCrypto);
+        break;
+    case QXmppJingleIq::Reason::CryptoRequired:
+        QVERIFY(rtpErrorCondition1 == QXmppJingleIq::Reason::CryptoRequired);
+    }
+
+    serializePacket(iq1, xml);
+
+    QXmppJingleIq iq2;
+    iq2.setType(QXmppIq::Set);
+    iq2.setId({});
+    iq2.setAction(QXmppJingleIq::SessionTerminate);
+
+    switch (condition) {
+    case QXmppJingleIq::Reason::NoErrorCondition:
+        iq2.reason().setRtpErrorCondition(QXmppJingleIq::Reason::NoErrorCondition);
+        break;
+    case QXmppJingleIq::Reason::InvalidCrypto:
+        iq2.reason().setRtpErrorCondition(QXmppJingleIq::Reason::InvalidCrypto);
+        break;
+    case QXmppJingleIq::Reason::CryptoRequired:
+        iq2.reason().setRtpErrorCondition(QXmppJingleIq::Reason::CryptoRequired);
+    }
+
+    iq2.reason().setType(QXmppJingleIq::Reason::SecurityError);
+
+    const auto rtpErrorCondition2 = iq2.reason().rtpErrorCondition();
+    switch (condition) {
+    case QXmppJingleIq::Reason::NoErrorCondition:
+        QVERIFY(rtpErrorCondition2 == QXmppJingleIq::Reason::NoErrorCondition);
+        break;
+    case QXmppJingleIq::Reason::InvalidCrypto:
+        QVERIFY(rtpErrorCondition2 == QXmppJingleIq::Reason::InvalidCrypto);
+        break;
+    case QXmppJingleIq::Reason::CryptoRequired:
+        QVERIFY(rtpErrorCondition2 == QXmppJingleIq::Reason::CryptoRequired);
+    }
+
+    serializePacket(iq2, xml);
 }
 
 QTEST_MAIN(tst_QXmppJingleIq)

--- a/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
+++ b/tests/qxmppjingleiq/tst_qxmppjingleiq.cpp
@@ -1174,6 +1174,7 @@ void tst_QXmppJingleIq::testRtpErrorCondition()
         break;
     case QXmppJingleIq::Reason::CryptoRequired:
         iq2.reason().setRtpErrorCondition(QXmppJingleIq::Reason::CryptoRequired);
+        break;
     }
 
     iq2.reason().setType(QXmppJingleIq::Reason::SecurityError);


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
