### PR TITLE
OmemoManager: Do not use a default fallback body for chat markers

### DIFF
--- a/src/omemo/QXmppOmemoManager_p.cpp
+++ b/src/omemo/QXmppOmemoManager_p.cpp
@@ -991,7 +991,7 @@ QXmppTask<QXmppE2eeExtension::MessageEncryptResult> ManagerPrivate::encryptMessa
                 };
                 interface.finish(error);
             } else {
-                const auto areDeliveryReceiptsUsed = message.isReceiptRequested() || !message.receiptId().isEmpty();
+                const auto deliveryReceiptsUsed = message.isReceiptRequested() || !message.receiptId().isEmpty();
                 const auto chatMarkerUsed = message.marker() != QXmppMessage::NoMarker;
 
                 // The following cases are covered:
@@ -1003,15 +1003,15 @@ QXmppTask<QXmppE2eeExtension::MessageEncryptResult> ManagerPrivate::encryptMessa
                 //       in case of delivery receipts or chat marker usage
                 //  2.2. Other message (e.g., trust message) => usage of EME and fallback body to
                 //       look like a normal message
-                if (!message.body().isEmpty() || (message.state() == QXmppMessage::None && !areDeliveryReceiptsUsed && !chatMarkerUsed)) {
+                if (!message.body().isEmpty() || (message.state() == QXmppMessage::None && !deliveryReceiptsUsed && !chatMarkerUsed)) {
                     message.setEncryptionMethod(QXmpp::Omemo2);
 
                     // A message processing hint for instructing the server to store the message is
                     // not needed because of the public fallback body.
                     message.setE2eeFallbackBody(QStringLiteral("This message is encrypted with %1 but could not be decrypted").arg(message.encryptionName()));
                     message.setIsFallback(true);
-                } else if (areDeliveryReceiptsUsed || chatMarkerUsed) {
-                    // A message processing hint for instructing the server to tore the message is
+                } else if (deliveryReceiptsUsed || chatMarkerUsed) {
+                    // A message processing hint for instructing the server to store the message is
                     // needed because of the missing public fallback body.
                     message.addHint(QXmppMessage::Store);
                 }


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
