### PR TITLE
tests: StreamInitiationIq: Fix usage of 'Q_SLOT' instead of 'slots:'

### DIFF
--- a/tests/qxmppstreaminitiationiq/tst_qxmppstreaminitiationiq.cpp
+++ b/tests/qxmppstreaminitiationiq/tst_qxmppstreaminitiationiq.cpp
@@ -12,11 +12,11 @@ class tst_QXmppStreamInitiationIq : public QObject
 {
     Q_OBJECT
 
-private slots:
-    void testFileInfo_data();
-    void testFileInfo();
-    void testOffer();
-    void testResult();
+private:
+    Q_SLOT void testFileInfo_data();
+    Q_SLOT void testFileInfo();
+    Q_SLOT void testOffer();
+    Q_SLOT void testResult();
 };
 
 void tst_QXmppStreamInitiationIq::testFileInfo_data()

--- a/tests/qxmppstreaminitiationiq/tst_qxmppstreaminitiationiq.cpp
+++ b/tests/qxmppstreaminitiationiq/tst_qxmppstreaminitiationiq.cpp
@@ -12,7 +12,6 @@ class tst_QXmppStreamInitiationIq : public QObject
 {
     Q_OBJECT
 
-private:
     Q_SLOT void testFileInfo_data();
     Q_SLOT void testFileInfo();
     Q_SLOT void testOffer();


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
