### PR TITLE
Implement history settings from XEP-0045

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ set(INSTALL_HEADER_FILES
     base/QXmppMixIq.h
     base/QXmppMixParticipantItem.h
     base/QXmppMucIq.h
+    base/QXmppMucHistory.h
     base/QXmppNonza.h
     base/QXmppNonSASLAuth.h
     base/QXmppOutOfBandUrl.h
@@ -183,6 +184,7 @@ set(SOURCE_FILES
     base/QXmppMixIq.cpp
     base/QXmppMixItems.cpp
     base/QXmppMucIq.cpp
+    base/QXmppMucHistory.cpp
     base/QXmppNonza.cpp
     base/QXmppNonSASLAuth.cpp
     base/QXmppOutOfBandUrl.cpp

--- a/src/base/QXmppMucHistory.cpp
+++ b/src/base/QXmppMucHistory.cpp
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: 2023 Matthieu Volat <mazhe@alkumuna.eu>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "QXmppMucHistory.h"
+
+#include "QXmppConstants_p.h"
+#include "QXmppUtils.h"
+
+#include <QDomElement>
+
+QXmppMucHistory::QXmppMucHistory()
+    : m_maxchars(-1),
+      m_maxstanzas(-1),
+      m_seconds(-1)
+{
+}
+
+/// Returns true if the history is not configured (is null).
+
+bool QXmppMucHistory::isNull() const
+{
+    return m_maxchars < 0 &&
+        m_maxstanzas < 0 &&
+        m_seconds < 0 &&
+        !m_since.isValid();
+}
+
+/// Returns the character limit of the room history.
+
+int QXmppMucHistory::maxchars() const
+{
+    return m_maxchars;
+}
+
+/// Sets the character limit of the room history.
+
+void QXmppMucHistory::setMaxchars(int maxchars)
+{
+    m_maxchars = maxchars;
+}
+
+/// Returns the stanza limit of the room history.
+
+int QXmppMucHistory::maxstanzas() const
+{
+    return m_maxstanzas;
+}
+
+/// Sets the stanza limit of the room history.
+
+void QXmppMucHistory::setMaxstanzas(int maxstanzas)
+{
+    m_maxstanzas = maxstanzas;
+}
+
+/// Returns the seconds limit of the room history.
+
+int QXmppMucHistory::seconds() const
+{
+    return m_seconds;
+}
+
+/// Sets the seconds limit of the room history.
+
+void QXmppMucHistory::setSeconds(int seconds)
+{
+    m_seconds = seconds;
+}
+
+/// Returns the datetime limit of the room history.
+
+QDateTime QXmppMucHistory::since() const
+{
+    return m_since;
+}
+
+/// Sets the datetime limit of the room history.
+
+void QXmppMucHistory::setSince(QDateTime &since)
+{
+    m_since = since;
+}
+
+/// \cond
+void QXmppMucHistory::parse(const QDomElement &element)
+{
+    m_maxchars = element.attribute(QStringLiteral("maxchars")).toUInt();
+    m_maxstanzas = element.attribute(QStringLiteral("maxstanzas")).toUInt();
+    m_seconds = element.attribute(QStringLiteral("seconds")).toUInt();
+    m_since = QXmppUtils::datetimeFromString(element.attribute(QStringLiteral("since")));
+}
+
+void QXmppMucHistory::toXml(QXmlStreamWriter *writer) const
+{
+	if (isNull())
+    {
+        return;
+    }
+    writer->writeStartElement(QStringLiteral("history"));
+    if (m_maxchars >= 0)
+    {
+        helperToXmlAddAttribute(writer, QStringLiteral("maxchars"), QString::number(m_maxchars));
+    }
+    if (m_maxstanzas >= 0)
+    {
+        helperToXmlAddAttribute(writer, QStringLiteral("maxstanzas"), QString::number(m_maxstanzas));
+    }
+    if (m_seconds >= 0)
+    {
+        helperToXmlAddAttribute(writer, QStringLiteral("seconds"), QString::number(m_seconds));
+    }
+    if (m_since.isValid())
+    {
+        helperToXmlAddAttribute(writer, QStringLiteral("since"), QXmppUtils::datetimeToString(m_since));
+    }
+    writer->writeEndElement();
+}
+/// \endcond

--- a/src/base/QXmppMucHistory.cpp
+++ b/src/base/QXmppMucHistory.cpp
@@ -93,25 +93,20 @@ void QXmppMucHistory::parse(const QDomElement &element)
 
 void QXmppMucHistory::toXml(QXmlStreamWriter *writer) const
 {
-	if (isNull())
-    {
+    if (isNull()) {
         return;
     }
     writer->writeStartElement(QStringLiteral("history"));
-    if (m_maxchars >= 0)
-    {
+    if (m_maxchars >= 0) {
         helperToXmlAddAttribute(writer, QStringLiteral("maxchars"), QString::number(m_maxchars));
     }
-    if (m_maxstanzas >= 0)
-    {
+    if (m_maxstanzas >= 0) {
         helperToXmlAddAttribute(writer, QStringLiteral("maxstanzas"), QString::number(m_maxstanzas));
     }
-    if (m_seconds >= 0)
-    {
+    if (m_seconds >= 0) {
         helperToXmlAddAttribute(writer, QStringLiteral("seconds"), QString::number(m_seconds));
     }
-    if (m_since.isValid())
-    {
+    if (m_since.isValid()) {
         helperToXmlAddAttribute(writer, QStringLiteral("since"), QXmppUtils::datetimeToString(m_since));
     }
     writer->writeEndElement();

--- a/src/base/QXmppMucHistory.h
+++ b/src/base/QXmppMucHistory.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2023 Matthieu Volat <mazhe@alkumuna.eu>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPMUCHISTORY_H
+#define QXMPPMUCHISTORY_H
+
+#include "QXmppStanza.h"
+#include <QDateTime>
+
+/// \brief The QXmppMucHistory class represents a room history request
+///
+/// It is used to manage how much history should be requested and received 
+/// when joining a room.
+///
+/// \ingroup Stanzas
+
+class QXMPP_EXPORT QXmppMucHistory
+{
+public:
+    QXmppMucHistory();
+    bool isNull() const;
+
+    int maxchars() const;
+	void setMaxchars(int maxchars);
+
+    int maxstanzas() const;
+	void setMaxstanzas(int maxstanzas);
+
+    int seconds() const;
+	void setSeconds(int seconds);
+
+    QDateTime since() const;
+    void setSince(QDateTime &since);
+
+    /// \cond
+    void parse(const QDomElement &element);
+    void toXml(QXmlStreamWriter *writer) const;
+    /// \endcond
+private:
+    int m_maxchars;
+    int m_maxstanzas;
+    int m_seconds;
+    QDateTime m_since;
+};
+
+#endif

--- a/src/base/QXmppMucHistory.h
+++ b/src/base/QXmppMucHistory.h
@@ -6,11 +6,12 @@
 #define QXMPPMUCHISTORY_H
 
 #include "QXmppStanza.h"
+
 #include <QDateTime>
 
 /// \brief The QXmppMucHistory class represents a room history request
 ///
-/// It is used to manage how much history should be requested and received 
+/// It is used to manage how much history should be requested and received
 /// when joining a room.
 ///
 /// \ingroup Stanzas
@@ -22,13 +23,13 @@ public:
     bool isNull() const;
 
     int maxchars() const;
-	void setMaxchars(int maxchars);
+    void setMaxchars(int maxchars);
 
     int maxstanzas() const;
-	void setMaxstanzas(int maxstanzas);
+    void setMaxstanzas(int maxstanzas);
 
     int seconds() const;
-	void setSeconds(int seconds);
+    void setSeconds(int seconds);
 
     QDateTime since() const;
     void setSince(QDateTime &since);

--- a/src/base/QXmppPresence.cpp
+++ b/src/base/QXmppPresence.cpp
@@ -46,6 +46,7 @@ public:
     QXmppMucItem mucItem;
     QString mucPassword;
     QList<int> mucStatusCodes;
+    QXmppMucHistory mucHistory;
     bool mucSupported;
 
     // XEP-0115: Entity Capabilities
@@ -353,6 +354,22 @@ void QXmppPresence::setMucStatusCodes(const QList<int> &codes)
     d->mucStatusCodes = codes;
 }
 
+/// Returns the MUC history limits
+
+QXmppMucHistory QXmppPresence::mucHistory() const
+{
+    return d->mucHistory;
+}
+
+/// Set the MUC history limits
+///
+/// \param history
+
+void QXmppPresence::setMucHistory(const QXmppMucHistory &history)
+{
+    d->mucHistory = history;
+}
+
 /// Returns true if the sender has indicated MUC support.
 
 bool QXmppPresence::isMucSupported() const
@@ -551,6 +568,10 @@ void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
     if (d->mucSupported) {
         xmlWriter->writeStartElement(QStringLiteral("x"));
         xmlWriter->writeDefaultNamespace(ns_muc);
+        if (!d->mucHistory.isNull())
+        {
+            d->mucHistory.toXml(xmlWriter);
+        }
         if (!d->mucPassword.isEmpty()) {
             xmlWriter->writeTextElement(QStringLiteral("password"), d->mucPassword);
         }

--- a/src/base/QXmppPresence.h
+++ b/src/base/QXmppPresence.h
@@ -8,6 +8,7 @@
 
 #include "QXmppJingleIq.h"
 #include "QXmppMucIq.h"
+#include "QXmppMucHistory.h"
 #include "QXmppStanza.h"
 
 class QXmppPresencePrivate;
@@ -85,6 +86,9 @@ public:
 
     QList<int> mucStatusCodes() const;
     void setMucStatusCodes(const QList<int> &codes);
+
+    QXmppMucHistory mucHistory() const;
+    void setMucHistory(const QXmppMucHistory &history);
 
     bool isMucSupported() const;
     void setMucSupported(bool supported);

--- a/src/client/QXmppMucManager.cpp
+++ b/src/client/QXmppMucManager.cpp
@@ -241,6 +241,26 @@ bool QXmppMucRoom::join()
     return d->client->sendPacket(packet);
 }
 
+/// Joins the chat room with history parameters.
+///
+/// \return true if the request was sent, false otherwise
+
+bool QXmppMucRoom::join(QXmppMucHistory &history)
+{
+    if (isJoined() || d->nickName.isEmpty()) {
+        return false;
+    }
+
+    // reflect our current presence in the chat room
+    QXmppPresence packet = d->client->clientPresence();
+    packet.setTo(d->ownJid());
+    packet.setType(QXmppPresence::Available);
+    packet.setMucPassword(d->password);
+    packet.setMucHistory(history);
+    packet.setMucSupported(true);
+    return d->client->sendPacket(packet);
+}
+
 /// Kicks the specified user from the chat room.
 ///
 /// The specified \a jid is the Occupant JID of the form "room@service/nick".

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -6,6 +6,7 @@
 #define QXMPPMUCMANAGER_H
 
 #include "QXmppClientExtension.h"
+#include "QXmppMucHistory.h"
 #include "QXmppMucIq.h"
 #include "QXmppPresence.h"
 
@@ -218,6 +219,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     bool ban(const QString &jid, const QString &reason);
     bool join();
+    bool join(QXmppMucHistory &history);
     bool kick(const QString &jid, const QString &reason);
     bool leave(const QString &message = QString());
     bool requestConfiguration();


### PR DESCRIPTION
PR check list:
- [X] Document your code
- [X] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [X] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] Update `doc/doap.xml`
- [ ] Add unit tests
- [X] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->

Hi, first thanks for your work on the QXmpp project. I am noticing that there is actually no way ton control how much history is send when joining a MUC room. Some clients might want to even disable it to use MAM instead.

I have put together some code to have this ability, basically it add a QXmppMucHistory (not fond of the name, but that's the node name in the spec) element to be used in QXmppPresence and an overloaded version of QXmppMucRoom::join() so that history can, for example, be disabled doing:
```
QXmppMucRoom *room = manager->addRoom("room@conference.example.com");
room->setNickName("mynick");
QXmppMucHistory history;
history.setMaxchars(0);
room->join(history);
```
I realize this is not really ideal, this is a bit of a request for comments, I could change it to be stored in `QXmppMucRoom` if you think this is better.

Also, I don't think there is a MUC testsuite to add some testing? Should I add something in the QXmppPresence testing?