### PR TITLE
Add future-based interface with encryption to MAM manager

### DIFF
--- a/src/client/QXmppE2eeExtension.cpp
+++ b/src/client/QXmppE2eeExtension.cpp
@@ -28,6 +28,12 @@
 ///
 
 ///
+/// \typedef QXmppE2eeExtension::MessageDecryptResult
+///
+/// Contains the decrypted QXmppMessage, NotEncrypted or an QXmppError.
+///
+
+///
 /// \typedef QXmppE2eeExtension::IqEncryptResult
 ///
 /// Contains the XML serialized IQ stanza with encrypted contents or a
@@ -53,6 +59,13 @@
 ///
 
 ///
+/// \fn QXmppE2eeExtension::decryptMessage
+///
+/// Decrypts a QXmppMessage and returns the decrypted QXmppMessage. In case the message was not
+/// encrypted, QXmppE2eeExtension::NotEncrypted should be returned.
+///
+
+///
 /// \fn QXmppE2eeExtension::encryptIq
 ///
 /// Encrypts a QXmppIq and returns the serialized XML stanza with encrypted
@@ -69,4 +82,16 @@
 /// Decrypts an IQ from a DOM element and returns a fully decrypted IQ as a DOM
 /// element via QFuture. If the input was not encrypted,
 /// QXmppE2eeExtension::NotEncrypted should be returned.
+///
+
+///
+/// \fn QXmppE2eeExtension::isEncrypted(const QDomElement &)
+///
+/// Returns whether the DOM element of an IQ or message stanza is encrypted with this encryption.
+///
+
+///
+/// \fn QXmppE2eeExtension::isEncrypted(const QXmppMessage &)
+///
+/// Returns whether the message is encrypted with this encryption.
 ///

--- a/src/client/QXmppE2eeExtension.h
+++ b/src/client/QXmppE2eeExtension.h
@@ -5,6 +5,7 @@
 #ifndef QXMPPE2EEEXTENSION_H
 #define QXMPPE2EEEXTENSION_H
 
+#include "QXmppError.h"
 #include "QXmppExtension.h"
 #include "QXmppSendResult.h"
 #include "QXmppSendStanzaParams.h"
@@ -25,13 +26,16 @@ public:
     };
 
     using MessageEncryptResult = std::variant<QByteArray, QXmpp::SendError>;
+    using MessageDecryptResult = std::variant<QXmppMessage, NotEncrypted, QXmppError>;
     using IqEncryptResult = std::variant<QByteArray, QXmpp::SendError>;
     using IqDecryptResult = std::variant<QDomElement, NotEncrypted, QXmpp::SendError>;
 
     virtual QFuture<MessageEncryptResult> encryptMessage(QXmppMessage &&, const std::optional<QXmppSendStanzaParams> &) = 0;
-
+    virtual QFuture<MessageDecryptResult> decryptMessage(QXmppMessage &&) = 0;
     virtual QFuture<IqEncryptResult> encryptIq(QXmppIq &&, const std::optional<QXmppSendStanzaParams> &) = 0;
     virtual QFuture<IqDecryptResult> decryptIq(const QDomElement &) = 0;
+    virtual bool isEncrypted(const QDomElement &) = 0;
+    virtual bool isEncrypted(const QXmppMessage &) = 0;
 };
 
 #endif  // QXMPPE2EEEXTENSION_H

--- a/src/client/QXmppMamManager.cpp
+++ b/src/client/QXmppMamManager.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2016 Niels Ole Salscheider <niels_ole@salscheider-online.de>
+// SPDX-FileCopyrightText: 2022 Linus Jahn <lnj@kaidan.im>
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -7,11 +8,77 @@
 #include "QXmppClient.h"
 #include "QXmppConstants_p.h"
 #include "QXmppDataForm.h"
+#include "QXmppE2eeExtension.h"
+#include "QXmppFutureUtils_p.h"
 #include "QXmppMamIq.h"
 #include "QXmppMessage.h"
 #include "QXmppUtils.h"
 
+#include <unordered_map>
+
 #include <QDomElement>
