### PR TITLE
QXmppOmemo: Fix ODR violation

### DIFF
--- a/src/omemo/QXmppOmemoData.cpp
+++ b/src/omemo/QXmppOmemoData.cpp
@@ -13,7 +13,7 @@
 #include <QDomElement>
 #include <QHash>
 
-const char *ns_omemo_2 = "urn:xmpp:omemo:2";
+constexpr auto ns_omemo_2 = "urn:xmpp:omemo:2";
 
 /// \cond
 ///

--- a/src/omemo/QXmppOmemoManager_p.cpp
+++ b/src/omemo/QXmppOmemoManager_p.cpp
@@ -38,14 +38,14 @@ using Error = QXmppStanza::Error;
 using Manager = QXmppOmemoManager;
 using ManagerPrivate = QXmppOmemoManagerPrivate;
 
-const char *ns_client = "jabber:client";
-const char *ns_pubsub_auto_create = "http://jabber.org/protocol/pubsub#auto-create";
-const char *ns_pubsub_config_node = "http://jabber.org/protocol/pubsub#config-node";
-const char *ns_pubsub_config_node_max = "http://jabber.org/protocol/pubsub#config-node-max";
-const char *ns_pubsub_create_and_configure = "http://jabber.org/protocol/pubsub#create-and-configure";
-const char *ns_pubsub_create_nodes = "http://jabber.org/protocol/pubsub#create-nodes";
-const char *ns_pubsub_publish = "http://jabber.org/protocol/pubsub#publish";
-const char *ns_pubsub_publish_options = "http://jabber.org/protocol/pubsub#publish-options";
+constexpr auto ns_client = "jabber:client";
+constexpr auto ns_pubsub_auto_create = "http://jabber.org/protocol/pubsub#auto-create";
+constexpr auto ns_pubsub_config_node = "http://jabber.org/protocol/pubsub#config-node";
+constexpr auto ns_pubsub_config_node_max = "http://jabber.org/protocol/pubsub#config-node-max";
+constexpr auto ns_pubsub_create_and_configure = "http://jabber.org/protocol/pubsub#create-and-configure";
+constexpr auto ns_pubsub_create_nodes = "http://jabber.org/protocol/pubsub#create-nodes";
+constexpr auto ns_pubsub_publish = "http://jabber.org/protocol/pubsub#publish";
+constexpr auto ns_pubsub_publish_options = "http://jabber.org/protocol/pubsub#publish-options";
 
 namespace QXmpp::Omemo::Private {
 


### PR DESCRIPTION
I wrote the problematic code, so yay

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
