### PR TITLE
ci: Add doxygen job that is failing on warnings

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,6 @@
 PR check list:
 - [ ] Document your code
 - [ ] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
-- [ ] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
 - [ ] Update `doc/doap.xml`
 - [ ] Add unit tests
 - [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,17 @@ jobs:
           # ctest
           # ctest --rerun-failed --output-on-failure
 
+  doxygen:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:stable
+    steps:
+      - name: Install dependencies
+        run: apt update && apt install -qq -y sudo git clang cmake qt6-base-dev doxygen graphviz
+      - uses: actions/checkout@v3
+      - name: Build doxygen documentation
+        run: tests/travis/build-documentation
+
   xmllint:
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +119,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1
+
   cpp-linter:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 CMakeLists.txt.*
 .DS_Store
-build*
+/build*
 .kdev4/
 *.kdev4
 support-chat-avatar.png

--- a/tests/travis/build-documentation
+++ b/tests/travis/build-documentation
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2024 Linus Jahn <lnj@kaidan.im>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+set -e
+
+# Make warnings errors
+echo "WARN_AS_ERROR = FAIL_ON_WARNINGS" >> doc/Doxyfile.in
+
+mkdir build
+cd build
+cmake .. -DBUILD_DOCUMENTATION=ON
+
+make doc


### PR DESCRIPTION
PR check list:
- [ ] Document your code
- [ ] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [ ] Fix doxygen warnings (see log when building with `-DBUILD_DOCUMENTATION=ON`)
- [ ] Update `doc/doap.xml`
- [ ] Add unit tests
- [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
