### PR TITLE
Replace '#ifndef QXMPP*_H' with '#pragma once'

### DIFF
--- a/src/base/QXmppArchiveIq.h
+++ b/src/base/QXmppArchiveIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPARCHIVEIQ_H
-#define QXMPPARCHIVEIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 #include "QXmppResultSet.h"
@@ -224,5 +223,3 @@ protected:
     void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 };
-
-#endif  // QXMPPARCHIVEIQ_H

--- a/src/base/QXmppBindIq.h
+++ b/src/base/QXmppBindIq.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBINDIQ_H
-#define QXMPPBINDIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -36,5 +35,3 @@ private:
     QString m_jid;
     QString m_resource;
 };
-
-#endif  // QXMPPBIND_H

--- a/src/base/QXmppBitsOfBinaryContentId.h
+++ b/src/base/QXmppBitsOfBinaryContentId.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBITSOFBINARYCONTENTID_H
-#define QXMPPBITSOFBINARYCONTENTID_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -44,5 +43,3 @@ public:
 private:
     QSharedDataPointer<QXmppBitsOfBinaryContentIdPrivate> d;
 };
-
-#endif  // QXMPPBITSOFBINARYCONTENTID_H

--- a/src/base/QXmppBitsOfBinaryData.h
+++ b/src/base/QXmppBitsOfBinaryData.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBITSOFBINARYDATA_H
-#define QXMPPBITSOFBINARYDATA_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -52,5 +51,3 @@ public:
 private:
     QSharedDataPointer<QXmppBitsOfBinaryDataPrivate> d;
 };
-
-#endif  // QXMPPBITSOFBINARYDATA_H

--- a/src/base/QXmppBitsOfBinaryDataList.h
+++ b/src/base/QXmppBitsOfBinaryDataList.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBITSOFBINARYDATACONTAINER_H
-#define QXMPPBITSOFBINARYDATACONTAINER_H
+#pragma once
 
 #include "QXmppBitsOfBinaryData.h"
 
@@ -26,5 +25,3 @@ public:
     void toXml(QXmlStreamWriter *writer) const;
     /// \endcond
 };
-
-#endif  // QXMPPBITSOFBINARYDATACONTAINER_H

--- a/src/base/QXmppBitsOfBinaryIq.h
+++ b/src/base/QXmppBitsOfBinaryIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBITSOFBINARYIQ_H
-#define QXMPPBITSOFBINARYIQ_H
+#pragma once
 
 #include "QXmppBitsOfBinaryData.h"
 #include "QXmppIq.h"
@@ -22,5 +21,3 @@ protected:
     void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 };
-
-#endif  // QXMPPBITSOFBINARYIQ_H

--- a/src/base/QXmppBookmarkSet.h
+++ b/src/base/QXmppBookmarkSet.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBOOKMARKSET_H
-#define QXMPPBOOKMARKSET_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -76,5 +75,3 @@ private:
     QList<QXmppBookmarkConference> m_conferences;
     QList<QXmppBookmarkUrl> m_urls;
 };
-
-#endif

--- a/src/base/QXmppByteStreamIq.h
+++ b/src/base/QXmppByteStreamIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBYTESTREAMIQ_H
-#define QXMPPBYTESTREAMIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -71,5 +70,3 @@ private:
     QList<StreamHost> m_streamHosts;
     QString m_streamHostUsed;
 };
-
-#endif

--- a/src/base/QXmppConstants_p.h
+++ b/src/base/QXmppConstants_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCONSTANTS_H
-#define QXMPPCONSTANTS_H
+#pragma once
 
 //
 //  W A R N I N G
@@ -227,5 +226,3 @@ extern const char *ns_esfs;
 extern const char *ns_atm;
 // XEP-0482: Call Invites
 extern const char *ns_call_invites;
-
-#endif  // QXMPPCONSTANTS_H

--- a/src/base/QXmppDataForm.h
+++ b/src/base/QXmppDataForm.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPDATAFORM_H
-#define QXMPPDATAFORM_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -212,5 +211,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppDataForm)
-
-#endif

--- a/src/base/QXmppDataFormBase.h
+++ b/src/base/QXmppDataFormBase.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPDATAFORMBASED_H
-#define QXMPPDATAFORMBASED_H
+#pragma once
 
 #include "QXmppDataForm.h"
 
@@ -120,5 +119,3 @@ protected:
 private:
     QSharedDataPointer<QXmppExtensibleDataFormBasePrivate> d;
 };
-
-#endif  // QXMPPDATAFORMBASED_H

--- a/src/base/QXmppDiscoveryIq.h
+++ b/src/base/QXmppDiscoveryIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPDISCOVERY_H
-#define QXMPPDISCOVERY_H
+#pragma once
 
 #include "QXmppDataForm.h"
 #include "QXmppIq.h"
@@ -113,5 +112,3 @@ protected:
 private:
     QSharedDataPointer<QXmppDiscoveryIqPrivate> d;
 };
-
-#endif

--- a/src/base/QXmppE2eeMetadata.h
+++ b/src/base/QXmppE2eeMetadata.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPE2EEMETADATA_H
-#define QXMPPE2EEMETADATA_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -41,5 +40,3 @@ private:
 
     QSharedDataPointer<QXmppE2eeMetadataPrivate> d;
 };
-
-#endif  // QXMPPE2EEMETADATA_H

--- a/src/base/QXmppElement.h
+++ b/src/base/QXmppElement.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPELEMENT_H
-#define QXMPPELEMENT_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -53,5 +52,3 @@ private:
     // ### QXmpp2: Use an std::shared_ptr if possible?
     QXmppElementPrivate *d;
 };
-
-#endif

--- a/src/base/QXmppEncryptedFileSource.h
+++ b/src/base/QXmppEncryptedFileSource.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPENCRYPTEDFILESOURCE_H
-#define QXMPPENCRYPTEDFILESOURCE_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppHash.h"
@@ -46,5 +45,3 @@ public:
 private:
     QSharedDataPointer<QXmppEncryptedFileSourcePrivate> d;
 };
-
-#endif  // QXMPPENCRYPTEDFILESOURCE_H

--- a/src/base/QXmppEntityTimeIq.h
+++ b/src/base/QXmppEntityTimeIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPENTITYTIMEIQ_H
-#define QXMPPENTITYTIMEIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -37,5 +36,3 @@ private:
     int m_tzo;
     QDateTime m_utc;
 };
-
-#endif  // QXMPPENTITYTIMEIQ_H

--- a/src/base/QXmppError.h
+++ b/src/base/QXmppError.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPERROR_H
-#define QXMPPERROR_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -55,5 +54,3 @@ struct QXMPP_EXPORT QXmppError
         return {};
     }
 };
-
-#endif  // QXMPPERROR_H

--- a/src/base/QXmppExtension.h
+++ b/src/base/QXmppExtension.h
@@ -2,13 +2,10 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPEXTENSION_H
-#define QXMPPEXTENSION_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
 class QXMPP_EXPORT QXmppExtension
 {
 };
-
-#endif  // QXMPPEXTENSION_H

--- a/src/base/QXmppExternalServiceDiscoveryIq.h
+++ b/src/base/QXmppExternalServiceDiscoveryIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPEXTERNALSERVICEDISCOVERYIQ_H
-#define QXMPPEXTERNALSERVICEDISCOVERYIQ_H
+#pragma once
 
 #include "QXmppExternalService.h"
 #include "QXmppIq.h"
@@ -33,5 +32,3 @@ protected:
 private:
     QSharedDataPointer<QXmppExternalServiceDiscoveryIqPrivate> d;
 };
-
-#endif  // QXMPPEXTERNALSERVICEDISCOVERYIQ_H

--- a/src/base/QXmppFileMetadata.h
+++ b/src/base/QXmppFileMetadata.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPFILEMETADATA_H
-#define QXMPPFILEMETADATA_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -66,5 +65,3 @@ public:
 private:
     QSharedDataPointer<QXmppFileMetadataPrivate> d;
 };
-
-#endif

--- a/src/base/QXmppFileShare.h
+++ b/src/base/QXmppFileShare.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPFILESHARE_H
-#define QXMPPFILESHARE_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -59,5 +58,3 @@ protected:
 private:
     QSharedDataPointer<QXmppFileSharePrivate> d;
 };
-
-#endif  // QXMPPFILESHARE_H

--- a/src/base/QXmppFutureUtils_p.h
+++ b/src/base/QXmppFutureUtils_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPFUTUREUTILS_P_H
-#define QXMPPFUTUREUTILS_P_H
+#pragma once
 
 //
 //  W A R N I N G
@@ -242,5 +241,3 @@ static auto taskFromFuture(QFuture<T> &&future) -> QXmppTask<T>
 }
 
 }  // namespace QXmpp::Private
