### PR TITLE
Client: Add constructor that allows to create without extensions

### DIFF
--- a/src/client/QXmppClient.cpp
+++ b/src/client/QXmppClient.cpp
@@ -188,15 +188,16 @@ bool process(QXmppClient *client, const QList<QXmppClientExtension *> &extension
 /// \since QXmpp 1.5
 ///
 
+///
 /// Creates a QXmppClient object.
-/// \param parent is passed to the QObject's constructor.
-/// The default value is 0.
-
-QXmppClient::QXmppClient(QObject *parent)
+///
+/// \param initialExtensions can be used to set the initial set of extensions.
+/// \param parent is passed to the QObject's constructor. The default value is 0.
+///
+QXmppClient::QXmppClient(InitialExtensions initialExtensions, QObject *parent)
     : QXmppLoggable(parent),
       d(new QXmppClientPrivate(this))
 {
-
     d->stream = new QXmppOutgoingClient(this);
     d->addProperCapability(d->clientPresence);
 
@@ -236,12 +237,29 @@ QXmppClient::QXmppClient(QObject *parent)
     // logging
     setLogger(QXmppLogger::getLogger());
 
+    // always add TLS manager (it is private and can't be added by the user)
     addExtension(new QXmppTlsManager);
-    addExtension(new QXmppRosterManager(this));
-    addExtension(new QXmppVCardManager);
-    addExtension(new QXmppVersionManager);
-    addExtension(new QXmppEntityTimeManager());
-    addExtension(new QXmppDiscoveryManager());
+
+    switch (initialExtensions) {
+    case NoExtensions:
+        break;
+    case BasicExtensions:
+        addExtension(new QXmppRosterManager(this));
+        addExtension(new QXmppVCardManager);
+        addExtension(new QXmppVersionManager);
+        addExtension(new QXmppEntityTimeManager());
+        addExtension(new QXmppDiscoveryManager());
+        break;
+    }
+}
+
+///
+/// Creates a QXmppClient object.
+/// \param parent is passed to the QObject's constructor.
+///
+QXmppClient::QXmppClient(QObject *parent)
+    : QXmppClient(BasicExtensions, parent)
+{
 }
 
 QXmppClient::~QXmppClient() = default;

--- a/src/client/QXmppClient.h
+++ b/src/client/QXmppClient.h
@@ -121,6 +121,16 @@ public:
         ResumedStream
     };
 
+    /// Used to decide which extensions should be added by default.
+    /// \since QXmpp 1.6
+    enum InitialExtensions {
+        /// Creates a client without any extensions.
+        NoExtensions,
+        /// Creates a client with the default set of extensions.
+        BasicExtensions,
+    };
+
+    QXmppClient(InitialExtensions, QObject *parent = nullptr);
     QXmppClient(QObject *parent = nullptr);
     ~QXmppClient() override;
 


### PR DESCRIPTION
Closes #585.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [ ] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
