### PR TITLE
Fix building Kaidan against QXmpp with MSVC 2019

### DIFF
--- a/src/base/QXmppMamIq.h
+++ b/src/base/QXmppMamIq.h
@@ -14,7 +14,7 @@
 class QXmppMamQueryIqPrivate;
 class QXmppMamResultIqPrivate;
 
-class QXmppMamQueryIq : public QXmppIq
+class QXMPP_EXPORT QXmppMamQueryIq : public QXmppIq
 {
 public:
     QXmppMamQueryIq();
@@ -46,7 +46,7 @@ private:
     QSharedDataPointer<QXmppMamQueryIqPrivate> d;
 };
 
-class QXmppMamResultIq : public QXmppIq
+class QXMPP_EXPORT QXmppMamResultIq : public QXmppIq
 {
 public:
     QXmppMamResultIq();

--- a/src/base/QXmppPubSubIq_p.h
+++ b/src/base/QXmppPubSubIq_p.h
@@ -151,7 +151,7 @@ void PubSubIq<T>::parseItems(const QDomElement &queryElement)
          childElement = childElement.nextSiblingElement(QStringLiteral("item"))) {
         T item;
         item.parse(childElement);
-        m_items << std::move(item);
+        m_items.push_back(std::move(item));
     }
 }
 

--- a/src/client/QXmppMamManager.h
+++ b/src/client/QXmppMamManager.h
@@ -40,7 +40,7 @@ class QXMPP_EXPORT QXmppMamManager : public QXmppClientExtension
     Q_OBJECT
 
 public:
-    struct RetrievedMessages
+    struct QXMPP_EXPORT RetrievedMessages
     {
         QXmppMamResultIq result;
         QVector<QXmppMessage> messages;


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
