### PR TITLE
CarbonManagerV2: Fix enabling carbons

### DIFF
--- a/src/client/QXmppCarbonManagerV2.cpp
+++ b/src/client/QXmppCarbonManagerV2.cpp
@@ -18,9 +18,10 @@ using namespace QXmpp::Private;
 class CarbonEnableIq : public QXmppIq
 {
 public:
-    CarbonEnableIq()
+    CarbonEnableIq(const QString &jid)
         : QXmppIq()
     {
+        setTo(jid);
         setType(QXmppIq::Set);
     }
 
@@ -30,7 +31,8 @@ public:
     }
     void toXmlElementFromChild(QXmlStreamWriter *writer) const override
     {
-        writer->writeStartElement(ns_carbons, "enable");
+        writer->writeStartElement(QStringLiteral("enable"));
+        writer->writeDefaultNamespace(ns_carbons);
         writer->writeEndElement();
     }
 };
@@ -163,7 +165,7 @@ void QXmppCarbonManagerV2::enableCarbons()
         return;
     }
 
-    client()->sendIq(CarbonEnableIq()).then(this, [this](QXmppClient::IqResult domResult) {
+    client()->sendIq(CarbonEnableIq(client()->configuration().jidBare())).then(this, [this](QXmppClient::IqResult domResult) {
         if (auto err = parseIq(std::move(domResult))) {
             warning("Could not enable message carbons: " % err->description);
         } else {


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