-
-#endif  // QXMPPFUTUREUTILS_P_H

--- a/src/base/QXmppGeolocItem.h
+++ b/src/base/QXmppGeolocItem.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPGEOLOCITEM_H
-#define QXMPPGEOLOCITEM_H
+#pragma once
 
 #include "QXmppPubSubBaseItem.h"
 
@@ -52,5 +51,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppGeolocItem)
-
-#endif  // QXMPPGEOLOCITEM_H

--- a/src/base/QXmppGlobal.h
+++ b/src/base/QXmppGlobal.h
@@ -5,8 +5,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPGLOBAL_H
-#define QXMPPGLOBAL_H
+#pragma once
 
 #include "qxmpp_export.h"
 
@@ -182,5 +181,3 @@ struct Cancelled
 };
 
 }  // namespace QXmpp
-
-#endif  // QXMPPGLOBAL_H

--- a/src/base/QXmppGlobal_p.h
+++ b/src/base/QXmppGlobal_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPGLOBAL_P_H
-#define QXMPPGLOBAL_P_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -16,5 +15,3 @@ QString encryptionToString(EncryptionMethod);
 QString encryptionToName(EncryptionMethod);
 
 }  // namespace QXmpp::Private
-
-#endif  // QXMPPGLOBAL_P_H

--- a/src/base/QXmppHash.h
+++ b/src/base/QXmppHash.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPHASH_H
-#define QXMPPHASH_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -71,5 +70,3 @@ public:
 private:
     QXmpp::HashAlgorithm m_algorithm = QXmpp::HashAlgorithm::Unknown;
 };
-
-#endif  // QXMPPHASH_H

--- a/src/base/QXmppHashing_p.h
+++ b/src/base/QXmppHashing_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPHASHING_H
-#define QXMPPHASHING_H
+#pragma once
 
 #include "QXmppError.h"
 #include "QXmppGlobal.h"
@@ -67,5 +66,3 @@ QXMPP_EXPORT QFuture<HashingResultPtr> calculateHashes(std::unique_ptr<QIODevice
 QFuture<HashVerificationResultPtr> verifyHashes(std::unique_ptr<QIODevice> data, std::vector<QXmppHash> hashes);
 
 }  // namespace QXmpp::Private
-
-#endif  // QXMPPHASHING_H

--- a/src/base/QXmppHttpFileSource.h
+++ b/src/base/QXmppHttpFileSource.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPHTTPFILESOURCE_H
-#define QXMPPHTTPFILESOURCE_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -31,5 +30,3 @@ private:
     static_assert(sizeof(QUrl) == sizeof(void *));
     QUrl m_url;
 };
-
-#endif  // QXMPPHTTPFILESOURCE_H

--- a/src/base/QXmppHttpUploadIq.h
+++ b/src/base/QXmppHttpUploadIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPHTTPUPLOADIQ_H
-#define QXMPPHTTPUPLOADIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -94,5 +93,3 @@ protected:
 private:
     QSharedDataPointer<QXmppHttpUploadSlotIqPrivate> d;
 };
-
-#endif  // QXMPPHTTPUPLOADIQ_H

--- a/src/base/QXmppIbbIq.h
+++ b/src/base/QXmppIbbIq.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPIBBIQ_H
-#define QXMPPIBBIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -79,5 +78,3 @@ private:
     QString m_sid;
     QByteArray m_payload;
 };
-
-#endif  // QXMPPIBBIQS_H

--- a/src/base/QXmppIq.h
+++ b/src/base/QXmppIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPIQ_H
-#define QXMPPIQ_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -54,5 +53,3 @@ public:
 private:
     QSharedDataPointer<QXmppIqPrivate> d;
 };
-
-#endif  // QXMPPIQ_H

--- a/src/base/QXmppJingleData.h
+++ b/src/base/QXmppJingleData.h
@@ -4,8 +4,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPJINGLEIQ_H
-#define QXMPPJINGLEIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -726,5 +725,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppJingleReason::RtpErrorCondition)
-
-#endif

--- a/src/base/QXmppLogger.h
+++ b/src/base/QXmppLogger.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPLOGGER_H
-#define QXMPPLOGGER_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -170,4 +169,3 @@ Q_SIGNALS:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(QXmppLogger::MessageTypes)
-#endif  // QXMPPLOGGER_H

--- a/src/base/QXmppMamIq.h
+++ b/src/base/QXmppMamIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMAMIQ_H
-#define QXMPPMAMIQ_H
+#pragma once
 
 #include "QXmppDataForm.h"
 #include "QXmppIq.h"
@@ -73,5 +72,3 @@ protected:
 private:
     QSharedDataPointer<QXmppMamResultIqPrivate> d;
 };
-
-#endif

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -6,8 +6,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMESSAGE_H
-#define QXMPPMESSAGE_H
+#pragma once
 
 #include "QXmppFileShare.h"
 #include "QXmppStanza.h"
@@ -295,5 +294,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppMessage)
-
-#endif  // QXMPPMESSAGE_H

--- a/src/base/QXmppMessageReaction.h
+++ b/src/base/QXmppMessageReaction.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMESSAGEREACTION_H
-#define QXMPPMESSAGEREACTION_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -36,5 +35,3 @@ public:
 private:
     QSharedDataPointer<QXmppMessageReactionPrivate> d;
 };
-
-#endif  // QXMPPMESSAGEREACTION_H

--- a/src/base/QXmppMixInfoItem.h
+++ b/src/base/QXmppMixInfoItem.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMIXINFOITEM_H
-#define QXMPPMIXINFOITEM_H
+#pragma once
 
 #include "QXmppPubSubBaseItem.h"
 
@@ -40,5 +39,3 @@ protected:
 private:
     QSharedDataPointer<QXmppMixInfoItemPrivate> d;
 };
-
-#endif  // QXMPPMIXINFOITEM_H

--- a/src/base/QXmppMixInvitation.h
+++ b/src/base/QXmppMixInvitation.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMIXINVITATION_H
-#define QXMPPMIXINVITATION_H
+#pragma once
 
 #include "QXmppElement.h"
 
@@ -53,5 +52,3 @@ public:
 private:
     QSharedDataPointer<QXmppMixInvitationPrivate> d;
 };
-
-#endif  // QXMPPMIXINVITATION_H

--- a/src/base/QXmppMixIq.h
+++ b/src/base/QXmppMixIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMIXIQ_H
-#define QXMPPMIXIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -73,5 +72,3 @@ protected:
 private:
     QSharedDataPointer<QXmppMixIqPrivate> d;
 };
-
-#endif  // QXMPPMIXIQ_H

--- a/src/base/QXmppMixParticipantItem.h
+++ b/src/base/QXmppMixParticipantItem.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMIXPARTICIPANTITEM_H
-#define QXMPPMIXPARTICIPANTITEM_H
+#pragma once
 
 #include "QXmppPubSubBaseItem.h"
 
@@ -37,5 +36,3 @@ protected:
 private:
     QSharedDataPointer<QXmppMixParticipantItemPrivate> d;
 };
-
-#endif  // QXMPPMIXPARTICIPANTITEM_H

--- a/src/base/QXmppMucIq.h
+++ b/src/base/QXmppMucIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMUCIQ_H
-#define QXMPPMUCIQ_H
+#pragma once
 
 #include "QXmppDataForm.h"
 #include "QXmppIq.h"
@@ -129,5 +128,3 @@ protected:
 private:
     QXmppDataForm m_form;
 };
-
-#endif

--- a/src/base/QXmppNonSASLAuth.h
+++ b/src/base/QXmppNonSASLAuth.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXmppNonSASLAuth_H
-#define QXmppNonSASLAuth_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -38,5 +37,3 @@ private:
     QString m_password;
     QString m_resource;
 };
-
-#endif  // QXmppNonSASLAuth_H

--- a/src/base/QXmppNonza.h
+++ b/src/base/QXmppNonza.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPNONZA_H
-#define QXMPPNONZA_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -20,5 +19,3 @@ public:
     virtual void parse(const QDomElement &) = 0;
     virtual void toXml(QXmlStreamWriter *writer) const = 0;
 };
-
-#endif  // QXMPPNONZA_H

--- a/src/base/QXmppOmemoElement_p.h
+++ b/src/base/QXmppOmemoElement_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOELEMENT_H
-#define QXMPPOMEMOELEMENT_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppOmemoEnvelope_p.h"
@@ -42,5 +41,3 @@ private:
 };
 
 Q_DECLARE_TYPEINFO(QXmppOmemoElement, Q_MOVABLE_TYPE);
-
-#endif  // QXMPPOMEMOELEMENT_H