+#include <QFuture>
+#include <QFutureInterface>
+
+using namespace QXmpp::Private;
+
+struct RetrieveRequestState
+{
+    QFutureInterface<QXmppMamManager::RetrieveResult> interface;
+    QXmppMamResultIq iq;
+    QVector<QXmppMessage> messages;
+
+    void reportFinished()
+    {
+        interface.reportResult(
+            QXmppMamManager::RetrievedMessages {
+                std::move(iq),
+                std::move(messages) });
+        interface.reportFinished();
+    }
+};
+
+class QXmppMamManagerPrivate
+{
+public:
+    // std::string because older Qt 5 versions don't add std::hash support for QString
+    std::unordered_map<std::string, RetrieveRequestState> ongoingRequests;
+};
+
+///
+/// \struct QXmppMamManager::RetrievedMessages
+///
+/// \brief Contains all retrieved messages and the result IQ that can be used for pagination.
+///
+/// \since QXmpp 1.5
+///
+
+///
+/// \var QXmppMamManager::RetrievedMessages::result
+///
+/// The returned result IQ from the MAM server.
+///
+
+///
+/// \var QXmppMamManager::RetrievedMessages::messages
+///
+/// A vector of retrieved QXmppMessages.
+///
+
+///
+/// \typedef QXmppMamManager::RetrieveResult
+///
+/// Contains RetrievedMessages or an QXmppError.
+///
+/// \since QXmpp 1.5
+///
+
+QXmppMamManager::QXmppMamManager()
+    : d(std::make_unique<QXmppMamManagerPrivate>())
+{
+}
+
+QXmppMamManager::~QXmppMamManager() = default;
 
 /// \cond
 QStringList QXmppMamManager::discoveryFeatures() const
