### PR TITLE
skip call manager macos

### DIFF
--- a/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
+++ b/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
@@ -8,35 +8,19 @@
 
 #include "util.h"
 #include <QBuffer>
-#include <QObject>
 
 class tst_QXmppCallManager : public QObject
 {
     Q_OBJECT
 
-private slots:
-    void init();
-    void testCall();
-
-    void acceptCall(QXmppCall *call);
-
 private:
-    QXmppCall *receiverCall;
+    Q_SLOT void testCall();
 };
-
-void tst_QXmppCallManager::init()
-{
-    receiverCall = nullptr;
-}
-
-void tst_QXmppCallManager::acceptCall(QXmppCall *call)
-{
-    receiverCall = call;
-    call->accept();
-}
 
 void tst_QXmppCallManager::testCall()
 {
+    QXmppCall *receiverCall = nullptr;
+
     const QString testDomain("localhost");
     const QHostAddress testHost(QHostAddress::LocalHost);
     const quint16 testPort = 12345;
@@ -77,8 +61,10 @@ void tst_QXmppCallManager::testCall()
     // prepare receiver
     QXmppClient receiver;
     auto *receiverManager = new QXmppCallManager;
-    connect(receiverManager, &QXmppCallManager::callReceived,
-            this, &tst_QXmppCallManager::acceptCall);
+    connect(receiverManager, &QXmppCallManager::callReceived, this, [&receiverCall](QXmppCall *call) {
+        receiverCall = call;
+        call->accept();
+    });
     receiver.addExtension(receiverManager);
     receiver.setLogger(&logger);
 

--- a/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
+++ b/tests/qxmppcallmanager/tst_qxmppcallmanager.cpp
@@ -19,6 +19,10 @@ private:
 
 void tst_QXmppCallManager::testCall()
 {
+    if (!qEnvironmentVariableIsEmpty("QXMPP_TESTS_SKIP_CALL_MANAGER")) {
+        QSKIP("Skipping because 'QXMPP_TESTS_SKIP_CALL_MANAGER' was set.");
+    }
+
     QXmppCall *receiverCall = nullptr;
 
     const QString testDomain("localhost");

--- a/tests/travis/build-and-test
+++ b/tests/travis/build-and-test
@@ -33,6 +33,11 @@ if [ "$CONFIG" = "full-debug" ]; then
     export CXXFLAGS="-fprofile-arcs -ftest-coverage"
 fi
 
+# Skip currently broken call manager test on macOS
+if [ $HOST_SYSTEM = "Darwin" ]; then
+    export QXMPP_TESTS_SKIP_CALL_MANAGER=1
+fi
+
 # compile
 mkdir build
 cd build


### PR DESCRIPTION
- Clean up CallManager test
- Skip call manager tests on macOS

PR check list:
- [ ] Document your code
- [ ] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [ ] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] Update `doc/doap.xml`
- [ ] Add unit tests
- [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