--- a/src/base/QXmppOmemoEnvelope_p.h
+++ b/src/base/QXmppOmemoEnvelope_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOENVELOPE_H
-#define QXMPPOMEMOENVELOPE_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -37,5 +36,3 @@ private:
 };
 
 Q_DECLARE_TYPEINFO(QXmppOmemoEnvelope, Q_MOVABLE_TYPE);
-
-#endif  // QXMPPOMEMOENVELOPE_H

--- a/src/base/QXmppOutOfBandUrl.h
+++ b/src/base/QXmppOutOfBandUrl.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOUTOFBANDURL_H
-#define QXMPPOUTOFBANDURL_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -36,5 +35,3 @@ public:
 private:
     QSharedDataPointer<QXmppOutOfBandUrlPrivate> d;
 };
-
-#endif  // QXMPPOUTOFBANDURL_H

--- a/src/base/QXmppPacket_p.h
+++ b/src/base/QXmppPacket_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPACKET_H
-#define QXMPPPACKET_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppPromise.h"
@@ -33,5 +32,3 @@ private:
     QByteArray m_data;
     bool m_isXmppStanza;
 };
-
-#endif  // QXMPPPACKET_H

--- a/src/base/QXmppPingIq.h
+++ b/src/base/QXmppPingIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPINGIQ_H
-#define QXMPPPINGIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -17,5 +16,3 @@ public:
     void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 };
-
-#endif

--- a/src/base/QXmppPresence.h
+++ b/src/base/QXmppPresence.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPRESENCE_H
-#define QXMPPPRESENCE_H
+#pragma once
 
 #include "QXmppJingleIq.h"
 #include "QXmppMucIq.h"
@@ -138,5 +137,3 @@ private:
 
     QSharedDataPointer<QXmppPresencePrivate> d;
 };
-
-#endif  // QXMPPPRESENCE_H

--- a/src/base/QXmppPromise.h
+++ b/src/base/QXmppPromise.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPROMISE_H
-#define QXMPPPROMISE_H
+#pragma once
 
 #include "QXmppTask.h"
 
@@ -101,5 +100,3 @@ public:
 private:
     QXmpp::Private::TaskPrivate d;
 };
-
-#endif  // QXMPPPROMISE_H

--- a/src/base/QXmppPubSubAffiliation.h
+++ b/src/base/QXmppPubSubAffiliation.h
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBAFFILIATION_H
-#define QXMPPPUBSUBAFFILIATION_H
-
 #include "QXmppGlobal.h"
 
 #include <QMetaType>
@@ -62,5 +59,3 @@ private:
 
 Q_DECLARE_METATYPE(QXmppPubSubAffiliation)
 Q_DECLARE_METATYPE(QXmppPubSubAffiliation::Affiliation)
-
-#endif  // QXMPPPUBSUBAFFILIATION_H

--- a/src/base/QXmppPubSubEvent.h
+++ b/src/base/QXmppPubSubEvent.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBEVENT_H
-#define QXMPPPUBSUBEVENT_H
+#pragma once
 
 #include "QXmppMessage.h"
 #include "QXmppPubSubSubscription.h"
@@ -146,5 +145,3 @@ void QXmppPubSubEvent<T>::serializeItems(QXmlStreamWriter *writer) const
 /// \endcond
 
 Q_DECLARE_METATYPE(QXmppPubSubEventBase::EventType)
-
-#endif  // QXMPPPUBSUBEVENT_H

--- a/src/base/QXmppPubSubIq_p.h
+++ b/src/base/QXmppPubSubIq_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBIQ_H
-#define QXMPPPUBSUBIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -166,5 +165,3 @@ void PubSubIq<T>::serializeItems(QXmlStreamWriter *writer) const
 /// \endcond
 
 }  // namespace QXmpp::Private
-
-#endif  // QXMPPPUBSUBIQ_H

--- a/src/base/QXmppPubSubMetadata.h
+++ b/src/base/QXmppPubSubMetadata.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBMETADATA_H
-#define QXMPPPUBSUBMETADATA_H
+#pragma once
 
 #include "QXmppDataFormBase.h"
 #include "QXmppPubSubNodeConfig.h"
@@ -78,5 +77,3 @@ protected:
 private:
     QSharedDataPointer<QXmppPubSubMetadataPrivate> d;
 };
-
-#endif  // QXMPPPUBSUBMETADATA_H

--- a/src/base/QXmppPubSubNodeConfig.h
+++ b/src/base/QXmppPubSubNodeConfig.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBNODECONFIG_H
-#define QXMPPPUBSUBNODECONFIG_H
+#pragma once
 
 #include "QXmppDataForm.h"
 #include "QXmppDataFormBase.h"
@@ -208,5 +207,3 @@ protected:
 
 Q_DECLARE_METATYPE(QXmppPubSubNodeConfig);
 Q_DECLARE_METATYPE(QXmppPubSubPublishOptions);
-
-#endif  // QXMPPPUBSUBNODECONFIG_H

--- a/src/base/QXmppPubSubSubAuthorization.h
+++ b/src/base/QXmppPubSubSubAuthorization.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBSUBAUTHORIZATION_H
-#define QXMPPPUBSUBSUBAUTHORIZATION_H
+#pragma once
 
 #include "QXmppDataFormBase.h"
 
@@ -42,5 +41,3 @@ protected:
 private:
     QSharedDataPointer<QXmppPubSubSubAuthorizationPrivate> d;
 };
-
-#endif  // QXMPPPUBSUBSUBAUTHORIZATION_H

--- a/src/base/QXmppPubSubSubscribeOptions.h
+++ b/src/base/QXmppPubSubSubscribeOptions.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBSUBSCRIBEOPTIONS_H
-#define QXMPPPUBSUBSUBSCRIBEOPTIONS_H
+#pragma once
 
 #include "QXmppDataForm.h"
 #include "QXmppDataFormBase.h"
@@ -88,5 +87,3 @@ private:
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(QXmppPubSubSubscribeOptions::PresenceStates)
 Q_DECLARE_METATYPE(QXmppPubSubSubscribeOptions)
-
-#endif  // QXMPPPUBSUBSUBSCRIBEOPTIONS_H

--- a/src/base/QXmppPubSubSubscription.h
+++ b/src/base/QXmppPubSubSubscription.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBSUBSCRIPTION_H
-#define QXMPPPUBSUBSUBSCRIPTION_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -100,5 +99,3 @@ Q_DECLARE_TYPEINFO(QXmppPubSubSubscription, Q_MOVABLE_TYPE);
 Q_DECLARE_METATYPE(QXmppPubSubSubscription)
 Q_DECLARE_METATYPE(QXmppPubSubSubscription::State)
 Q_DECLARE_METATYPE(QXmppPubSubSubscription::ConfigurationSupport)
-
-#endif  // QXMPPPUBSUBSUBSCRIPTION_H

--- a/src/base/QXmppRegisterIq.h
+++ b/src/base/QXmppRegisterIq.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPREGISTERIQ_H
-#define QXMPPREGISTERIQ_H
+#pragma once
 
 #include "QXmppDataForm.h"
 #include "QXmppIq.h"
@@ -74,5 +73,3 @@ protected:
 private:
     QSharedDataPointer<QXmppRegisterIqPrivate> d;
 };
-
-#endif

--- a/src/base/QXmppResultSet.h
+++ b/src/base/QXmppResultSet.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPRESULTSET_H
-#define QXMPPRESULTSET_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -76,5 +75,3 @@ private:
     QString m_first;
     QString m_last;
 };
-
-#endif  // QXMPPRESULTSET_H

--- a/src/base/QXmppRosterIq.h
+++ b/src/base/QXmppRosterIq.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPROSTERIQ_H
-#define QXMPPROSTERIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -114,5 +113,3 @@ protected:
 private:
     QSharedDataPointer<QXmppRosterIqPrivate> d;
 };
-
-#endif  // QXMPPROSTERIQ_H

--- a/src/base/QXmppRpcIq.h
+++ b/src/base/QXmppRpcIq.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPRPCIQ_H
-#define QXMPPRPCIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -106,5 +105,3 @@ protected:
 private:
     QXmppRpcInvokeIq m_query;
 };
-
-#endif  // QXMPPRPCIQ_H

--- a/src/base/QXmppSasl_p.h
+++ b/src/base/QXmppSasl_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSASL_P_H
-#define QXMPPSASL_P_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppLogger.h"
@@ -323,5 +322,3 @@ public:
 private:
     int m_step;
 };
-
-#endif

--- a/src/base/QXmppSendResult.h
+++ b/src/base/QXmppSendResult.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSENDRESULT_H
-#define QXMPPSENDRESULT_H
+#pragma once
 
 #include "QXmppError.h"
 
@@ -44,5 +43,3 @@ struct SendSuccess
 using SendResult = std::variant<SendSuccess, QXmppError>;
 
 }  // namespace QXmpp
