### PR TITLE
Add an ability to chose Qt major version from outside of the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/modules")
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Network Xml)
+if(NOT DEFINED QT_VERSION_MAJOR)
+    find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Network Xml)
+endif()
 message("-- Choosing Qt ${QT_VERSION_MAJOR}")
 find_package(Qt${QT_VERSION_MAJOR} 5.9.2 REQUIRED COMPONENTS Core Network Xml)
+
 # QCA (optional)
 find_package(Qca-qt${QT_VERSION_MAJOR} QUIET)
 if(${QT_VERSION_MAJOR} EQUAL 6)


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
This commit adds the ability to chose Qt Major Version from outside of the project.


The way it's written right now if a host have some Qt6 packages installed qxmpp automatically builds against Qt6 and there is no other way to affect it apart from patches ([read the comments here](https://aur.archlinux.org/packages/qxmpp))


The way I suggest it's going to change nothing by default but if someone is building qxmpp from other CMake project qxmpp is going to be build to the corresponding version of Qt of the parent project. This also is going to enable a way to quickly change Qt version with cmake build flags like `-D QT_MAJOR_VERSION=5` or `-D QT_MAJOR_VERSION=6`