### PR TITLE
Fix: remove unused variable

### DIFF
--- a/tests/qxmppdiscoverymanager/tst_qxmppdiscoverymanager.cpp
+++ b/tests/qxmppdiscoverymanager/tst_qxmppdiscoverymanager.cpp
@@ -59,7 +59,6 @@ void tst_QXmppDiscoveryManager::testItems()
 
     const auto items = expectFutureVariant<QList<QXmppDiscoveryIq::Item>>(future.toFuture(this));
 
-    const QStringList expFeatures = { "http://jabber.org/protocol/pubsub", "urn:xmpp:mix:core:1" };
     QCOMPARE(items.size(), 4);
     QCOMPARE(items.at(0).name(), QStringLiteral("368866411b877c30064a5f62b917cffe"));
     QCOMPARE(items.at(1).name(), QStringLiteral("3300659945416e274474e469a1f0154c"));


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

Removed unused variable in QXmppDiscoveryManager test.