-
-#endif  // QXMPPSENDRESULT_H

--- a/src/base/QXmppSessionIq.h
+++ b/src/base/QXmppSessionIq.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSESSIONIQ_H
-#define QXMPPSESSIONIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -25,5 +24,3 @@ private:
     void toXmlElementFromChild(QXmlStreamWriter *writer) const override;
     /// \endcond
 };
-
-#endif  // QXMPPSESSION_H

--- a/src/base/QXmppSocks.h
+++ b/src/base/QXmppSocks.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSOCKS_H
-#define QXMPPSOCKS_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -58,5 +57,3 @@ private:
     QTcpServer *m_server_v6;
     QMap<QTcpSocket *, int> m_states;
 };
-
-#endif

--- a/src/base/QXmppStanza.h
+++ b/src/base/QXmppStanza.h
@@ -6,8 +6,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTANZA_H
-#define QXMPPSTANZA_H
+#pragma once
 
 #include <optional>
 
@@ -240,5 +239,3 @@ private:
 
 Q_DECLARE_METATYPE(QXmppStanza::Error::Type);
 Q_DECLARE_METATYPE(QXmppStanza::Error::Condition);
-
-#endif  // QXMPPSTANZA_H

--- a/src/base/QXmppStanza_p.h
+++ b/src/base/QXmppStanza_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTANZA_P_H
-#define QXMPPSTANZA_P_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -30,5 +29,3 @@ auto typeToString(QXmppStanza::Error::Type type) -> QString;
 auto typeFromString(const QString &string) -> std::optional<QXmppStanza::Error::Type>;
 
 }  // namespace QXmpp::Private
-
-#endif

--- a/src/base/QXmppStartTlsPacket.h
+++ b/src/base/QXmppStartTlsPacket.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTARTTLSPACKET_H
-#define QXMPPSTARTTLSPACKET_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -43,5 +42,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppStartTlsPacket::Type);
-
-#endif  // QXMPPSTARTTLSPACKET_H

--- a/src/base/QXmppStream.h
+++ b/src/base/QXmppStream.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTREAM_H
-#define QXMPPSTREAM_H
+#pragma once
 
 #include "QXmppLogger.h"
 #include "QXmppSendResult.h"
@@ -105,5 +104,3 @@ private:
 
     QXmppStreamPrivate *const d;
 };
-
-#endif  // QXMPPSTREAM_H

--- a/src/base/QXmppStreamFeatures.h
+++ b/src/base/QXmppStreamFeatures.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTREAMFEATURES_H
-#define QXMPPSTREAMFEATURES_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -76,5 +75,3 @@ public:
 private:
     QSharedDataPointer<QXmppStreamFeaturesPrivate> d;
 };
-
-#endif

--- a/src/base/QXmppStreamInitiationIq_p.h
+++ b/src/base/QXmppStreamInitiationIq_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTREAMINITIATIONIQ_P_H
-#define QXMPPSTREAMINITIATIONIQ_P_H
+#pragma once
 
 #include "QXmppDataForm.h"
 #include "QXmppIq.h"
@@ -62,5 +61,3 @@ private:
     QString m_siId;
 };
 /// \endcond
-
-#endif

--- a/src/base/QXmppStreamManagement_p.h
+++ b/src/base/QXmppStreamManagement_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTREAMMANAGEMENT_P_H
-#define QXMPPSTREAMMANAGEMENT_P_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppStanza.h"
@@ -199,5 +198,3 @@ private:
     unsigned int m_lastIncomingSequenceNumber = 0;
 };
 /// \endcond
-
-#endif

--- a/src/base/QXmppStun.h
+++ b/src/base/QXmppStun.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTUN_H
-#define QXMPPSTUN_H
+#pragma once
 
 #include "QXmppJingleIq.h"
 #include "QXmppLogger.h"
@@ -306,5 +305,3 @@ private Q_SLOTS:
 private:
     QXmppIceConnectionPrivate *d;
 };
-
-#endif

--- a/src/base/QXmppStun_p.h
+++ b/src/base/QXmppStun_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSTUN_P_H
-#define QXMPPSTUN_P_H
+#pragma once
 
 #include "QXmppStun.h"
 
@@ -169,5 +168,3 @@ private Q_SLOTS:
 private:
     QUdpSocket *m_socket;
 };
-
-#endif

--- a/src/base/QXmppTask.h
+++ b/src/base/QXmppTask.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTASK_H
-#define QXMPPTASK_H
+#pragma once
 
 #include "qxmpp_export.h"
 
@@ -220,5 +219,3 @@ private:
 
     QXmpp::Private::TaskPrivate d;
 };
-
-#endif  // QXMPPTASK_H

--- a/src/base/QXmppThumbnail.h
+++ b/src/base/QXmppThumbnail.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTHUMBNAIL_H
-#define QXMPPTHUMBNAIL_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -47,5 +46,3 @@ public:
 private:
     QSharedDataPointer<QXmppThumbnailPrivate> d;
 };
-
-#endif  // QXMPPTHUMBNAIL_H

--- a/src/base/QXmppTrustMessageElement.h
+++ b/src/base/QXmppTrustMessageElement.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRUSTMESSAGEELEMENT_H
-#define QXMPPTRUSTMESSAGEELEMENT_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -47,5 +46,3 @@ private:
 };
 
 Q_DECLARE_TYPEINFO(QXmppTrustMessageElement, Q_MOVABLE_TYPE);
-
-#endif  // QXMPPTRUSTMESSAGEELEMENT_H

--- a/src/base/QXmppTrustMessageKeyOwner.h
+++ b/src/base/QXmppTrustMessageKeyOwner.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRUSTMESSAGEKEYOWNER_H
-#define QXMPPTRUSTMESSAGEKEYOWNER_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -45,5 +44,3 @@ private:
 };
 
 Q_DECLARE_TYPEINFO(QXmppTrustMessageKeyOwner, Q_MOVABLE_TYPE);
-
-#endif  // QXMPPTRUSTMESSAGEKEYOWNER_H

--- a/src/base/QXmppUserTuneItem.h
+++ b/src/base/QXmppUserTuneItem.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPUSERTUNEITEM_H
-#define QXMPPUSERTUNEITEM_H
+#pragma once
 
 #include "QXmppPubSubBaseItem.h"
 
@@ -89,5 +88,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppTuneItem)
-
-#endif  // QXMPPUSERTUNEITEM_H

--- a/src/base/QXmppUtils.h
+++ b/src/base/QXmppUtils.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPUTILS_H
-#define QXMPPUTILS_H
+#pragma once
 
 // forward declarations of QXmlStream* classes will not work on Mac, we need to
 // include the whole header.
@@ -48,5 +47,3 @@ void helperToXmlAddAttribute(QXmlStreamWriter *stream, const QString &name,
                              const QString &value);
 void helperToXmlAddTextElement(QXmlStreamWriter *stream, const QString &name,
                                const QString &value);
-
-#endif  // QXMPPUTILS_H

--- a/src/base/QXmppUtils_p.h
+++ b/src/base/QXmppUtils_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPUTILS_P_H
-#define QXMPPUTILS_P_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -19,5 +18,3 @@ QXMPP_EXPORT void generateRandomBytes(uint8_t *bytes, uint32_t byteCount);
 float calculateProgress(qint64 transferred, qint64 total);
 
 }  // namespace QXmpp::Private
-
-#endif  // QXMPPUTILS_P_H

--- a/src/base/QXmppVCardIq.h
+++ b/src/base/QXmppVCardIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPVCARDIQ_H
-#define QXMPPVCARDIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -277,5 +276,3 @@ private:
 
 QXMPP_EXPORT bool operator==(const QXmppVCardIq &, const QXmppVCardIq &);
 QXMPP_EXPORT bool operator!=(const QXmppVCardIq &, const QXmppVCardIq &);
-
-#endif  // QXMPPVCARDIQ_H

--- a/src/base/QXmppVersionIq.h
+++ b/src/base/QXmppVersionIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPVERSIONIQ_H
-#define QXMPPVERSIONIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -40,5 +39,3 @@ private:
     QString m_os;
     QString m_version;
 };
-
-#endif

--- a/src/base/compat/QXmppPubSubIq.h
+++ b/src/base/compat/QXmppPubSubIq.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBIQ_H
-#define QXMPPPUBSUBIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 
@@ -62,5 +61,3 @@ private:
     QSharedDataPointer<QXmppPubSubIqPrivate> d;
 };
 #endif
-
-#endif  // QXMPPPUBSUBIQ_H

--- a/src/base/compat/QXmppPubSubItem.h
+++ b/src/base/compat/QXmppPubSubItem.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBITEM_H
-#define QXMPPPUBSUBITEM_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -38,5 +37,3 @@ private:
     QSharedDataPointer<QXmppPubSubItemPrivate> d;
 };
 #endif
