### PR TITLE
MamManager: Fix crash when reading .size() from a deleted QVector

### DIFF
--- a/src/client/QXmppMamManager.cpp
+++ b/src/client/QXmppMamManager.cpp
@@ -339,7 +339,8 @@ QXmppTask<QXmppMamManager::RetrieveResult> QXmppMamManager::retrieveMessages(con
             // because some decryptMessage() jobs could finish instantly
             state.runningDecryptionJobs = encryptedCount;
 
-            for (auto i = 0; i < state.messages.size(); i++) {
+            int size = state.messages.size();
+            for (auto i = 0; i < size; i++) {
                 if (!messagesEncrypted[i]) {
                     continue;
                 }


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
