### PR TITLE
Fix the generated qxmpp pkgconfig files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,16 +126,16 @@ install(
 )
 
 # Generate QXmppQt5/6.pc
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qxmpp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/qxmpp.pc @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qxmpp.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${QXMPP_TARGET}.pc @ONLY)
 install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/qxmpp.pc
-    RENAME QXmppQt${QT_VERSION_MAJOR}.pc
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/${QXMPP_TARGET}.pc
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
     COMPONENT Devel
 )
 
 # "qxmpp.pc" for backwards-compatibility
 if(QT_VERSION_MAJOR EQUAL 5)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/qxmpp_legacy.pc.in ${CMAKE_CURRENT_BINARY_DIR}/qxmpp.pc @ONLY)
     install(
         FILES ${CMAKE_CURRENT_BINARY_DIR}/qxmpp.pc
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"

--- a/qxmpp_legacy.pc.in
+++ b/qxmpp_legacy.pc.in
@@ -5,13 +5,13 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@QXMPP_TARGET@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/QXmppQt5
 
 
-Name: @QXMPP_TARGET@
+Name: Qxmpp
 Description: QXmpp Library
 Version: @PROJECT_VERSION@
-Libs: -l@QXMPP_TARGET@
-Libs.private: -lQt@QT_VERSION_MAJOR@Network -lQt@QT_VERSION_MAJOR@Xml -lQt@QT_VERSION_MAJOR@Core
+Requires: QXmppQt5
+Libs: -lQXmppQt5
 Cflags: -I${includedir}
 


### PR DESCRIPTION
The include directory and link targets changed.
Also add a backward compatible pkgconfig file for Qt5 builds.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