-
-#endif  // QXMPPPUBSUBITEM_H

--- a/src/client/QXmppArchiveManager.h
+++ b/src/client/QXmppArchiveManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPARCHIVEMANAGER_H
-#define QXMPPARCHIVEMANAGER_H
+#pragma once
 
 #include "QXmppArchiveIq.h"
 #include "QXmppClientExtension.h"
@@ -53,5 +52,3 @@ Q_SIGNALS:
     /// after calling retrieveCollection()
     void archiveChatReceived(const QXmppArchiveChat &, const QXmppResultSetReply &rsm = QXmppResultSetReply());
 };
-
-#endif

--- a/src/client/QXmppAtmManager.h
+++ b/src/client/QXmppAtmManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPATMMANAGER_H
-#define QXMPPATMMANAGER_H
+#pragma once
 
 #include "QXmppAtmTrustStorage.h"
 #include "QXmppSendResult.h"
@@ -50,5 +49,3 @@ private:
 
     friend class tst_QXmppAtmManager;
 };
-
-#endif  // QXMPPATMMANAGER_H

--- a/src/client/QXmppAtmTrustMemoryStorage.h
+++ b/src/client/QXmppAtmTrustMemoryStorage.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPATMTRUSTMEMORYSTORAGE_H
-#define QXMPPATMTRUSTMEMORYSTORAGE_H
+#pragma once
 
 #include "QXmppAtmTrustStorage.h"
 #include "QXmppTrustMemoryStorage.h"
@@ -29,5 +28,3 @@ public:
 private:
     const std::unique_ptr<QXmppAtmTrustMemoryStoragePrivate> d;
 };
-
-#endif  // QXMPPATMTRUSTMEMORYSTORAGE_H

--- a/src/client/QXmppAtmTrustStorage.h
+++ b/src/client/QXmppAtmTrustStorage.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPATMTRUSTSTORAGE_H
-#define QXMPPATMTRUSTSTORAGE_H
+#pragma once
 
 #include "QXmppTrustStorage.h"
 
@@ -22,5 +21,3 @@ public:
     virtual QXmppTask<void> removeKeysForPostponedTrustDecisions(const QString &encryption) = 0;
     virtual QXmppTask<QHash<bool, QMultiHash<QString, QByteArray>>> keysForPostponedTrustDecisions(const QString &encryption, const QList<QByteArray> &senderKeyIds = {}) = 0;
 };
-
-#endif  // QXMPPATMTRUSTSTORAGE_H

--- a/src/client/QXmppAttentionManager.h
+++ b/src/client/QXmppAttentionManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPATTENTIONMANAGER_H
-#define QXMPPATTENTIONMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -44,5 +43,3 @@ private Q_SLOTS:
 private:
     const std::unique_ptr<QXmppAttentionManagerPrivate> d;
 };
-
-#endif  // QXMPPATTENTIONMANAGER_H

--- a/src/client/QXmppBookmarkManager.h
+++ b/src/client/QXmppBookmarkManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPBOOKMARKMANAGER_H
-#define QXMPPBOOKMARKMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -48,5 +47,3 @@ private Q_SLOTS:
 private:
     const std::unique_ptr<QXmppBookmarkManagerPrivate> d;
 };
-
-#endif

--- a/src/client/QXmppCall.h
+++ b/src/client/QXmppCall.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCALL_H
-#define QXMPPCALL_H
+#pragma once
 
 #include "QXmppCallStream.h"
 #include "QXmppClientExtension.h"
@@ -94,5 +93,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppCall::State)
-
-#endif

--- a/src/client/QXmppCallInviteManager.h
+++ b/src/client/QXmppCallInviteManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCALLINVITEMANAGER_H
-#define QXMPPCALLINVITEMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -120,5 +119,3 @@ private:
 };
 Q_DECLARE_METATYPE(QXmppCallInvite::Result)
 Q_DECLARE_METATYPE(std::shared_ptr<QXmppCallInvite>)
-
-#endif  // QXMPPJINGLEMESSAGEINITIATIONMANAGER_H

--- a/src/client/QXmppCallManager.h
+++ b/src/client/QXmppCallManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCALLMANAGER_H
-#define QXMPPCALLMANAGER_H
+#pragma once
 
 #include "QXmppCall.h"
 #include "QXmppClientExtension.h"
@@ -91,5 +90,3 @@ private:
     friend class QXmppCallPrivate;
     friend class QXmppCallManagerPrivate;
 };
-
-#endif

--- a/src/client/QXmppCallManager_p.h
+++ b/src/client/QXmppCallManager_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCALLMANAGER_P_H
-#define QXMPPCALLMANAGER_P_H
+#pragma once
 
 #include "QXmppCall.h"
 
@@ -39,5 +38,3 @@ public:
 private:
     QXmppCallManager *q;
 };
-
-#endif

--- a/src/client/QXmppCallStream.h
+++ b/src/client/QXmppCallStream.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCALLSTREAM_H
-#define QXMPPCALLSTREAM_H
+#pragma once
 
 #include <QXmppGlobal.h>
 
@@ -40,5 +39,3 @@ private:
     friend class QXmppCall;
     friend class QXmppCallPrivate;
 };
-
-#endif

--- a/src/client/QXmppCallStream_p.h
+++ b/src/client/QXmppCallStream_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCALLSTREAM_P_H
-#define QXMPPCALLSTREAM_P_H
+#pragma once
 
 #include "QXmppCall_p.h"
 #include "QXmppJingleIq.h"
@@ -80,5 +79,3 @@ public:
 
     QList<QXmppJinglePayloadType> payloadTypes;
 };
-
-#endif

--- a/src/client/QXmppCall_p.h
+++ b/src/client/QXmppCall_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCALL_P_H
-#define QXMPPCALL_P_H
+#pragma once
 
 #include "QXmppCall.h"
 #include "QXmppJingleIq.h"
@@ -113,5 +112,3 @@ public:
 private:
     QXmppCall *q;
 };
-
-#endif

--- a/src/client/QXmppCarbonManager.h
+++ b/src/client/QXmppCarbonManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCARBONMANAGER_H
-#define QXMPPCARBONMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -45,5 +44,3 @@ Q_SIGNALS:
 private:
     bool m_carbonsEnabled;
 };
-
-#endif  // QXMPPCARBONMANAGER_H

--- a/src/client/QXmppCarbonManagerV2.h
+++ b/src/client/QXmppCarbonManagerV2.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCARBONMANAGERV2_H
-#define QXMPPCARBONMANAGERV2_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -25,5 +24,3 @@ private:
     // placeholder (we may need a d-ptr in the future)
     void *d;
 };
-
-#endif  // QXMPPCARBONMANAGERV2_H

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCLIENT_H
-#define QXMPPCLIENT_H
+#pragma once
 
 #include "QXmppConfiguration.h"
 #include "QXmppLogger.h"
@@ -330,5 +329,3 @@ private:
     friend class QXmppInternalClientExtension;
     friend class TestClient;
 };
-
-#endif  // QXMPPCLIENT_H

--- a/src/client/QXmppClientExtension.h
+++ b/src/client/QXmppClientExtension.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCLIENTEXTENSION_H
-#define QXMPPCLIENTEXTENSION_H
+#pragma once
 
 #include "QXmppDiscoveryIq.h"
 #include "QXmppExtension.h"
@@ -56,5 +55,3 @@ private:
 
     friend class QXmppClient;
 };
-
-#endif

--- a/src/client/QXmppClient_p.h
+++ b/src/client/QXmppClient_p.h
@@ -15,8 +15,7 @@
 // We mean it.
 //
 
-#ifndef QXMPPCLIENT_P_H
-#define QXMPPCLIENT_P_H
+#pragma once
 
 #include "QXmppPresence.h"
 
@@ -57,5 +56,3 @@ public:
 private:
     QXmppClient *q;
 };
-
-#endif  // QXMPPCLIENT_P_H

--- a/src/client/QXmppConfiguration.h
+++ b/src/client/QXmppConfiguration.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPCONFIGURATION_H
-#define QXMPPCONFIGURATION_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -131,5 +130,3 @@ public:
 private:
     QSharedDataPointer<QXmppConfigurationPrivate> d;
 };
-
-#endif  // QXMPPCONFIGURATION_H

--- a/src/client/QXmppDiscoveryManager.h
+++ b/src/client/QXmppDiscoveryManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPDISCOVERYMANAGER_H
-#define QXMPPDISCOVERYMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -72,5 +71,3 @@ Q_SIGNALS:
 private:
     const std::unique_ptr<QXmppDiscoveryManagerPrivate> d;
 };
