### PR TITLE
E2eeExtension: Return encrypted stanzas as Message/Iq instead of XML

### DIFF
--- a/src/client/QXmppE2eeExtension.h
+++ b/src/client/QXmppE2eeExtension.h
@@ -10,6 +10,7 @@
 #include "QXmppSendResult.h"
 #include "QXmppSendStanzaParams.h"
 
+#include <memory>
 #include <optional>
 
 class QDomElement;
@@ -25,9 +26,9 @@ public:
     {
     };
 
-    using MessageEncryptResult = std::variant<QByteArray, QXmppError>;
+    using MessageEncryptResult = std::variant<std::unique_ptr<QXmppMessage>, QXmppError>;
     using MessageDecryptResult = std::variant<QXmppMessage, NotEncrypted, QXmppError>;
-    using IqEncryptResult = std::variant<QByteArray, QXmppError>;
+    using IqEncryptResult = std::variant<std::unique_ptr<QXmppIq>, QXmppError>;
     using IqDecryptResult = std::variant<QDomElement, NotEncrypted, QXmppError>;
 
     virtual QXmppTask<MessageEncryptResult> encryptMessage(QXmppMessage &&, const std::optional<QXmppSendStanzaParams> &) = 0;

--- a/src/omemo/QXmppOmemoManager.cpp
+++ b/src/omemo/QXmppOmemoManager.cpp
@@ -1061,19 +1061,15 @@ QXmppTask<QXmppE2eeExtension::IqEncryptResult> Manager::encryptIq(QXmppIq &&iq, 
                     SendError::EncryptionError });
 
             } else {
-                QXmppOmemoIq omemoIq;
-                omemoIq.setId(iq.id());
-                omemoIq.setType(iq.type());
-                omemoIq.setLang(iq.lang());
-                omemoIq.setFrom(iq.from());
-                omemoIq.setTo(iq.to());
-                omemoIq.setOmemoElement(*omemoElement);
+                auto omemoIq = std::make_unique<QXmppOmemoIq>();
+                omemoIq->setId(iq.id());
+                omemoIq->setType(iq.type());
+                omemoIq->setLang(iq.lang());
+                omemoIq->setFrom(iq.from());
+                omemoIq->setTo(iq.to());
+                omemoIq->setOmemoElement(*omemoElement);
 
-                QByteArray serializedEncryptedIq;
-                QXmlStreamWriter writer(&serializedEncryptedIq);
-                omemoIq.toXml(&writer);
-
-                interface.finish(serializedEncryptedIq);
+                interface.finish(std::move(omemoIq));
             }
         });
     }

--- a/src/omemo/QXmppOmemoManager_p.cpp
+++ b/src/omemo/QXmppOmemoManager_p.cpp
@@ -1090,11 +1090,7 @@ QXmppTask<QXmppE2eeExtension::MessageEncryptResult> ManagerPrivate::encryptMessa
 
                 message.setOmemoElement(omemoElement);
 
-                QByteArray serializedEncryptedMessage;
-                QXmlStreamWriter writer(&serializedEncryptedMessage);
-                message.toXml(&writer, QXmpp::ScePublic);
-
-                interface.finish(serializedEncryptedMessage);
+                interface.finish(std::make_unique<QXmppMessage>(std::move(message)));
             }
         });
     }


### PR DESCRIPTION
Part of #513.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