@@ -22,23 +89,38 @@ QStringList QXmppMamManager::discoveryFeatures() const
 
 bool QXmppMamManager::handleStanza(const QDomElement &element)
 {
+
     if (element.tagName() == "message") {
         QDomElement resultElement = element.firstChildElement("result");
         if (!resultElement.isNull() && resultElement.namespaceURI() == ns_mam) {
             QDomElement forwardedElement = resultElement.firstChildElement("forwarded");
             QString queryId = resultElement.attribute("queryid");
-            if (!forwardedElement.isNull() && forwardedElement.namespaceURI() == ns_forwarding) {
-                QDomElement messageElement = forwardedElement.firstChildElement("message");
-                QDomElement delayElement = forwardedElement.firstChildElement("delay");
-                if (!messageElement.isNull()) {
-                    QXmppMessage message;
-                    message.parse(messageElement);
-                    if (!delayElement.isNull() && delayElement.namespaceURI() == ns_delayed_delivery) {
-                        const QString stamp = delayElement.attribute("stamp");
-                        message.setStamp(QXmppUtils::datetimeFromString(stamp));
-                    }
-                    emit archivedMessageReceived(queryId, message);
-                }
+
+            if (forwardedElement.isNull() || forwardedElement.namespaceURI() != ns_forwarding) {
+                return false;
+            }
+
+            auto messageElement = forwardedElement.firstChildElement("message");
+            auto delayElement = forwardedElement.firstChildElement("delay");
+
+            if (messageElement.isNull()) {
+                return false;
+            }
+
+            QXmppMessage message;
+            message.parse(messageElement);
+            if (!delayElement.isNull() && delayElement.namespaceURI() == ns_delayed_delivery) {
+                const QString stamp = delayElement.attribute("stamp");
+                message.setStamp(QXmppUtils::datetimeFromString(stamp));
+            }
+
+            auto itr = d->ongoingRequests.find(queryId.toStdString());
+            if (itr != d->ongoingRequests.end()) {
+                // future-based API
+                itr->second.messages.append(std::move(message));
+            } else {
+                // signal-based API
+                emit archivedMessageReceived(queryId, message);
             }
             return true;
         }
@@ -53,31 +135,12 @@ bool QXmppMamManager::handleStanza(const QDomElement &element)
 }
 /// \endcond
 
-/// Retrieves archived messages. For each received message, the
-/// archiveMessageReceived() signal is emitted. Once all messages are received,
-/// the resultsRecieved() signal is emitted. It returns a result set that can
-/// be used to page through the results.
-/// The number of results may be limited by the server.
-///
-/// \param to Optional entity that should be queried. Leave this empty to query
-///           the local archive.
-/// \param node Optional node that should be queried. This is used when querying
-///             a pubsub node.
-/// \param jid Optional JID to filter the results.
-/// \param start Optional start time to filter the results.
-/// \param end Optional end time to filter the results.
-/// \param resultSetQuery Optional Result Set Management query. This can be used
-///                       to limit the number of results and to page through the
-///                       archive.
-/// \return query id of the request. This can be used to associate the
-///         corresponding resultsRecieved signal.
-///
-QString QXmppMamManager::retrieveArchivedMessages(const QString &to,
-                                                  const QString &node,
-                                                  const QString &jid,
-                                                  const QDateTime &start,
-                                                  const QDateTime &end,
-                                                  const QXmppResultSetQuery &resultSetQuery)
+static QXmppMamQueryIq buildRequest(const QString &to,
+                                    const QString &node,
+                                    const QString &jid,
+                                    const QDateTime &start,
+                                    const QDateTime &end,
+                                    const QXmppResultSetQuery &resultSetQuery)
 {
     QList<QXmppDataForm::Field> fields;
 
@@ -118,6 +181,131 @@ QString QXmppMamManager::retrieveArchivedMessages(const QString &to,
     queryIq.setQueryId(queryId);
     queryIq.setForm(form);
     queryIq.setResultSetQuery(resultSetQuery);
+    return queryIq;
+}
+
+///
+/// Retrieves archived messages. For each received message, the
+/// archiveMessageReceived() signal is emitted. Once all messages are received,
+/// the resultsRecieved() signal is emitted. It returns a result set that can
+/// be used to page through the results.
+/// The number of results may be limited by the server.
+///
+/// \warning This API does not work with end-to-end encrypted messages. You can
+/// use the new QFuture-based API (retrieveMessages()) for that.
+///
+/// \param to Optional entity that should be queried. Leave this empty to query
+///           the local archive.
+/// \param node Optional node that should be queried. This is used when querying
+///             a pubsub node.
+/// \param jid Optional JID to filter the results.
+/// \param start Optional start time to filter the results.
+/// \param end Optional end time to filter the results.
+/// \param resultSetQuery Optional Result Set Management query. This can be used
+///                       to limit the number of results and to page through the
+///                       archive.
+/// \return query id of the request. This can be used to associate the
+///         corresponding resultsRecieved signal.
+///
+QString QXmppMamManager::retrieveArchivedMessages(const QString &to,
+                                                  const QString &node,
+                                                  const QString &jid,
+                                                  const QDateTime &start,
+                                                  const QDateTime &end,
+                                                  const QXmppResultSetQuery &resultSetQuery)
+{
+    auto queryIq = buildRequest(to, node, jid, start, end, resultSetQuery);
     client()->sendPacket(queryIq);
-    return queryId;
+    return queryIq.id();
+}
+
+///
+/// Retrieves archived messages and reports all messages at once via a QFuture.
+///
+/// This function tries to decrypt encrypted messages.
+///
+/// The number of results may be limited by the server.
+///
+/// \param to Optional entity that should be queried. Leave this empty to query
+///           the local archive.
+/// \param node Optional node that should be queried. This is used when querying
+///             a pubsub node.
+/// \param jid Optional JID to filter the results.
+/// \param start Optional start time to filter the results.
+/// \param end Optional end time to filter the results.
+/// \param resultSetQuery Optional Result Set Management query. This can be used
+///                       to limit the number of results and to page through the
+///                       archive.
+/// \return query id of the request. This can be used to associate the
+///         corresponding resultsRecieved signal.
+///
+/// \since QXmpp 1.5
+///
+QFuture<QXmppMamManager::RetrieveResult> QXmppMamManager::retrieveMessages(const QString &to, const QString &node, const QString &jid, const QDateTime &start, const QDateTime &end, const QXmppResultSetQuery &resultSetQuery)
+{
+    auto queryIq = buildRequest(to, node, jid, start, end, resultSetQuery);
+
+    auto [itr, _] = d->ongoingRequests.insert({ queryIq.queryId().toStdString(), RetrieveRequestState() });
+
+    // retrieve messages
+    await(client()->sendIq(std::move(queryIq)), this, [this, queryId = queryIq.queryId()](QXmppClient::IqResult result) {
+        auto itr = d->ongoingRequests.find(queryId.toStdString());
+        if (itr == d->ongoingRequests.end()) {
+            return;
+        }
+
+        if (std::holds_alternative<QDomElement>(result)) {
+            auto &iq = itr->second.iq;
+            iq.parse(std::get<QDomElement>(result));
+
+            if (iq.type() == QXmppIq::Error) {
+                itr->second.interface.reportResult(QXmppError { iq.error().text(), iq.error() });
+                itr->second.interface.reportFinished();
+                d->ongoingRequests.erase(itr);
+                return;
+            }
+
+            // decrypt encrypted messages
+            if (auto *e2eeExt = client()->encryptionExtension()) {
+                auto &messages = itr->second.messages;
+                auto running = std::make_shared<uint>(0);
+
+                for (auto i = 0; i < messages.size(); i++) {
+                    if (!e2eeExt->isEncrypted(messages.at(i))) {
+                        continue;
+                    }
+
+                    auto message = messages.at(i);
+                    (*running)++;
+                    await(e2eeExt->decryptMessage(std::move(message)), this, [this, i, running, queryId](auto result) {
+                        (*running)--;
+                        auto itr = d->ongoingRequests.find(queryId.toStdString());
+                        if (itr == d->ongoingRequests.end()) {
+                            return;
+                        }
+
+                        if (std::holds_alternative<QXmppMessage>(result)) {
+                            itr->second.messages[i] = std::get<QXmppMessage>(std::move(result));
+                        } else {
+                            warning(QStringLiteral("Error decrypting message."));
+                        }
+                        if (*running == 0) {
+                            itr->second.reportFinished();
+                            d->ongoingRequests.erase(itr);
+                        }
+                    });
+                }
+            } else {
+                itr->second.reportFinished();
+                d->ongoingRequests.erase(itr);
+            }
+        } else {
+            auto &error = std::get<QXmpp::SendError>(result);
+            itr->second.interface.reportResult(QXmppError { error.text, error });
+            itr->second.interface.reportFinished();
+            d->ongoingRequests.erase(itr);
+        }
+    });
+
+    return itr->second.interface.future();
 }

--- a/src/client/QXmppMamManager.h
+++ b/src/client/QXmppMamManager.h
@@ -6,11 +6,18 @@
 #define QXMPPMAMMANAGER_H
 
 #include "QXmppClientExtension.h"
+#include "QXmppError.h"
+#include "QXmppMamIq.h"
 #include "QXmppResultSet.h"
+
+#include <variant>
 
 #include <QDateTime>
 
+template<typename T>
+class QFuture;
 class QXmppMessage;
+class QXmppMamManagerPrivate;
 
 ///
 /// \brief The QXmppMamManager class makes it possible to access message
@@ -33,12 +40,29 @@ class QXMPP_EXPORT QXmppMamManager : public QXmppClientExtension
     Q_OBJECT
 
 public:
+    struct RetrievedMessages
+    {
+        QXmppMamResultIq result;
+        QVector<QXmppMessage> messages;
+    };
+
+    using RetrieveResult = std::variant<RetrievedMessages, QXmppError>;
+
+    QXmppMamManager();
+    ~QXmppMamManager();
+
     QString retrieveArchivedMessages(const QString &to = QString(),
                                      const QString &node = QString(),
                                      const QString &jid = QString(),
                                      const QDateTime &start = QDateTime(),
                                      const QDateTime &end = QDateTime(),
                                      const QXmppResultSetQuery &resultSetQuery = QXmppResultSetQuery());
+    QFuture<RetrieveResult> retrieveMessages(const QString &to = QString(),
+                                             const QString &node = QString(),
+                                             const QString &jid = QString(),
+                                             const QDateTime &start = QDateTime(),
+                                             const QDateTime &end = QDateTime(),
+                                             const QXmppResultSetQuery &resultSetQuery = QXmppResultSetQuery());
 
     /// \cond
     QStringList discoveryFeatures() const override;
@@ -54,6 +78,9 @@ Q_SIGNALS:
     void resultsRecieved(const QString &queryId,
                          const QXmppResultSetReply &resultSetReply,
                          bool complete);
+
+private:
+    std::unique_ptr<QXmppMamManagerPrivate> d;
 };
 
 #endif

--- a/src/omemo/QXmppOmemoManager.h
+++ b/src/omemo/QXmppOmemoManager.h
@@ -125,9 +125,13 @@ public:
 
     /// \cond
     QFuture<MessageEncryptResult> encryptMessage(QXmppMessage &&message, const std::optional<QXmppSendStanzaParams> &params) override;
+    QFuture<MessageDecryptResult> decryptMessage(QXmppMessage &&message) override;
 
     QFuture<IqEncryptResult> encryptIq(QXmppIq &&iq, const std::optional<QXmppSendStanzaParams> &params) override;
     QFuture<IqDecryptResult> decryptIq(const QDomElement &element) override;
+
+    bool isEncrypted(const QDomElement &) override;
+    bool isEncrypted(const QXmppMessage &) override;
 
     QStringList discoveryFeatures() const override;
     bool handleStanza(const QDomElement &stanza) override;

--- a/tests/qxmppclient/tst_qxmppclient.cpp
+++ b/tests/qxmppclient/tst_qxmppclient.cpp
@@ -103,6 +103,8 @@ public:
         return makeReadyFuture<MessageEncryptResult>(QXmpp::SendError { "it's only a test", QXmpp::SendError::EncryptionError });
     }
 
+    QFuture<MessageDecryptResult> decryptMessage(QXmppMessage &&) override { return {}; };
+
     QFuture<IqEncryptResult> encryptIq(QXmppIq &&, const std::optional<QXmppSendStanzaParams> &) override
     {
         iqCalled = true;
@@ -113,6 +115,9 @@ public:
     {
         return makeReadyFuture<IqDecryptResult>(QXmpp::SendError { "it's only a test", QXmpp::SendError::EncryptionError });
     }
+
+    bool isEncrypted(const QDomElement &) override { return false; };
+    bool isEncrypted(const QXmppMessage &) override { return false; };
 };
 
 void tst_QXmppClient::testE2eeExtension()


### PR DESCRIPTION
- E2eeExtension: Add isEncrypted() and decryptMessage() functions
- OmemoManager: Implement isEncrypted() and decryptMessage()
- MamManager: Add future based interface with encryption support

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [ ] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