-
-#endif  // QXMPPDISCOVERYMANAGER_H

--- a/src/client/QXmppE2eeExtension.h
+++ b/src/client/QXmppE2eeExtension.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPE2EEEXTENSION_H
-#define QXMPPE2EEEXTENSION_H
+#pragma once
 
 #include "QXmppError.h"
 #include "QXmppExtension.h"
@@ -38,5 +37,3 @@ public:
     virtual bool isEncrypted(const QDomElement &) = 0;
     virtual bool isEncrypted(const QXmppMessage &) = 0;
 };
-
-#endif  // QXMPPE2EEEXTENSION_H

--- a/src/client/QXmppEncryptedFileSharingProvider.h
+++ b/src/client/QXmppEncryptedFileSharingProvider.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPENCRYPTEDHTTPFILESHARINGPROVIDER_H
-#define QXMPPENCRYPTEDHTTPFILESHARINGPROVIDER_H
+#pragma once
 
 #include "QXmppEncryptedFileSource.h"
 #include "QXmppHttpFileSharingProvider.h"
@@ -35,5 +34,3 @@ public:
 private:
     std::unique_ptr<QXmppEncryptedFileSharingProviderPrivate> d;
 };
-
-#endif  // QXMPPENCRYPTEDHTTPFILESHARINGPROVIDER_H

--- a/src/client/QXmppEntityTimeManager.h
+++ b/src/client/QXmppEntityTimeManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPENTITYTIMEMANAGER_H
-#define QXMPPENTITYTIMEMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -42,5 +41,3 @@ Q_SIGNALS:
     /// emitted when the QFuture-based request is used.
     void timeReceived(const QXmppEntityTimeIq &);
 };
-
-#endif  // QXMPPENTITYTIMEMANAGER_H

--- a/src/client/QXmppExternalServiceDiscoveryManager.h
+++ b/src/client/QXmppExternalServiceDiscoveryManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPEXTERNALSERVICEDISCOVERYMANAGER_H
-#define QXMPPEXTERNALSERVICEDISCOVERYMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -30,5 +29,3 @@ public:
     QStringList discoveryFeatures() const override;
     /// \endcond
 };
-
-#endif  // QXMPPEXTERNALSERVICEDISCOVERYMANAGER_H

--- a/src/client/QXmppFileEncryption.h
+++ b/src/client/QXmppFileEncryption.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPFILEENCRYPTION_H
-#define QXMPPFILEENCRYPTION_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -73,5 +72,3 @@ private:
 };
 
 }  // namespace QXmpp::Private::Encryption
-
-#endif  // QXMPPFILEENCRYPTION_H

--- a/src/client/QXmppFileSharingManager.h
+++ b/src/client/QXmppFileSharingManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPFILESHARINGMANAGER_H
-#define QXMPPFILESHARINGMANAGER_H
+#pragma once
 
 #include "QXmppBitsOfBinaryDataList.h"
 #include "QXmppClientExtension.h"
@@ -170,5 +169,3 @@ private:
 
     std::unique_ptr<QXmppFileSharingManagerPrivate> d;
 };
-
-#endif  // QXMPPFILESHARINGMANAGER_H

--- a/src/client/QXmppFileSharingProvider.h
+++ b/src/client/QXmppFileSharingProvider.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPFILESHARINGPROVIDER_H
-#define QXMPPFILESHARINGPROVIDER_H
+#pragma once
 
 #include "QXmppError.h"
 #include "QXmppGlobal.h"
@@ -86,5 +85,3 @@ public:
                             std::function<void(quint64, quint64)> reportProgress,
                             std::function<void(UploadResult)> reportFinished) -> std::shared_ptr<Upload> = 0;
 };
-
-#endif  // QXMPPFILESHARINGPROVIDER_H

--- a/src/client/QXmppHttpFileSharingProvider.h
+++ b/src/client/QXmppHttpFileSharingProvider.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPHTTPFILESHARINGPROVIDER_H
-#define QXMPPHTTPFILESHARINGPROVIDER_H
+#pragma once
 
 #include "QXmppFileSharingProvider.h"
 #include "QXmppHttpFileSource.h"
@@ -36,5 +35,3 @@ public:
 private:
     std::unique_ptr<QXmppHttpFileSharingProviderPrivate> d;
 };
-
-#endif  // QXMPPHTTPFILESHARINGPROVIDER_H

--- a/src/client/QXmppHttpUploadManager.h
+++ b/src/client/QXmppHttpUploadManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPHTTPUPLOADMANAGER_H
-#define QXMPPHTTPUPLOADMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -64,5 +63,3 @@ public:
 private:
     std::unique_ptr<QXmppHttpUploadManagerPrivate> d;
 };
-
-#endif  // QXMPPHTTPUPLOADMANAGER_H

--- a/src/client/QXmppInternalClientExtension_p.h
+++ b/src/client/QXmppInternalClientExtension_p.h
@@ -14,8 +14,7 @@
 // We mean it.
 //
 
-#ifndef QXMPPINTERNALCLIENTEXTENSION_H
-#define QXMPPINTERNALCLIENTEXTENSION_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -38,5 +37,3 @@ public:
 protected:
     QXmppOutgoingClient *clientStream();
 };
-
-#endif  // QXMPPINTERNALCLIENTEXTENSION_H

--- a/src/client/QXmppInvokable.h
+++ b/src/client/QXmppInvokable.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPINVOKABLE_H
-#define QXMPPINVOKABLE_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -55,5 +54,3 @@ private:
     QHash<QByteArray, int> m_methodHash;
     QReadWriteLock m_lock;
 };
-
-#endif

--- a/src/client/QXmppIqHandling.h
+++ b/src/client/QXmppIqHandling.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPIQHANDLING_H
-#define QXMPPIQHANDLING_H
+#pragma once
 
 #include "QXmppClient.h"
 #include "QXmppE2eeMetadata.h"
@@ -272,5 +271,3 @@ bool handleIqRequests(const QDomElement &element, QXmppClient *client, Handler h
 }
 
 }  // namespace QXmpp
-
-#endif  // QXMPPIQHANDLING_H

--- a/src/client/QXmppJingleMessageInitiationManager.h
+++ b/src/client/QXmppJingleMessageInitiationManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPJINGLEMESSAGEINITIATIONMANAGER_H
-#define QXMPPJINGLEMESSAGEINITIATIONMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -122,5 +121,3 @@ private:
 };
 
 Q_DECLARE_METATYPE(QXmppJingleMessageInitiation::Result)
-
-#endif  // QXMPPJINGLEMESSAGEINITIATIONMANAGER_H

--- a/src/client/QXmppMamManager.h
+++ b/src/client/QXmppMamManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMAMMANAGER_H
-#define QXMPPMAMMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -82,5 +81,3 @@ Q_SIGNALS:
 private:
     std::unique_ptr<QXmppMamManagerPrivate> d;
 };
-
-#endif

--- a/src/client/QXmppMessageHandler.h
+++ b/src/client/QXmppMessageHandler.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMESSAGEHANDLER_H
-#define QXMPPMESSAGEHANDLER_H
+#pragma once
 
 #include "QXmppExtension.h"
 #include "QXmppMessage.h"
@@ -17,5 +16,3 @@ class QXMPP_EXPORT QXmppMessageHandler : public QXmppExtension
 public:
     virtual bool handleMessage(const QXmppMessage &) = 0;
 };
-
-#endif  // QXMPPMESSAGEHANDLER_H

--- a/src/client/QXmppMessageReceiptManager.h
+++ b/src/client/QXmppMessageReceiptManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMESSAGERECEIPTMANAGER_H
-#define QXMPPMESSAGERECEIPTMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppMessageHandler.h"
@@ -33,5 +32,3 @@ Q_SIGNALS:
     /// calling QXmppMessage::id().
     void messageDelivered(const QString &jid, const QString &id);
 };
-
-#endif  // QXMPPMESSAGERECEIPTMANAGER_H

--- a/src/client/QXmppMucManager.h
+++ b/src/client/QXmppMucManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPMUCMANAGER_H
-#define QXMPPMUCMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppMucIq.h"
@@ -240,5 +239,3 @@ private:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(QXmppMucRoom::Actions)
-
-#endif

--- a/src/client/QXmppOutgoingClient.h
+++ b/src/client/QXmppOutgoingClient.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOUTGOINGCLIENT_H
-#define QXMPPOUTGOINGCLIENT_H
+#pragma once
 
 #include "QXmppClient.h"
 #include "QXmppStanza.h"
@@ -97,5 +96,3 @@ private:
 
     const std::unique_ptr<QXmppOutgoingClientPrivate> d;
 };
-
-#endif  // QXMPPOUTGOINGCLIENT_H

