### PR TITLE
Don't search for your headers in your install dir, when building the lib

### DIFF
--- a/src/omemo/CMakeLists.txt
+++ b/src/omemo/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(${QXMPPOMEMO_TARGET}
     qca-qt${QT_VERSION_MAJOR}
 )
 target_include_directories(${QXMPPOMEMO_TARGET}
-    PUBLIC
+    INTERFACE
     ${OMEMO_HEADER_DIR}
     PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}


### PR DESCRIPTION
This leads to "not found" warnings with -Wmissing-include-dirs but worse, it will one day lead to build errors when having different APIs in the installed headers and locally (after making changes)

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