--- a/src/client/QXmppPubSubEventHandler.h
+++ b/src/client/QXmppPubSubEventHandler.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBEVENTHANDLER_H
-#define QXMPPPUBSUBEVENTHANDLER_H
+#pragma once
 
 #include "QXmppExtension.h"
 
@@ -16,5 +15,3 @@ class QXMPP_EXPORT QXmppPubSubEventHandler : public QXmppExtension
 public:
     virtual bool handlePubSubEvent(const QDomElement &element, const QString &pubSubService, const QString &nodeName) = 0;
 };
-
-#endif  // QXMPPPUBSUBEVENTHANDLER_H

--- a/src/client/QXmppPubSubManager.h
+++ b/src/client/QXmppPubSubManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPUBSUBMANAGER_H
-#define QXMPPPUBSUBMANAGER_H
+#pragma once
 
 #include "QXmppClient.h"
 #include "QXmppClientExtension.h"
@@ -387,5 +386,3 @@ QXmppTask<QXmppPubSubManager::PublishItemsResult> QXmppPubSubManager::publishOwn
 {
     return publishItems(client()->configuration().jidBare(), nodeName, items);
 }
-
-#endif  // QXMPPPUBSUBMANAGER_H

--- a/src/client/QXmppRegistrationManager.h
+++ b/src/client/QXmppRegistrationManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPREGISTRATIONMANAGER_H
-#define QXMPPREGISTRATIONMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppRegisterIq.h"
@@ -348,5 +347,3 @@ private:
 
     const std::unique_ptr<QXmppRegistrationManagerPrivate> d;
 };
-
-#endif  // QXMPPREGISTRATIONMANAGER_H

--- a/src/client/QXmppRemoteMethod.h
+++ b/src/client/QXmppRemoteMethod.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPREMOTEMETHOD_H
-#define QXMPPREMOTEMETHOD_H
+#pragma once
 
 #include "QXmppRpcIq.h"
 
@@ -40,5 +39,3 @@ private:
     QXmppClient *m_client;
     QXmppRemoteMethodResult m_result;
 };
-
-#endif  // QXMPPREMOTEMETHOD_H

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -4,8 +4,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPROSTERMANAGER_H
-#define QXMPPROSTERMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppPresence.h"
@@ -137,5 +136,3 @@ private Q_SLOTS:
 private:
     const std::unique_ptr<QXmppRosterManagerPrivate> d;
 };
-
-#endif  // QXMPPROSTER_H

--- a/src/client/QXmppRpcManager.h
+++ b/src/client/QXmppRpcManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPRPCMANAGER_H
-#define QXMPPRPCMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppInvokable.h"
@@ -70,5 +69,3 @@ private:
 
     QMap<QString, QXmppInvokable *> m_interfaces;
 };
-
-#endif

--- a/src/client/QXmppSceEnvelope_p.h
+++ b/src/client/QXmppSceEnvelope_p.h
@@ -14,8 +14,7 @@
 // We mean it.
 //
 
-#ifndef QXMPPSCEENVELOPE_P_H
-#define QXMPPSCEENVELOPE_P_H
+#pragma once
 
 #include "QXmppUtils.h"
 
@@ -106,5 +105,3 @@ public:
 private:
     QXmlStreamWriter &writer;
 };
-
-#endif  // QXMPPSCEENVELOPE_P_H

--- a/src/client/QXmppSendStanzaParams.h
+++ b/src/client/QXmppSendStanzaParams.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSENDSTANZAPARAMS_H
-#define QXMPPSENDSTANZAPARAMS_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppTrustLevel.h"
@@ -33,5 +32,3 @@ public:
 private:
     QSharedDataPointer<QXmppSendStanzaParamsPrivate> d;
 };
-
-#endif  // QXMPPSENDSTANZAPARAMS_H

--- a/src/client/QXmppTlsManager_p.h
+++ b/src/client/QXmppTlsManager_p.h
@@ -14,8 +14,7 @@
 // We mean it.
 //
 
-#ifndef QXMPPTLSMANAGER_H
-#define QXMPPTLSMANAGER_H
+#pragma once
 
 #include "QXmppInternalClientExtension_p.h"
 
@@ -35,5 +34,3 @@ public:
 
     bool handleStanza(const QDomElement &stanza) override;
 };
-
-#endif  // QXMPPTLSMANAGER_H

--- a/src/client/QXmppTransferManager.h
+++ b/src/client/QXmppTransferManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRANSFERMANAGER_H
-#define QXMPPTRANSFERMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -279,5 +278,3 @@ private:
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(QXmppTransferJob::Methods)
-
-#endif

--- a/src/client/QXmppTransferManager_p.h
+++ b/src/client/QXmppTransferManager_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRANSFERMANAGER_P_H
-#define QXMPPTRANSFERMANAGER_P_H
+#pragma once
 
 #include "QXmppByteStreamIq.h"
 #include "QXmppTransferManager.h"
@@ -65,5 +64,3 @@ private Q_SLOTS:
     void _q_proxyReady();
     void _q_sendData();
 };
-
-#endif

--- a/src/client/QXmppTrustLevel.h
+++ b/src/client/QXmppTrustLevel.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRUSTLEVEL_H
-#define QXMPPTRUSTLEVEL_H
+#pragma once
 
 #include <QFlags>
 #include <QHashFunctions>
@@ -44,5 +43,3 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(TrustLevels)
 // Scoped enums (enum class) are not implicitly converted to int
 inline uint qHash(QXmpp::TrustLevel key, uint seed) noexcept { return qHash(std::underlying_type_t<QXmpp::TrustLevel>(key), seed); }
 /// \endcond
-
-#endif  // QXMPPTRUSTLEVEL_H

--- a/src/client/QXmppTrustManager.h
+++ b/src/client/QXmppTrustManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRUSTMANAGER_H
-#define QXMPPTRUSTMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppTrustLevel.h"
@@ -57,5 +56,3 @@ protected:
 private:
     QXmppTrustStorage *m_trustStorage;
 };
-
-#endif  // QXMPPTRUSTMANAGER_H

--- a/src/client/QXmppTrustMemoryStorage.h
+++ b/src/client/QXmppTrustMemoryStorage.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRUSTMEMORYSTORAGE_H
-#define QXMPPTRUSTMEMORYSTORAGE_H
+#pragma once
 
 #include "QXmppTrustStorage.h"
 
@@ -44,5 +43,3 @@ public:
 private:
     std::unique_ptr<QXmppTrustMemoryStoragePrivate> d;
 };
-
-#endif  // QXMPPTRUSTMEMORYSTORAGE_H

--- a/src/client/QXmppTrustSecurityPolicy.h
+++ b/src/client/QXmppTrustSecurityPolicy.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRUSTSECURITYPOLICY_H
-#define QXMPPTRUSTSECURITYPOLICY_H
+#pragma once
 
 #include <QMetaType>
 
@@ -26,5 +25,3 @@ enum TrustSecurityPolicy {
 }  // namespace QXmpp
 
 Q_DECLARE_METATYPE(QXmpp::TrustSecurityPolicy)
-
-#endif  // QXMPPTRUSTSECURITYPOLICY_H

--- a/src/client/QXmppTrustStorage.h
+++ b/src/client/QXmppTrustStorage.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPTRUSTSTORAGE_H
-#define QXMPPTRUSTSTORAGE_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppTrustLevel.h"
@@ -39,5 +38,3 @@ public:
 
     virtual QXmppTask<void> resetAll(const QString &encryption) = 0;
 };
-
-#endif  // QXMPPTRUSTSTORAGE_H

--- a/src/client/QXmppUploadRequestManager.h
+++ b/src/client/QXmppUploadRequestManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPUPLOADREQUESTMANAGER_H
-#define QXMPPUPLOADREQUESTMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -136,5 +135,3 @@ private:
 
     const std::unique_ptr<QXmppUploadRequestManagerPrivate> d;
 };
-
-#endif  // QXMPPUPLOADREQUESTMANAGER_H

--- a/src/client/QXmppUserLocationManager.h
+++ b/src/client/QXmppUserLocationManager.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPUSERLOCATIONMANAGER_H
-#define QXMPPUSERLOCATIONMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -39,5 +38,3 @@ protected:
     bool handlePubSubEvent(const QDomElement &element, const QString &pubSubService, const QString &nodeName) override;
     /// \endcond
 };
-
-#endif  // QXMPPUSERLOCATIONMANAGER_H

--- a/src/client/QXmppUserTuneManager.h
+++ b/src/client/QXmppUserTuneManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPUSERTUNEMANAGER_H
-#define QXMPPUSERTUNEMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppError.h"
@@ -38,5 +37,3 @@ protected:
     bool handlePubSubEvent(const QDomElement &element, const QString &pubSubService, const QString &nodeName) override;
     /// \endcond
 };
-
-#endif  // QXMPPUSERTUNEMANAGER_H

--- a/src/client/QXmppVCardManager.h
+++ b/src/client/QXmppVCardManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPVCARDMANAGER_H
-#define QXMPPVCARDMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -67,5 +66,3 @@ Q_SIGNALS:
 private:
     const std::unique_ptr<QXmppVCardManagerPrivate> d;
 };
-
-#endif  // QXMPPVCARDMANAGER_H

--- a/src/client/QXmppVersionManager.h
+++ b/src/client/QXmppVersionManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPVERSIONMANAGER_H
-#define QXMPPVERSIONMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 
@@ -51,5 +50,3 @@ Q_SIGNALS:
 private:
     const std::unique_ptr<QXmppVersionManagerPrivate> d;
 };
-
-#endif  // QXMPPVERSIONMANAGER_H

--- a/src/omemo/QXmppOmemoDeviceBundle_p.h
+++ b/src/omemo/QXmppOmemoDeviceBundle_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMODEVICEBUNDLE_H
-#define QXMPPOMEMODEVICEBUNDLE_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -48,5 +47,3 @@ private:
 };
 
 Q_DECLARE_TYPEINFO(QXmppOmemoDeviceBundle, Q_MOVABLE_TYPE);
-
-#endif  // QXMPPOMEMODEVICEBUNDLE_H

--- a/src/omemo/QXmppOmemoDeviceElement_p.h
+++ b/src/omemo/QXmppOmemoDeviceElement_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMODEVICEELEMENT_H
-#define QXMPPOMEMODEVICEELEMENT_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -35,5 +34,3 @@ private:
 };
 
 Q_DECLARE_TYPEINFO(QXmppOmemoDeviceElement, Q_MOVABLE_TYPE);
-
-#endif  // QXMPPOMEMODEVICEELEMENT_H

--- a/src/omemo/QXmppOmemoDeviceList_p.h
+++ b/src/omemo/QXmppOmemoDeviceList_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMODEVICELIST_H
-#define QXMPPOMEMODEVICELIST_H
+#pragma once
 
 #include "QXmppGlobal.h"
 #include "QXmppOmemoDeviceElement_p.h"
@@ -26,5 +25,3 @@ public:
 };
 
 Q_DECLARE_TYPEINFO(QXmppOmemoDeviceList, Q_MOVABLE_TYPE);
-
-#endif  // QXMPPOMEMODEVICELIST_H

--- a/src/omemo/QXmppOmemoIq_p.h
+++ b/src/omemo/QXmppOmemoIq_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOIQ_H
-#define QXMPPOMEMOIQ_H
+#pragma once
 
 #include "QXmppIq.h"
 #include "QXmppOmemoElement_p.h"
@@ -24,5 +23,3 @@ public:
 private:
     QXmppOmemoElement m_omemoElement;
 };
-
-#endif  // QXMPPOMEMOIQ_H

--- a/src/omemo/QXmppOmemoItems_p.h
+++ b/src/omemo/QXmppOmemoItems_p.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOITEMS_H
-#define QXMPPOMEMOITEMS_H
+#pragma once
 
 #include "QXmppOmemoDeviceBundle_p.h"
 #include "QXmppOmemoDeviceList_p.h"
@@ -40,5 +39,3 @@ protected:
 private:
     QXmppOmemoDeviceList m_deviceList;
 };
-
-#endif  // QXMPPOMEMOITEMS_H

--- a/src/omemo/QXmppOmemoManager.h
+++ b/src/omemo/QXmppOmemoManager.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOMANAGER_H
-#define QXMPPOMEMOMANAGER_H
+#pragma once
 
 #include "QXmppClientExtension.h"
 #include "QXmppE2eeExtension.h"
@@ -157,5 +156,3 @@ private:
     friend class QXmppOmemoManagerPrivate;
     friend class tst_QXmppOmemoManager;
 };
-
-#endif  // QXMPPOMEMOMANAGER_H

--- a/src/omemo/QXmppOmemoManager_p.h
+++ b/src/omemo/QXmppOmemoManager_p.h
@@ -3,8 +3,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOMANAGER_P_H
-#define QXMPPOMEMOMANAGER_P_H
+#pragma once
 
 #include "QXmppE2eeMetadata.h"
 #include "QXmppOmemoDeviceBundle_p.h"
@@ -352,5 +351,3 @@ public:
 
     void warning(const QString &msg) const;
 };
-
-#endif  // QXMPPOMEMOMANAGER_P_H

--- a/src/omemo/QXmppOmemoMemoryStorage.h
+++ b/src/omemo/QXmppOmemoMemoryStorage.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOMEMORYSTORAGE_H
-#define QXMPPOMEMOMEMORYSTORAGE_H
+#pragma once
 
 #include "QXmppOmemoStorage.h"
 #include "QXmppTask.h"
@@ -40,5 +39,3 @@ public:
 private:
     std::unique_ptr<QXmppOmemoMemoryStoragePrivate> d;
 };
-
-#endif  // QXMPPOMEMOMEMORYSTORAGE_H

--- a/src/omemo/QXmppOmemoStorage.h
+++ b/src/omemo/QXmppOmemoStorage.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOMEMOSTORAGE_H
-#define QXMPPOMEMOSTORAGE_H
+#pragma once
 
 #include "QXmppTask.h"
 #include "qxmppomemo_export.h"
@@ -171,5 +170,3 @@ public:
 
     virtual QXmppTask<void> resetAll() = 0;
 };
-
-#endif  // QXMPPOMEMOSTORAGE_H

--- a/src/server/QXmppDialback.h
+++ b/src/server/QXmppDialback.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPDIALBACK_H
-#define QXMPPDIALBACK_H
+#pragma once
 
 #include "QXmppStanza.h"
 
@@ -46,5 +45,3 @@ private:
     QString m_key;
     QString m_type;
 };
-
-#endif

--- a/src/server/QXmppIncomingClient.h
+++ b/src/server/QXmppIncomingClient.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPINCOMINGCLIENT_H
-#define QXMPPINCOMINGCLIENT_H
+#pragma once
 
 #include "QXmppStream.h"
 
@@ -52,5 +51,3 @@ private:
     QXmppIncomingClientPrivate *d;
     friend class QXmppIncomingClientPrivate;
 };
-
-#endif

--- a/src/server/QXmppIncomingServer.h
+++ b/src/server/QXmppIncomingServer.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPINCOMINGSERVER_H
-#define QXMPPINCOMINGSERVER_H
+#pragma once
 
 #include "QXmppStream.h"
 
@@ -48,5 +47,3 @@ private:
     QXmppIncomingServerPrivate *d;
     friend class QXmppIncomingServerPrivate;
 };
-
-#endif

--- a/src/server/QXmppOutgoingServer.h
+++ b/src/server/QXmppOutgoingServer.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPOUTGOINGSERVER_H
-#define QXMPPOUTGOINGSERVER_H
+#pragma once
 
 #include "QXmppStream.h"
 
@@ -60,5 +59,3 @@ private:
     Q_DISABLE_COPY(QXmppOutgoingServer)
     QXmppOutgoingServerPrivate *const d;
 };
-
-#endif

--- a/src/server/QXmppPasswordChecker.h
+++ b/src/server/QXmppPasswordChecker.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPPASSWORDCHECKER_H
-#define QXMPPPASSWORDCHECKER_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -89,5 +88,3 @@ public:
 protected:
     virtual QXmppPasswordReply::Error getPassword(const QXmppPasswordRequest &request, QString &password);
 };
-
-#endif

--- a/src/server/QXmppServer.h
+++ b/src/server/QXmppServer.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSERVER_H
-#define QXMPPSERVER_H
+#pragma once
 
 #include "QXmppLogger.h"
 
@@ -130,5 +129,3 @@ private:
     void incomingConnection(qintptr socketDescriptor) override;
     QXmppSslServerPrivate *const d;
 };
-
-#endif

--- a/src/server/QXmppServerExtension.h
+++ b/src/server/QXmppServerExtension.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSERVEREXTENSION_H
-#define QXMPPSERVEREXTENSION_H
+#pragma once
 
 #include "QXmppLogger.h"
 
@@ -53,5 +52,3 @@ private:
 
     friend class QXmppServer;
 };
-
-#endif

--- a/src/server/QXmppServerPlugin.h
+++ b/src/server/QXmppServerPlugin.h
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef QXMPPSERVERPLUGIN_H
-#define QXMPPSERVERPLUGIN_H
+#pragma once
 
 #include "QXmppGlobal.h"
 
@@ -42,5 +41,3 @@ public:
     ///
     QStringList keys() const override = 0;
 };
-
-#endif


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
