### PR TITLE
Utils: Namespace xml helper functions and mark private

### DIFF
--- a/src/base/QXmppArchiveIq.cpp
+++ b/src/base/QXmppArchiveIq.cpp
@@ -6,8 +6,11 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 QXmppArchiveMessage::QXmppArchiveMessage()
     : m_received(false)
@@ -95,21 +98,21 @@ void QXmppArchiveChat::toXml(QXmlStreamWriter *writer, const QXmppResultSetReply
 {
     writer->writeStartElement(QStringLiteral("chat"));
     writer->writeDefaultNamespace(ns_archive);
-    helperToXmlAddAttribute(writer, QStringLiteral("with"), m_with);
+    writeOptionalXmlAttribute(writer, QStringLiteral("with"), m_with);
     if (m_start.isValid()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
+        writeOptionalXmlAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
     }
-    helperToXmlAddAttribute(writer, QStringLiteral("subject"), m_subject);
-    helperToXmlAddAttribute(writer, QStringLiteral("thread"), m_thread);
+    writeOptionalXmlAttribute(writer, QStringLiteral("subject"), m_subject);
+    writeOptionalXmlAttribute(writer, QStringLiteral("thread"), m_thread);
     if (m_version) {
-        helperToXmlAddAttribute(writer, QStringLiteral("version"), QString::number(m_version));
+        writeOptionalXmlAttribute(writer, QStringLiteral("version"), QString::number(m_version));
     }
 
     QDateTime prevTime = m_start;
 
     for (const QXmppArchiveMessage &message : m_messages) {
         writer->writeStartElement(message.isReceived() ? QStringLiteral("from") : QStringLiteral("to"));
-        helperToXmlAddAttribute(writer, QStringLiteral("secs"), QString::number(prevTime.secsTo(message.date())));
+        writeOptionalXmlAttribute(writer, QStringLiteral("secs"), QString::number(prevTime.secsTo(message.date())));
         writer->writeTextElement(QStringLiteral("body"), message.body());
         writer->writeEndElement();
         prevTime = message.date();
@@ -399,13 +402,13 @@ void QXmppArchiveListIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     writer->writeStartElement(QStringLiteral("list"));
     writer->writeDefaultNamespace(ns_archive);
     if (!m_with.isEmpty()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("with"), m_with);
+        writeOptionalXmlAttribute(writer, QStringLiteral("with"), m_with);
     }
     if (m_start.isValid()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
+        writeOptionalXmlAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
     }
     if (m_end.isValid()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("end"), QXmppUtils::datetimeToString(m_end));
+        writeOptionalXmlAttribute(writer, QStringLiteral("end"), QXmppUtils::datetimeToString(m_end));
     }
     if (!m_rsmQuery.isNull()) {
         m_rsmQuery.toXml(writer);
@@ -509,13 +512,13 @@ void QXmppArchiveRemoveIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     writer->writeStartElement(QStringLiteral("remove"));
     writer->writeDefaultNamespace(ns_archive);
     if (!m_with.isEmpty()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("with"), m_with);
+        writeOptionalXmlAttribute(writer, QStringLiteral("with"), m_with);
     }
     if (m_start.isValid()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
+        writeOptionalXmlAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
     }
     if (m_end.isValid()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("end"), QXmppUtils::datetimeToString(m_end));
+        writeOptionalXmlAttribute(writer, QStringLiteral("end"), QXmppUtils::datetimeToString(m_end));
     }
     writer->writeEndElement();
 }
@@ -598,8 +601,8 @@ void QXmppArchiveRetrieveIq::toXmlElementFromChild(QXmlStreamWriter *writer) con
 {
     writer->writeStartElement(QStringLiteral("retrieve"));
     writer->writeDefaultNamespace(ns_archive);
-    helperToXmlAddAttribute(writer, QStringLiteral("with"), m_with);
-    helperToXmlAddAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
+    writeOptionalXmlAttribute(writer, QStringLiteral("with"), m_with);
+    writeOptionalXmlAttribute(writer, QStringLiteral("start"), QXmppUtils::datetimeToString(m_start));
     if (!m_rsmQuery.isNull()) {
         m_rsmQuery.toXml(writer);
     }

--- a/src/base/QXmppBindIq.cpp
+++ b/src/base/QXmppBindIq.cpp
@@ -6,11 +6,13 @@
 #include "QXmppBindIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QTextStream>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 /// Returns the bound JID.
 ///
@@ -65,10 +67,10 @@ void QXmppBindIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     writer->writeStartElement(QStringLiteral("bind"));
     writer->writeDefaultNamespace(ns_bind);
     if (!m_jid.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("jid"), m_jid);
+        writeXmlTextElement(writer, QStringLiteral("jid"), m_jid);
     }
     if (!m_resource.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("resource"), m_resource);
+        writeXmlTextElement(writer, QStringLiteral("resource"), m_resource);
     }
     writer->writeEndElement();
 }

--- a/src/base/QXmppBitsOfBinaryData.cpp
+++ b/src/base/QXmppBitsOfBinaryData.cpp
@@ -5,13 +5,15 @@
 #include "QXmppBitsOfBinaryContentId.h"
 #include "QXmppBitsOfBinaryDataList.h"
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QMimeDatabase>
 #include <QMimeType>
 #include <QSharedData>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 class QXmppBitsOfBinaryDataPrivate : public QSharedData
 {
@@ -180,11 +182,11 @@ void QXmppBitsOfBinaryData::toXmlElementFromChild(QXmlStreamWriter *writer) cons
 {
     writer->writeStartElement(QStringLiteral("data"));
     writer->writeDefaultNamespace(ns_bob);
-    helperToXmlAddAttribute(writer, QStringLiteral("cid"), d->cid.toContentId());
+    writeOptionalXmlAttribute(writer, QStringLiteral("cid"), d->cid.toContentId());
     if (d->maxAge > -1) {
-        helperToXmlAddAttribute(writer, QStringLiteral("max-age"), QString::number(d->maxAge));
+        writeOptionalXmlAttribute(writer, QStringLiteral("max-age"), QString::number(d->maxAge));
     }
-    helperToXmlAddAttribute(writer, QStringLiteral("type"), d->contentType.name());
+    writeOptionalXmlAttribute(writer, QStringLiteral("type"), d->contentType.name());
     writer->writeCharacters(d->data.toBase64());
     writer->writeEndElement();
 }

--- a/src/base/QXmppBookmarkSet.cpp
+++ b/src/base/QXmppBookmarkSet.cpp
@@ -4,9 +4,11 @@
 
 #include "QXmppBookmarkSet.h"
 
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 static const char *ns_bookmarks = "storage:bookmarks";
 
@@ -191,19 +193,19 @@ void QXmppBookmarkSet::toXml(QXmlStreamWriter *writer) const
     for (const auto &conference : m_conferences) {
         writer->writeStartElement(QStringLiteral("conference"));
         if (conference.autoJoin()) {
-            helperToXmlAddAttribute(writer, QStringLiteral("autojoin"), QStringLiteral("true"));
+            writeOptionalXmlAttribute(writer, QStringLiteral("autojoin"), QStringLiteral("true"));
         }
-        helperToXmlAddAttribute(writer, QStringLiteral("jid"), conference.jid());
-        helperToXmlAddAttribute(writer, QStringLiteral("name"), conference.name());
+        writeOptionalXmlAttribute(writer, QStringLiteral("jid"), conference.jid());
+        writeOptionalXmlAttribute(writer, QStringLiteral("name"), conference.name());
         if (!conference.nickName().isEmpty()) {
-            helperToXmlAddTextElement(writer, QStringLiteral("nick"), conference.nickName());
+            writeXmlTextElement(writer, QStringLiteral("nick"), conference.nickName());
         }
         writer->writeEndElement();
     }
     for (const auto &url : m_urls) {
         writer->writeStartElement(QStringLiteral("url"));
-        helperToXmlAddAttribute(writer, QStringLiteral("name"), url.name());
-        helperToXmlAddAttribute(writer, QStringLiteral("url"), url.url().toString());
+        writeOptionalXmlAttribute(writer, QStringLiteral("name"), url.name());
+        writeOptionalXmlAttribute(writer, QStringLiteral("url"), url.url().toString());
         writer->writeEndElement();
     }
     writer->writeEndElement();

--- a/src/base/QXmppByteStreamIq.cpp
+++ b/src/base/QXmppByteStreamIq.cpp
@@ -5,9 +5,11 @@
 #include "QXmppByteStreamIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 ///
 /// \enum QXmppByteStreamIq::Mode
@@ -213,28 +215,28 @@ void QXmppByteStreamIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("query"));
     writer->writeDefaultNamespace(ns_bytestreams);
-    helperToXmlAddAttribute(writer, QStringLiteral("sid"), m_sid);
+    writeOptionalXmlAttribute(writer, QStringLiteral("sid"), m_sid);
     QString modeStr;
     if (m_mode == Tcp) {
         modeStr = QStringLiteral("tcp");
     } else if (m_mode == Udp) {
         modeStr = QStringLiteral("udp");
     }
-    helperToXmlAddAttribute(writer, QStringLiteral("mode"), modeStr);
+    writeOptionalXmlAttribute(writer, QStringLiteral("mode"), modeStr);
     for (const auto &streamHost : m_streamHosts) {
         writer->writeStartElement(QStringLiteral("streamhost"));
-        helperToXmlAddAttribute(writer, QStringLiteral("host"), streamHost.host());
-        helperToXmlAddAttribute(writer, QStringLiteral("jid"), streamHost.jid());
-        helperToXmlAddAttribute(writer, QStringLiteral("port"), QString::number(streamHost.port()));
-        helperToXmlAddAttribute(writer, QStringLiteral("zeroconf"), streamHost.zeroconf());
+        writeOptionalXmlAttribute(writer, QStringLiteral("host"), streamHost.host());
+        writeOptionalXmlAttribute(writer, QStringLiteral("jid"), streamHost.jid());
+        writeOptionalXmlAttribute(writer, QStringLiteral("port"), QString::number(streamHost.port()));
+        writeOptionalXmlAttribute(writer, QStringLiteral("zeroconf"), streamHost.zeroconf());
         writer->writeEndElement();
     }
     if (!m_activate.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("activate"), m_activate);
+        writeXmlTextElement(writer, QStringLiteral("activate"), m_activate);
     }
     if (!m_streamHostUsed.isEmpty()) {
         writer->writeStartElement(QStringLiteral("streamhost-used"));
-        helperToXmlAddAttribute(writer, QStringLiteral("jid"), m_streamHostUsed);
+        writeOptionalXmlAttribute(writer, QStringLiteral("jid"), m_streamHostUsed);
         writer->writeEndElement();
     }
 

--- a/src/base/QXmppDataForm.cpp
+++ b/src/base/QXmppDataForm.cpp
@@ -7,7 +7,7 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppDataFormBase.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <optional>
 
@@ -18,6 +18,8 @@
 #include <QSize>
 #include <QStringList>
 #include <QUrl>
+
+using namespace QXmpp::Private;
 
 struct field_type
 {
@@ -909,26 +911,26 @@ void QXmppDataForm::toXml(QXmlStreamWriter *writer) const
         writer->writeAttribute("type", fieldTypeToString(field.type()));
 
         /* field attributes */
-        helperToXmlAddAttribute(writer, "label", field.label());
-        helperToXmlAddAttribute(writer, "var", field.key());
+        writeOptionalXmlAttribute(writer, "label", field.label());
+        writeOptionalXmlAttribute(writer, "var", field.key());
 
         /* field value(s) */
         switch (field.type()) {
         case Field::BooleanField:
-            helperToXmlAddTextElement(writer, "value", field.value().toBool() ? "1" : "0");
+            writeXmlTextElement(writer, "value", field.value().toBool() ? "1" : "0");
             break;
         case Field::ListMultiField:
         case Field::JidMultiField:
         case Field::TextMultiField: {
             const auto values = field.value().toStringList();
             for (const QString &value : values) {
-                helperToXmlAddTextElement(writer, "value", value);
+                writeXmlTextElement(writer, "value", value);
             }
             break;
         }
         default:
             if (const auto value = field.value().toString(); !value.isEmpty()) {
-                helperToXmlAddTextElement(writer, "value", value);
+                writeXmlTextElement(writer, "value", value);
             }
         }
 
@@ -939,13 +941,13 @@ void QXmppDataForm::toXml(QXmlStreamWriter *writer) const
 
             // media width and height
             if (field.mediaSize().width() > 0) {
-                helperToXmlAddAttribute(
+                writeOptionalXmlAttribute(
                     writer,
                     QStringLiteral("width"),
                     QString::number(field.mediaSize().width()));
             }
             if (field.mediaSize().height() > 0) {
-                helperToXmlAddAttribute(
+                writeOptionalXmlAttribute(
                     writer,
                     QStringLiteral("height"),
                     QString::number(field.mediaSize().height()));
@@ -954,7 +956,7 @@ void QXmppDataForm::toXml(QXmlStreamWriter *writer) const
             const auto sources = field.mediaSources();
             for (const auto &source : sources) {
                 writer->writeStartElement(QStringLiteral("uri"));
-                helperToXmlAddAttribute(writer, QStringLiteral("type"), source.contentType().name());
+                writeOptionalXmlAttribute(writer, QStringLiteral("type"), source.contentType().name());
                 writer->writeCharacters(source.uri().toString());
                 writer->writeEndElement();
             }
@@ -969,8 +971,8 @@ void QXmppDataForm::toXml(QXmlStreamWriter *writer) const
             const auto options = field.options();
             for (const auto &option : options) {
                 writer->writeStartElement("option");
-                helperToXmlAddAttribute(writer, "label", option.first);
-                helperToXmlAddTextElement(writer, "value", option.second);
+                writeOptionalXmlAttribute(writer, "label", option.first);
+                writeXmlTextElement(writer, "value", option.second);
                 writer->writeEndElement();
             }
         }
@@ -980,10 +982,10 @@ void QXmppDataForm::toXml(QXmlStreamWriter *writer) const
 
         /* other properties */
         if (!field.description().isEmpty()) {
-            helperToXmlAddTextElement(writer, "description", field.description());
+            writeXmlTextElement(writer, "description", field.description());
         }
         if (field.isRequired()) {
-            helperToXmlAddTextElement(writer, "required", "");
+            writeXmlTextElement(writer, "required", "");
         }
 
         writer->writeEndElement();

--- a/src/base/QXmppDiscoveryIq.cpp
+++ b/src/base/QXmppDiscoveryIq.cpp
@@ -5,11 +5,13 @@
 #include "QXmppDiscoveryIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QCryptographicHash>
 #include <QDomElement>
 #include <QSharedData>
+
+using namespace QXmpp::Private;
 
 static bool identityLessThan(const QXmppDiscoveryIq::Identity &i1, const QXmppDiscoveryIq::Identity &i2)
 {
@@ -495,29 +497,29 @@ void QXmppDiscoveryIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     writer->writeStartElement("query");
     writer->writeDefaultNamespace(
         d->queryType == InfoQuery ? ns_disco_info : ns_disco_items);
-    helperToXmlAddAttribute(writer, "node", d->queryNode);
+    writeOptionalXmlAttribute(writer, "node", d->queryNode);
 
     if (d->queryType == InfoQuery) {
         for (const auto &identity : d->identities) {
             writer->writeStartElement("identity");
-            helperToXmlAddAttribute(writer, "xml:lang", identity.language());
-            helperToXmlAddAttribute(writer, "category", identity.category());
-            helperToXmlAddAttribute(writer, "name", identity.name());
-            helperToXmlAddAttribute(writer, "type", identity.type());
+            writeOptionalXmlAttribute(writer, "xml:lang", identity.language());
+            writeOptionalXmlAttribute(writer, "category", identity.category());
+            writeOptionalXmlAttribute(writer, "name", identity.name());
+            writeOptionalXmlAttribute(writer, "type", identity.type());
             writer->writeEndElement();
         }
 
         for (const auto &feature : d->features) {
             writer->writeStartElement("feature");
-            helperToXmlAddAttribute(writer, "var", feature);
+            writeOptionalXmlAttribute(writer, "var", feature);
             writer->writeEndElement();
         }
     } else {
         for (const auto &item : d->items) {
             writer->writeStartElement("item");
-            helperToXmlAddAttribute(writer, "jid", item.jid());
-            helperToXmlAddAttribute(writer, "name", item.name());
-            helperToXmlAddAttribute(writer, "node", item.node());
+            writeOptionalXmlAttribute(writer, "jid", item.jid());
+            writeOptionalXmlAttribute(writer, "name", item.name());
+            writeOptionalXmlAttribute(writer, "node", item.node());
             writer->writeEndElement();
         }
     }

--- a/src/base/QXmppElement.cpp
+++ b/src/base/QXmppElement.cpp
@@ -4,10 +4,12 @@
 
 #include "QXmppElement.h"
 
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QTextStream>
+
+using namespace QXmpp::Private;
 
 class QXmppElementPrivate
 {
@@ -294,7 +296,7 @@ void QXmppElement::toXml(QXmlStreamWriter *writer) const
     }
     std::for_each(d->attributes.keyBegin(), d->attributes.keyEnd(), [this, writer](const QString &key) {
         if (key != "xmlns") {
-            helperToXmlAddAttribute(writer, key, d->attributes.value(key));
+            writeOptionalXmlAttribute(writer, key, d->attributes.value(key));
         }
     });
     if (!d->value.isEmpty()) {

--- a/src/base/QXmppEntityTimeIq.cpp
+++ b/src/base/QXmppEntityTimeIq.cpp
@@ -6,8 +6,11 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 ///
 /// Returns the timezone offset in seconds.
@@ -73,8 +76,8 @@ void QXmppEntityTimeIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     writer->writeDefaultNamespace(ns_entity_time);
 
     if (m_utc.isValid()) {
-        helperToXmlAddTextElement(writer, "tzo", QXmppUtils::timezoneOffsetToString(m_tzo));
-        helperToXmlAddTextElement(writer, "utc", QXmppUtils::datetimeToString(m_utc));
+        writeXmlTextElement(writer, "tzo", QXmppUtils::timezoneOffsetToString(m_tzo));
+        writeXmlTextElement(writer, "utc", QXmppUtils::datetimeToString(m_utc));
     }
     writer->writeEndElement();
 }

--- a/src/base/QXmppExternalServiceDiscoveryIq.cpp
+++ b/src/base/QXmppExternalServiceDiscoveryIq.cpp
@@ -6,9 +6,12 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDateTime>
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 using Action = QXmppExternalService::Action;
 using Transport = QXmppExternalService::Transport;
@@ -326,39 +329,39 @@ void QXmppExternalService::parse(const QDomElement &el)
 void QXmppExternalService::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement("service");
-    helperToXmlAddAttribute(writer, "host", d->host);
-    helperToXmlAddAttribute(writer, "type", d->type);
+    writeOptionalXmlAttribute(writer, "host", d->host);
+    writeOptionalXmlAttribute(writer, "type", d->type);
 
     if (d->action) {
-        helperToXmlAddAttribute(writer, "action", actionToString(d->action.value()));
+        writeOptionalXmlAttribute(writer, "action", actionToString(d->action.value()));
     }
 
     if (d->expires) {
-        helperToXmlAddAttribute(writer, "expires", d->expires->toString(Qt::ISODateWithMs));
+        writeOptionalXmlAttribute(writer, "expires", d->expires->toString(Qt::ISODateWithMs));
     }
 
     if (d->name) {
-        helperToXmlAddAttribute(writer, "name", d->name.value());
+        writeOptionalXmlAttribute(writer, "name", d->name.value());
     }
 
     if (d->password) {
-        helperToXmlAddAttribute(writer, "password", d->password.value());
+        writeOptionalXmlAttribute(writer, "password", d->password.value());
     }
 
     if (d->port) {
-        helperToXmlAddAttribute(writer, "port", QString::number(d->port.value()));
+        writeOptionalXmlAttribute(writer, "port", QString::number(d->port.value()));
     }
 
     if (d->restricted) {
-        helperToXmlAddAttribute(writer, "restricted", d->restricted.value() ? "true" : "false");
+        writeOptionalXmlAttribute(writer, "restricted", d->restricted.value() ? "true" : "false");
     }
 
     if (d->transport) {
-        helperToXmlAddAttribute(writer, "transport", transportToString(d->transport.value()));
+        writeOptionalXmlAttribute(writer, "transport", transportToString(d->transport.value()));
     }
 
     if (d->username) {
-        helperToXmlAddAttribute(writer, "username", d->username.value());
+        writeOptionalXmlAttribute(writer, "username", d->username.value());
     }
 
     writer->writeEndElement();

--- a/src/base/QXmppGeolocItem.cpp
+++ b/src/base/QXmppGeolocItem.cpp
@@ -5,10 +5,12 @@
 #include "QXmppGeolocItem.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 /// \cond
 class QXmppGeolocItemPrivate : public QSharedData
@@ -185,7 +187,7 @@ auto writeTextEl(QXmlStreamWriter *writer, const QString &name, const std::optio
 }
 auto writeTextEl(QXmlStreamWriter *writer, const QString &name, const QString &val)
 {
-    helperToXmlAddTextElement(writer, name, val);
+    writeXmlTextElement(writer, name, val);
 }
 
 void QXmppGeolocItem::serializePayload(QXmlStreamWriter *writer) const

--- a/src/base/QXmppIq.cpp
+++ b/src/base/QXmppIq.cpp
@@ -4,10 +4,12 @@
 
 #include "QXmppIq.h"
 
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 static const char *iq_types[] = {
     "error",
@@ -106,10 +108,10 @@ void QXmppIq::toXml(QXmlStreamWriter *xmlWriter) const
 {
     xmlWriter->writeStartElement("iq");
 
-    helperToXmlAddAttribute(xmlWriter, "id", id());
-    helperToXmlAddAttribute(xmlWriter, "to", to());
-    helperToXmlAddAttribute(xmlWriter, "from", from());
-    helperToXmlAddAttribute(xmlWriter, "type", iq_types[d->type]);
+    writeOptionalXmlAttribute(xmlWriter, "id", id());
+    writeOptionalXmlAttribute(xmlWriter, "to", to());
+    writeOptionalXmlAttribute(xmlWriter, "from", from());
+    writeOptionalXmlAttribute(xmlWriter, "type", iq_types[d->type]);
     toXmlElementFromChild(xmlWriter);
     error().toXml(xmlWriter);
     xmlWriter->writeEndElement();

--- a/src/base/QXmppJingleData.cpp
+++ b/src/base/QXmppJingleData.cpp
@@ -6,12 +6,14 @@
 #include "QXmppJingleData.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDate>
 #include <QDateTime>
 #include <QDomElement>
 #include <QRegularExpression>
+
+using namespace QXmpp::Private;
 
 static const int RTP_COMPONENT = 1;
 
@@ -761,16 +763,16 @@ void QXmppJingleIq::Content::toXml(QXmlStreamWriter *writer) const
     }
 
     writer->writeStartElement(QStringLiteral("content"));
-    helperToXmlAddAttribute(writer, QStringLiteral("creator"), d->creator);
-    helperToXmlAddAttribute(writer, QStringLiteral("disposition"), d->disposition);
-    helperToXmlAddAttribute(writer, QStringLiteral("name"), d->name);
-    helperToXmlAddAttribute(writer, QStringLiteral("senders"), d->senders);
+    writeOptionalXmlAttribute(writer, QStringLiteral("creator"), d->creator);
+    writeOptionalXmlAttribute(writer, QStringLiteral("disposition"), d->disposition);
+    writeOptionalXmlAttribute(writer, QStringLiteral("name"), d->name);
+    writeOptionalXmlAttribute(writer, QStringLiteral("senders"), d->senders);
 
     // description
     if (!d->description.type().isEmpty() || !d->description.payloadTypes().isEmpty()) {
         writer->writeStartElement(QStringLiteral("description"));
         writer->writeDefaultNamespace(d->description.type());
-        helperToXmlAddAttribute(writer, QStringLiteral("media"), d->description.media());
+        writeOptionalXmlAttribute(writer, QStringLiteral("media"), d->description.media());
 
         if (d->description.ssrc()) {
             writer->writeAttribute(QStringLiteral("ssrc"), QString::number(d->description.ssrc()));
@@ -798,8 +800,8 @@ void QXmppJingleIq::Content::toXml(QXmlStreamWriter *writer) const
     if (!d->transportType.isEmpty() || !d->transportCandidates.isEmpty()) {
         writer->writeStartElement(QStringLiteral("transport"));
         writer->writeDefaultNamespace(d->transportType);
-        helperToXmlAddAttribute(writer, QStringLiteral("ufrag"), d->transportUser);
-        helperToXmlAddAttribute(writer, QStringLiteral("pwd"), d->transportPassword);
+        writeOptionalXmlAttribute(writer, QStringLiteral("ufrag"), d->transportUser);
+        writeOptionalXmlAttribute(writer, QStringLiteral("pwd"), d->transportPassword);
         for (const auto &candidate : d->transportCandidates) {
             candidate.toXml(writer);
         }
@@ -1129,7 +1131,7 @@ void QXmppJingleReason::toXml(QXmlStreamWriter *writer) const
     writer->writeDefaultNamespace(ns_jingle);
 
     if (!d->m_text.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("text"), d->m_text);
+        writeXmlTextElement(writer, QStringLiteral("text"), d->m_text);
     }
     writer->writeEmptyElement(jingle_reasons[d->m_type]);
 
@@ -1454,16 +1456,16 @@ void QXmppJingleIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("jingle"));
     writer->writeDefaultNamespace(ns_jingle);
-    helperToXmlAddAttribute(writer, QStringLiteral("action"), jingle_actions[d->action]);
-    helperToXmlAddAttribute(writer, QStringLiteral("initiator"), d->initiator);
-    helperToXmlAddAttribute(writer, QStringLiteral("responder"), d->responder);
-    helperToXmlAddAttribute(writer, QStringLiteral("sid"), d->sid);
+    writeOptionalXmlAttribute(writer, QStringLiteral("action"), jingle_actions[d->action]);
+    writeOptionalXmlAttribute(writer, QStringLiteral("initiator"), d->initiator);
+    writeOptionalXmlAttribute(writer, QStringLiteral("responder"), d->responder);
+    writeOptionalXmlAttribute(writer, QStringLiteral("sid"), d->sid);
 
     // XEP-0272: Multiparty Jingle (Muji)
     if (!d->mujiGroupChatJid.isEmpty()) {
         writer->writeStartElement(QStringLiteral("muji"));
         writer->writeDefaultNamespace(ns_muji);
-        helperToXmlAddAttribute(writer, QStringLiteral("room"), d->mujiGroupChatJid);
+        writeOptionalXmlAttribute(writer, QStringLiteral("room"), d->mujiGroupChatJid);
         writer->writeEndElement();
     }
 
@@ -1493,12 +1495,12 @@ void QXmppJingleIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
             }
 
             if (rtpSessionStateMuting->creator == Initiator) {
-                helperToXmlAddAttribute(writer, QStringLiteral("creator"), QStringLiteral("initiator"));
+                writeOptionalXmlAttribute(writer, QStringLiteral("creator"), QStringLiteral("initiator"));
             } else if (rtpSessionStateMuting->creator == Responder) {
-                helperToXmlAddAttribute(writer, QStringLiteral("creator"), QStringLiteral("responder"));
+                writeOptionalXmlAttribute(writer, QStringLiteral("creator"), QStringLiteral("responder"));
             }
 
-            helperToXmlAddAttribute(writer, QStringLiteral("name"), rtpSessionStateMuting->name);
+            writeOptionalXmlAttribute(writer, QStringLiteral("name"), rtpSessionStateMuting->name);
         } else {
             writeStartElementWithNamespace(QStringLiteral("ringing"));
         }
@@ -1755,16 +1757,16 @@ void QXmppJingleCandidate::parse(const QDomElement &element)
 void QXmppJingleCandidate::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("candidate"));
-    helperToXmlAddAttribute(writer, QStringLiteral("component"), QString::number(d->component));
-    helperToXmlAddAttribute(writer, QStringLiteral("foundation"), d->foundation);
-    helperToXmlAddAttribute(writer, QStringLiteral("generation"), QString::number(d->generation));
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), d->id);
-    helperToXmlAddAttribute(writer, QStringLiteral("ip"), d->host.toString());
-    helperToXmlAddAttribute(writer, QStringLiteral("network"), QString::number(d->network));
-    helperToXmlAddAttribute(writer, QStringLiteral("port"), QString::number(d->port));
-    helperToXmlAddAttribute(writer, QStringLiteral("priority"), QString::number(d->priority));
-    helperToXmlAddAttribute(writer, QStringLiteral("protocol"), d->protocol);
-    helperToXmlAddAttribute(writer, QStringLiteral("type"), typeToString(d->type));
+    writeOptionalXmlAttribute(writer, QStringLiteral("component"), QString::number(d->component));
+    writeOptionalXmlAttribute(writer, QStringLiteral("foundation"), d->foundation);
+    writeOptionalXmlAttribute(writer, QStringLiteral("generation"), QString::number(d->generation));
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), d->id);
+    writeOptionalXmlAttribute(writer, QStringLiteral("ip"), d->host.toString());
+    writeOptionalXmlAttribute(writer, QStringLiteral("network"), QString::number(d->network));
+    writeOptionalXmlAttribute(writer, QStringLiteral("port"), QString::number(d->port));
+    writeOptionalXmlAttribute(writer, QStringLiteral("priority"), QString::number(d->priority));
+    writeOptionalXmlAttribute(writer, QStringLiteral("protocol"), d->protocol);
+    writeOptionalXmlAttribute(writer, QStringLiteral("type"), typeToString(d->type));
     writer->writeEndElement();
 }
 
@@ -2039,19 +2041,19 @@ void QXmppJinglePayloadType::parse(const QDomElement &element)
 void QXmppJinglePayloadType::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("payload-type"));
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), QString::number(d->id));
-    helperToXmlAddAttribute(writer, QStringLiteral("name"), d->name);
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), QString::number(d->id));
+    writeOptionalXmlAttribute(writer, QStringLiteral("name"), d->name);
     if (d->channels > 1) {
-        helperToXmlAddAttribute(writer, QStringLiteral("channels"), QString::number(d->channels));
+        writeOptionalXmlAttribute(writer, QStringLiteral("channels"), QString::number(d->channels));
     }
     if (d->clockrate > 0) {
-        helperToXmlAddAttribute(writer, QStringLiteral("clockrate"), QString::number(d->clockrate));
+        writeOptionalXmlAttribute(writer, QStringLiteral("clockrate"), QString::number(d->clockrate));
     }
     if (d->maxptime > 0) {
-        helperToXmlAddAttribute(writer, QStringLiteral("maxptime"), QString::number(d->maxptime));
+        writeOptionalXmlAttribute(writer, QStringLiteral("maxptime"), QString::number(d->maxptime));
     }
     if (d->ptime > 0) {
-        helperToXmlAddAttribute(writer, QStringLiteral("ptime"), QString::number(d->ptime));
+        writeOptionalXmlAttribute(writer, QStringLiteral("ptime"), QString::number(d->ptime));
     }
 
     for (auto itr = d->parameters.begin(); itr != d->parameters.end(); itr++) {
@@ -2215,7 +2217,7 @@ void QXmppJingleDescription::toXml(QXmlStreamWriter *writer) const
     writer->writeStartElement(QStringLiteral("description"));
     writer->writeDefaultNamespace(d->type);
 
-    helperToXmlAddAttribute(writer, QStringLiteral("media"), d->media);
+    writeOptionalXmlAttribute(writer, QStringLiteral("media"), d->media);
 
     if (d->ssrc) {
         writer->writeAttribute(QStringLiteral("ssrc"), QString::number(d->ssrc));
@@ -2309,10 +2311,10 @@ void QXmppSdpParameter::parse(const QDomElement &element)
 void QXmppSdpParameter::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("parameter"));
-    helperToXmlAddAttribute(writer, QStringLiteral("name"), d->name);
+    writeOptionalXmlAttribute(writer, QStringLiteral("name"), d->name);
 
     if (!d->value.isEmpty()) {
-        helperToXmlAddAttribute(writer, QStringLiteral("value"), d->value);
+        writeOptionalXmlAttribute(writer, QStringLiteral("value"), d->value);
     }
 
     writer->writeEndElement();
@@ -2457,7 +2459,7 @@ void QXmppJingleRtpCryptoElement::toXml(QXmlStreamWriter *writer) const
         writer->writeAttribute(QStringLiteral("tag"), QString::number(d->tag));
         writer->writeAttribute(QStringLiteral("crypto-suite"), d->cryptoSuite);
         writer->writeAttribute(QStringLiteral("key-params"), d->keyParams);
-        helperToXmlAddAttribute(writer, QStringLiteral("session-params"), d->sessionParams);
+        writeOptionalXmlAttribute(writer, QStringLiteral("session-params"), d->sessionParams);
         writer->writeEndElement();
     }
 }
@@ -2696,13 +2698,13 @@ void QXmppJingleRtpFeedbackProperty::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("rtcp-fb"));
     writer->writeDefaultNamespace(ns_jingle_rtp_feedback_negotiation);
-    helperToXmlAddAttribute(writer, QStringLiteral("type"), d->type);
+    writeOptionalXmlAttribute(writer, QStringLiteral("type"), d->type);
 
     // If there are parameters, they must be used instead of the subtype.
     if (d->subtype.isEmpty()) {
         sdpParametersToXml(writer, d->parameters);
     } else {
-        helperToXmlAddAttribute(writer, QStringLiteral("subtype"), d->subtype);
+        writeOptionalXmlAttribute(writer, QStringLiteral("subtype"), d->subtype);
     }
 
     writer->writeEndElement();
@@ -2770,7 +2772,7 @@ void QXmppJingleRtpFeedbackInterval::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("rtcp-fb-trr-int"));
     writer->writeDefaultNamespace(ns_jingle_rtp_feedback_negotiation);
-    helperToXmlAddAttribute(writer, QStringLiteral("value"), QString::number(m_value));
+    writeOptionalXmlAttribute(writer, QStringLiteral("value"), QString::number(m_value));
     writer->writeEndElement();
 }
 /// \endcond
@@ -2927,11 +2929,11 @@ void QXmppJingleRtpHeaderExtensionProperty::toXml(QXmlStreamWriter *writer) cons
 {
     writer->writeStartElement(QStringLiteral("rtp-hdrext"));
     writer->writeDefaultNamespace(ns_jingle_rtp_header_extensions_negotiation);
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), QString::number(d->id));
-    helperToXmlAddAttribute(writer, QStringLiteral("uri"), d->uri);
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), QString::number(d->id));
+    writeOptionalXmlAttribute(writer, QStringLiteral("uri"), d->uri);
 
     if (d->senders != QXmppJingleRtpHeaderExtensionProperty::Both) {
-        helperToXmlAddAttribute(writer, QStringLiteral("senders"), JINGLE_RTP_HEADER_EXTENSIONS_SENDERS.at(d->senders));
+        writeOptionalXmlAttribute(writer, QStringLiteral("senders"), JINGLE_RTP_HEADER_EXTENSIONS_SENDERS.at(d->senders));
     }
 
     sdpParametersToXml(writer, d->parameters);
@@ -3146,7 +3148,7 @@ void QXmppJingleMessageInitiationElement::toXml(QXmlStreamWriter *writer) const
     writer->writeStartElement(jmiElementTypeToString(d->type));
     writer->writeDefaultNamespace(ns_jingle_message_initiation);
 
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), d->id);
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), d->id);
 
     if (d->description) {
         d->description->toXml(writer);
@@ -3162,7 +3164,7 @@ void QXmppJingleMessageInitiationElement::toXml(QXmlStreamWriter *writer) const
 
     if (!d->migratedTo.isEmpty()) {
         writer->writeEmptyElement(QStringLiteral("migrated"));
-        helperToXmlAddAttribute(writer, QStringLiteral("to"), d->migratedTo);
+        writeOptionalXmlAttribute(writer, QStringLiteral("to"), d->migratedTo);
     }
 
     writer->writeEndElement();
@@ -3412,7 +3414,7 @@ void QXmppCallInviteElement::toXml(QXmlStreamWriter *writer) const
 
     // write namespace and ID.
     writer->writeDefaultNamespace(ns_call_invites);
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), d->id);
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), d->id);
 
     switch (d->type) {
     case Type::Reject:
@@ -3424,10 +3426,10 @@ void QXmppCallInviteElement::toXml(QXmlStreamWriter *writer) const
         if (d->type == Type::Invite) {
             // only overwrite defaults.
             if (!d->audio) {
-                helperToXmlAddAttribute(writer, QStringLiteral("audio"), "false");
+                writeOptionalXmlAttribute(writer, QStringLiteral("audio"), "false");
             }
             if (d->video) {
-                helperToXmlAddAttribute(writer, QStringLiteral("video"), "true");
+                writeOptionalXmlAttribute(writer, QStringLiteral("video"), "true");
             }
         }
 
@@ -3517,16 +3519,16 @@ void QXmppCallInviteElement::Jingle::parse(const QDomElement &element)
 void QXmppCallInviteElement::Jingle::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeEmptyElement(QStringLiteral("jingle"));
-    helperToXmlAddAttribute(writer, QStringLiteral("sid"), sid);
+    writeOptionalXmlAttribute(writer, QStringLiteral("sid"), sid);
 
     if (jid) {
-        helperToXmlAddAttribute(writer, QStringLiteral("jid"), *jid);
+        writeOptionalXmlAttribute(writer, QStringLiteral("jid"), *jid);
     }
 }
 
 void QXmppCallInviteElement::External::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeEmptyElement(QStringLiteral("external"));
-    helperToXmlAddAttribute(writer, QStringLiteral("uri"), uri);
+    writeOptionalXmlAttribute(writer, QStringLiteral("uri"), uri);
 }
 /// \endcond

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -22,11 +22,14 @@
 #include "QXmppOutOfBandUrl.h"
 #include "QXmppTrustMessageElement.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDateTime>
 #include <QDomElement>
 #include <QTextStream>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 static const QStringList CHAT_STATES = {
     QString(),
@@ -1359,11 +1362,11 @@ void QXmppMessage::toXml(QXmlStreamWriter *writer) const
 void QXmppMessage::toXml(QXmlStreamWriter *writer, QXmpp::SceMode sceMode) const
 {
     writer->writeStartElement(QStringLiteral("message"));
-    helperToXmlAddAttribute(writer, QStringLiteral("xml:lang"), lang());
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), id());
-    helperToXmlAddAttribute(writer, QStringLiteral("to"), to());
-    helperToXmlAddAttribute(writer, QStringLiteral("from"), from());
-    helperToXmlAddAttribute(writer, QStringLiteral("type"), MESSAGE_TYPES.at(d->type));
+    writeOptionalXmlAttribute(writer, QStringLiteral("xml:lang"), lang());
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), id());
+    writeOptionalXmlAttribute(writer, QStringLiteral("to"), to());
+    writeOptionalXmlAttribute(writer, QStringLiteral("from"), from());
+    writeOptionalXmlAttribute(writer, QStringLiteral("type"), MESSAGE_TYPES.at(d->type));
     error().toXml(writer);
 
     // extensions
@@ -1705,8 +1708,8 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
         if (!d->mixUserJid.isEmpty() || !d->mixUserNick.isEmpty()) {
             writer->writeStartElement(QStringLiteral("mix"));
             writer->writeDefaultNamespace(ns_mix);
-            helperToXmlAddTextElement(writer, QStringLiteral("jid"), d->mixUserJid);
-            helperToXmlAddTextElement(writer, QStringLiteral("nick"), d->mixUserNick);
+            writeXmlTextElement(writer, QStringLiteral("jid"), d->mixUserJid);
+            writeXmlTextElement(writer, QStringLiteral("nick"), d->mixUserNick);
             writer->writeEndElement();
         }
 
@@ -1715,7 +1718,7 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
             writer->writeStartElement(QStringLiteral("encryption"));
             writer->writeDefaultNamespace(ns_eme);
             writer->writeAttribute(QStringLiteral("namespace"), d->encryptionMethod);
-            helperToXmlAddAttribute(writer, QStringLiteral("name"), encryptionName());
+            writeOptionalXmlAttribute(writer, QStringLiteral("name"), encryptionName());
             writer->writeEndElement();
         }
 
@@ -1755,7 +1758,7 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
             if (!baseNamespace.isNull()) {
                 writer->writeDefaultNamespace(baseNamespace);
             }
-            helperToXmlAddAttribute(writer, QStringLiteral("parent"), d->parentThread);
+            writeOptionalXmlAttribute(writer, QStringLiteral("parent"), d->parentThread);
             writer->writeCharacters(d->thread);
             writer->writeEndElement();
         }
@@ -1791,13 +1794,13 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
                 // XEP-0203: Delayed Delivery
                 writer->writeStartElement(QStringLiteral("delay"));
                 writer->writeDefaultNamespace(ns_delayed_delivery);
-                helperToXmlAddAttribute(writer, QStringLiteral("stamp"), QXmppUtils::datetimeToString(utcStamp));
+                writeOptionalXmlAttribute(writer, QStringLiteral("stamp"), QXmppUtils::datetimeToString(utcStamp));
                 writer->writeEndElement();
             } else {
                 // XEP-0091: Legacy Delayed Delivery
                 writer->writeStartElement(QStringLiteral("x"));
                 writer->writeDefaultNamespace(ns_legacy_delayed_delivery);
-                helperToXmlAddAttribute(writer, QStringLiteral("stamp"), utcStamp.toString(QStringLiteral("yyyyMMddThh:mm:ss")));
+                writeOptionalXmlAttribute(writer, QStringLiteral("stamp"), utcStamp.toString(QStringLiteral("yyyyMMddThh:mm:ss")));
                 writer->writeEndElement();
             }
         }

--- a/src/base/QXmppMessageReaction.cpp
+++ b/src/base/QXmppMessageReaction.cpp
@@ -5,9 +5,12 @@
 #include "QXmppMessageReaction.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+#include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 class QXmppMessageReactionPrivate : public QSharedData
 {
@@ -112,7 +115,7 @@ void QXmppMessageReaction::toXml(QXmlStreamWriter *writer) const
     writer->writeAttribute(QStringLiteral("id"), d->messageId);
 
     for (const auto &reaction : d->emojis) {
-        helperToXmlAddTextElement(writer, QStringLiteral("reaction"), reaction);
+        writeXmlTextElement(writer, QStringLiteral("reaction"), reaction);
     }
     writer->writeEndElement();
 }

--- a/src/base/QXmppMixInvitation.cpp
+++ b/src/base/QXmppMixInvitation.cpp
@@ -5,10 +5,12 @@
 #include "QXmppMixInvitation.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QSharedData>
+
+using namespace QXmpp::Private;
 
 class QXmppMixInvitationPrivate : public QSharedData
 {
@@ -133,10 +135,10 @@ void QXmppMixInvitation::toXml(QXmlStreamWriter *writer) const
     writer->writeStartElement(QStringLiteral("invitation"));
     writer->writeDefaultNamespace(ns_mix_misc);
 
-    helperToXmlAddTextElement(writer, QStringLiteral("inviter"), d->inviterJid);
-    helperToXmlAddTextElement(writer, QStringLiteral("invitee"), d->inviteeJid);
-    helperToXmlAddTextElement(writer, QStringLiteral("channel"), d->channelJid);
-    helperToXmlAddTextElement(writer, QStringLiteral("token"), d->token);
+    writeXmlTextElement(writer, QStringLiteral("inviter"), d->inviterJid);
+    writeXmlTextElement(writer, QStringLiteral("invitee"), d->inviteeJid);
+    writeXmlTextElement(writer, QStringLiteral("channel"), d->channelJid);
+    writeXmlTextElement(writer, QStringLiteral("token"), d->token);
 
     writer->writeEndElement();
 }

--- a/src/base/QXmppMixIq.cpp
+++ b/src/base/QXmppMixIq.cpp
@@ -5,11 +5,12 @@
 #include "QXmppMixIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppDataForm.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QSharedData>
+
+using namespace QXmpp::Private;
 
 static const QStringList MIX_ACTION_TYPES = {
     QString(),
@@ -178,7 +179,7 @@ void QXmppMixIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     if (d->actionType == ClientJoin || d->actionType == ClientLeave) {
         writer->writeDefaultNamespace(ns_mix_pam);
         if (type() == Set) {
-            helperToXmlAddAttribute(writer, QStringLiteral("channel"), d->jid);
+            writeOptionalXmlAttribute(writer, QStringLiteral("channel"), d->jid);
         }
 
         if (d->actionType == ClientJoin) {
@@ -189,9 +190,9 @@ void QXmppMixIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     }
 
     writer->writeDefaultNamespace(ns_mix);
-    helperToXmlAddAttribute(writer, QStringLiteral("channel"), d->channelName);
+    writeOptionalXmlAttribute(writer, QStringLiteral("channel"), d->channelName);
     if (type() == Result) {
-        helperToXmlAddAttribute(writer, QStringLiteral("jid"), d->jid);
+        writeOptionalXmlAttribute(writer, QStringLiteral("jid"), d->jid);
     }
 
     for (const auto &node : d->nodes) {

--- a/src/base/QXmppMucIq.cpp
+++ b/src/base/QXmppMucIq.cpp
@@ -5,9 +5,11 @@
 #include "QXmppMucIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 QXmppMucItem::QXmppMucItem()
     : m_affiliation(QXmppMucItem::UnspecifiedAffiliation),
@@ -207,17 +209,17 @@ void QXmppMucItem::parse(const QDomElement &element)
 void QXmppMucItem::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("item"));
-    helperToXmlAddAttribute(writer, QStringLiteral("affiliation"), affiliationToString(m_affiliation));
-    helperToXmlAddAttribute(writer, QStringLiteral("jid"), m_jid);
-    helperToXmlAddAttribute(writer, QStringLiteral("nick"), m_nick);
-    helperToXmlAddAttribute(writer, QStringLiteral("role"), roleToString(m_role));
+    writeOptionalXmlAttribute(writer, QStringLiteral("affiliation"), affiliationToString(m_affiliation));
+    writeOptionalXmlAttribute(writer, QStringLiteral("jid"), m_jid);
+    writeOptionalXmlAttribute(writer, QStringLiteral("nick"), m_nick);
+    writeOptionalXmlAttribute(writer, QStringLiteral("role"), roleToString(m_role));
     if (!m_actor.isEmpty()) {
         writer->writeStartElement(QStringLiteral("actor"));
-        helperToXmlAddAttribute(writer, QStringLiteral("jid"), m_actor);
+        writeOptionalXmlAttribute(writer, QStringLiteral("jid"), m_actor);
         writer->writeEndElement();
     }
     if (!m_reason.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("reason"), m_reason);
+        writeXmlTextElement(writer, QStringLiteral("reason"), m_reason);
     }
     writer->writeEndElement();
 }

--- a/src/base/QXmppOmemoDataBase.cpp
+++ b/src/base/QXmppOmemoDataBase.cpp
@@ -7,9 +7,12 @@
 #include "QXmppOmemoElement_p.h"
 #include "QXmppOmemoEnvelope_p.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 /// \cond
 ///
@@ -109,7 +112,7 @@ void QXmppOmemoEnvelope::toXml(QXmlStreamWriter *writer) const
     writer->writeAttribute(QStringLiteral("rid"), QString::number(m_recipientDeviceId));
 
     if (m_isUsedForKeyExchange) {
-        helperToXmlAddAttribute(writer, QStringLiteral("kex"), QStringLiteral("true"));
+        writeOptionalXmlAttribute(writer, QStringLiteral("kex"), QStringLiteral("true"));
     }
 
     writer->writeCharacters(m_data.toBase64());

--- a/src/base/QXmppPresence.cpp
+++ b/src/base/QXmppPresence.cpp
@@ -8,9 +8,12 @@
 #include "QXmppConstants_p.h"
 #include "QXmppJingleIq.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDateTime>
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 static const QStringList PRESENCE_TYPES = {
     QStringLiteral("error"),
@@ -528,21 +531,21 @@ void QXmppPresence::parseExtension(const QDomElement &element, QXmppElementList 
 void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
 {
     xmlWriter->writeStartElement(QStringLiteral("presence"));
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("xml:lang"), lang());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("id"), id());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("to"), to());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("from"), from());
-    helperToXmlAddAttribute(xmlWriter, QStringLiteral("type"), PRESENCE_TYPES.at(d->type));
+    writeOptionalXmlAttribute(xmlWriter, QStringLiteral("xml:lang"), lang());
+    writeOptionalXmlAttribute(xmlWriter, QStringLiteral("id"), id());
+    writeOptionalXmlAttribute(xmlWriter, QStringLiteral("to"), to());
+    writeOptionalXmlAttribute(xmlWriter, QStringLiteral("from"), from());
+    writeOptionalXmlAttribute(xmlWriter, QStringLiteral("type"), PRESENCE_TYPES.at(d->type));
 
     const QString show = AVAILABLE_STATUS_TYPES.at(d->availableStatusType);
     if (!show.isEmpty()) {
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("show"), show);
+        writeXmlTextElement(xmlWriter, QStringLiteral("show"), show);
     }
     if (!d->statusText.isEmpty()) {
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("status"), d->statusText);
+        writeXmlTextElement(xmlWriter, QStringLiteral("status"), d->statusText);
     }
     if (d->priority != 0) {
-        helperToXmlAddTextElement(xmlWriter, QStringLiteral("priority"), QString::number(d->priority));
+        writeXmlTextElement(xmlWriter, QStringLiteral("priority"), QString::number(d->priority));
     }
 
     error().toXml(xmlWriter);
@@ -577,9 +580,9 @@ void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
         !d->capabilityHash.isEmpty()) {
         xmlWriter->writeStartElement(QStringLiteral("c"));
         xmlWriter->writeDefaultNamespace(ns_capabilities);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("hash"), d->capabilityHash);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("node"), d->capabilityNode);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("ver"), d->capabilityVer.toBase64());
+        writeOptionalXmlAttribute(xmlWriter, QStringLiteral("hash"), d->capabilityHash);
+        writeOptionalXmlAttribute(xmlWriter, QStringLiteral("node"), d->capabilityNode);
+        writeOptionalXmlAttribute(xmlWriter, QStringLiteral("ver"), d->capabilityVer.toBase64());
         xmlWriter->writeEndElement();
     }
 
@@ -592,7 +595,7 @@ void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
             xmlWriter->writeEmptyElement(QStringLiteral("photo"));
             break;
         case VCardUpdateValidPhoto:
-            helperToXmlAddTextElement(xmlWriter, QStringLiteral("photo"), d->photoHash.toHex());
+            writeXmlTextElement(xmlWriter, QStringLiteral("photo"), d->photoHash.toHex());
             break;
         default:
             break;
@@ -620,7 +623,7 @@ void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
     if (!d->lastUserInteraction.isNull() && d->lastUserInteraction.isValid()) {
         xmlWriter->writeStartElement(QStringLiteral("idle"));
         xmlWriter->writeDefaultNamespace(ns_idle);
-        helperToXmlAddAttribute(xmlWriter, QStringLiteral("since"), QXmppUtils::datetimeToString(d->lastUserInteraction));
+        writeOptionalXmlAttribute(xmlWriter, QStringLiteral("since"), QXmppUtils::datetimeToString(d->lastUserInteraction));
         xmlWriter->writeEndElement();
     }
 
@@ -629,10 +632,10 @@ void QXmppPresence::toXml(QXmlStreamWriter *xmlWriter) const
         xmlWriter->writeStartElement(QStringLiteral("mix"));
         xmlWriter->writeDefaultNamespace(ns_mix_presence);
         if (!d->mixUserJid.isEmpty()) {
-            helperToXmlAddTextElement(xmlWriter, QStringLiteral("jid"), d->mixUserJid);
+            writeXmlTextElement(xmlWriter, QStringLiteral("jid"), d->mixUserJid);
         }
         if (!d->mixUserNick.isEmpty()) {
-            helperToXmlAddTextElement(xmlWriter, QStringLiteral("nick"), d->mixUserNick);
+            writeXmlTextElement(xmlWriter, QStringLiteral("nick"), d->mixUserNick);
         }
         xmlWriter->writeEndElement();
     }

--- a/src/base/QXmppPubSubAffiliation.cpp
+++ b/src/base/QXmppPubSubAffiliation.cpp
@@ -5,10 +5,12 @@
 #include "QXmppPubSubAffiliation.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 ///
 /// \class QXmppPubSubAffiliation
@@ -158,8 +160,8 @@ void QXmppPubSubAffiliation::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("affiliation"));
     writer->writeAttribute(QStringLiteral("affiliation"), PUBSUB_AFFILIATIONS.at(int(d->type)));
-    helperToXmlAddAttribute(writer, QStringLiteral("node"), d->node);
-    helperToXmlAddAttribute(writer, QStringLiteral("jid"), d->jid);
+    writeOptionalXmlAttribute(writer, QStringLiteral("node"), d->node);
+    writeOptionalXmlAttribute(writer, QStringLiteral("jid"), d->jid);
     writer->writeEndElement();
 }
 /// \endcond

--- a/src/base/QXmppPubSubBaseItem.cpp
+++ b/src/base/QXmppPubSubBaseItem.cpp
@@ -6,9 +6,11 @@
 #include "QXmppPubSubBaseItem.h"
 
 #include "QXmppElement.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 class QXmppPubSubBaseItemPrivate : public QSharedData
 {
@@ -115,8 +117,8 @@ void QXmppPubSubBaseItem::parse(const QDomElement &element)
 void QXmppPubSubBaseItem::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("item"));
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), d->id);
-    helperToXmlAddAttribute(writer, QStringLiteral("publisher"), d->publisher);
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), d->id);
+    writeOptionalXmlAttribute(writer, QStringLiteral("publisher"), d->publisher);
 
     serializePayload(writer);
 

--- a/src/base/QXmppPubSubEvent.cpp
+++ b/src/base/QXmppPubSubEvent.cpp
@@ -6,9 +6,11 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppDataForm.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 ///
 /// \class QXmppPubSubEventBase
@@ -404,7 +406,7 @@ void QXmppPubSubEventBase::serializeExtensions(QXmlStreamWriter *writer, QXmpp::
             break;
         case Configuration:
             // node attribute is optional
-            helperToXmlAddAttribute(writer, QStringLiteral("node"), d->node);
+            writeOptionalXmlAttribute(writer, QStringLiteral("node"), d->node);
             break;
         case Subscription:
             break;

--- a/src/base/QXmppPubSubIq.cpp
+++ b/src/base/QXmppPubSubIq.cpp
@@ -9,7 +9,7 @@
 #include "QXmppPubSubIq_p.h"
 #include "QXmppPubSubSubscription.h"
 #include "QXmppResultSet.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QSharedData>
 
@@ -553,15 +553,15 @@ void PubSubIqBase::toXmlElementFromChild(QXmlStreamWriter *writer) const
     } else {
         // write query type
         writer->writeStartElement(PUBSUB_QUERIES.at(d->queryType));
-        helperToXmlAddAttribute(writer, QStringLiteral("jid"), d->queryJid);
-        helperToXmlAddAttribute(writer, QStringLiteral("node"), d->queryNode);
+        writeOptionalXmlAttribute(writer, QStringLiteral("jid"), d->queryJid);
+        writeOptionalXmlAttribute(writer, QStringLiteral("node"), d->queryNode);
 
         // write subid
         switch (d->queryType) {
         case Items:
         case Unsubscribe:
         case Options:
-            helperToXmlAddAttribute(writer, QStringLiteral("subid"), d->subscriptionId);
+            writeOptionalXmlAttribute(writer, QStringLiteral("subid"), d->subscriptionId);
         default:
             break;
         }

--- a/src/base/QXmppPubSubSubscription.cpp
+++ b/src/base/QXmppPubSubSubscription.cpp
@@ -6,10 +6,13 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDateTime>
 #include <QDomElement>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 ///
 /// \class QXmppPubSubSubscription
@@ -297,9 +300,9 @@ void QXmppPubSubSubscription::toXml(QXmlStreamWriter *writer) const
 
     // jid is required
     writer->writeAttribute(QStringLiteral("jid"), d->jid);
-    helperToXmlAddAttribute(writer, QStringLiteral("node"), d->node);
-    helperToXmlAddAttribute(writer, QStringLiteral("subscription"), stateToString(d->state));
-    helperToXmlAddAttribute(writer, QStringLiteral("subid"), d->subId);
+    writeOptionalXmlAttribute(writer, QStringLiteral("node"), d->node);
+    writeOptionalXmlAttribute(writer, QStringLiteral("subscription"), stateToString(d->state));
+    writeOptionalXmlAttribute(writer, QStringLiteral("subid"), d->subId);
     if (d->expiry.isValid()) {
         writer->writeAttribute(QStringLiteral("expiry"),
                                QXmppUtils::datetimeToString(d->expiry));

--- a/src/base/QXmppResultSet.cpp
+++ b/src/base/QXmppResultSet.cpp
@@ -5,10 +5,12 @@
 #include "QXmppResultSet.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDebug>
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 QXmppResultSetQuery::QXmppResultSetQuery()
     : m_index(-1), m_max(-1)
@@ -122,16 +124,16 @@ void QXmppResultSetQuery::toXml(QXmlStreamWriter *writer) const
     writer->writeStartElement(QStringLiteral("set"));
     writer->writeDefaultNamespace(ns_rsm);
     if (m_max >= 0) {
-        helperToXmlAddTextElement(writer, QStringLiteral("max"), QString::number(m_max));
+        writeXmlTextElement(writer, QStringLiteral("max"), QString::number(m_max));
     }
     if (!m_after.isNull()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("after"), m_after);
+        writeXmlTextElement(writer, QStringLiteral("after"), m_after);
     }
     if (!m_before.isNull()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("before"), m_before);
+        writeXmlTextElement(writer, QStringLiteral("before"), m_before);
     }
     if (m_index >= 0) {
-        helperToXmlAddTextElement(writer, QStringLiteral("index"), QString::number(m_index));
+        writeXmlTextElement(writer, QStringLiteral("index"), QString::number(m_index));
     }
     writer->writeEndElement();
 }
@@ -250,11 +252,11 @@ void QXmppResultSetReply::toXml(QXmlStreamWriter *writer) const
         writer->writeEndElement();
     }
     if (!m_last.isNull()) {
-        helperToXmlAddTextElement(writer, "last", m_last);
+        writeXmlTextElement(writer, "last", m_last);
     }
 
     if (m_count >= 0) {
-        helperToXmlAddTextElement(writer, "count", QString::number(m_count));
+        writeXmlTextElement(writer, "count", QString::number(m_count));
     }
     writer->writeEndElement();
 }

--- a/src/base/QXmppRosterIq.cpp
+++ b/src/base/QXmppRosterIq.cpp
@@ -6,11 +6,13 @@
 #include "QXmppRosterIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QSharedData>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 class QXmppRosterIqPrivate : public QSharedData
 {
@@ -425,17 +427,17 @@ void QXmppRosterIq::Item::parse(const QDomElement &element)
 void QXmppRosterIq::Item::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("item"));
-    helperToXmlAddAttribute(writer, QStringLiteral("jid"), d->bareJid);
-    helperToXmlAddAttribute(writer, QStringLiteral("name"), d->name);
-    helperToXmlAddAttribute(writer, QStringLiteral("subscription"), getSubscriptionTypeStr());
-    helperToXmlAddAttribute(writer, QStringLiteral("ask"), subscriptionStatus());
+    writeOptionalXmlAttribute(writer, QStringLiteral("jid"), d->bareJid);
+    writeOptionalXmlAttribute(writer, QStringLiteral("name"), d->name);
+    writeOptionalXmlAttribute(writer, QStringLiteral("subscription"), getSubscriptionTypeStr());
+    writeOptionalXmlAttribute(writer, QStringLiteral("ask"), subscriptionStatus());
     if (d->approved) {
         writer->writeAttribute(QStringLiteral("approved"), QStringLiteral("true"));
     }
 
     QSet<QString>::const_iterator i = d->groups.constBegin();
     while (i != d->groups.constEnd()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("group"), *i);
+        writeXmlTextElement(writer, QStringLiteral("group"), *i);
         ++i;
     }
 
@@ -443,7 +445,7 @@ void QXmppRosterIq::Item::toXml(QXmlStreamWriter *writer) const
     if (d->isMixChannel) {
         writer->writeStartElement(QStringLiteral("channel"));
         writer->writeAttribute(QStringLiteral("xmlns"), ns_mix_roster);
-        helperToXmlAddAttribute(writer, QStringLiteral("participant-id"), d->mixParticipantId);
+        writeOptionalXmlAttribute(writer, QStringLiteral("participant-id"), d->mixParticipantId);
         writer->writeEndElement();
     }
 

--- a/src/base/QXmppStanza.cpp
+++ b/src/base/QXmppStanza.cpp
@@ -12,6 +12,7 @@
 #include "QXmppE2eeMetadata.h"
 #include "QXmppStanza_p.h"
 #include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDateTime>
 #include <QDomElement>
@@ -600,13 +601,13 @@ void QXmppStanza::Error::toXml(QXmlStreamWriter *writer) const
     }
 
     writer->writeStartElement(QStringLiteral("error"));
-    helperToXmlAddAttribute(writer, QStringLiteral("by"), d->by);
+    writeOptionalXmlAttribute(writer, QStringLiteral("by"), d->by);
     if (d->type != NoType) {
         writer->writeAttribute(QStringLiteral("type"), typeToString(d->type));
     }
 
     if (d->code > 0) {
-        helperToXmlAddAttribute(writer, QStringLiteral("code"), QString::number(d->code));
+        writeOptionalXmlAttribute(writer, QStringLiteral("code"), QString::number(d->code));
     }
 
     if (d->condition != NoCondition) {
@@ -632,8 +633,8 @@ void QXmppStanza::Error::toXml(QXmlStreamWriter *writer) const
     if (d->fileTooLarge) {
         writer->writeStartElement(QStringLiteral("file-too-large"));
         writer->writeDefaultNamespace(ns_http_upload);
-        helperToXmlAddTextElement(writer, QStringLiteral("max-file-size"),
-                                  QString::number(d->maxFileSize));
+        writeXmlTextElement(writer, QStringLiteral("max-file-size"),
+                            QString::number(d->maxFileSize));
         writer->writeEndElement();
     } else if (!d->retryDate.isNull() && d->retryDate.isValid()) {
         writer->writeStartElement(QStringLiteral("retry"));

--- a/src/base/QXmppStreamInitiationIq.cpp
+++ b/src/base/QXmppStreamInitiationIq.cpp
@@ -4,9 +4,11 @@
 
 #include "QXmppConstants_p.h"
 #include "QXmppStreamInitiationIq_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 /// \cond
 QXmppDataForm QXmppStreamInitiationIq::featureForm() const
@@ -91,10 +93,10 @@ void QXmppStreamInitiationIq::toXmlElementFromChild(QXmlStreamWriter *writer) co
 {
     writer->writeStartElement(QStringLiteral("si"));
     writer->writeDefaultNamespace(ns_stream_initiation);
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), m_siId);
-    helperToXmlAddAttribute(writer, QStringLiteral("mime-type"), m_mimeType);
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), m_siId);
+    writeOptionalXmlAttribute(writer, QStringLiteral("mime-type"), m_mimeType);
     if (m_profile == FileTransfer) {
-        helperToXmlAddAttribute(writer, QStringLiteral("profile"), ns_stream_initiation_file_transfer);
+        writeOptionalXmlAttribute(writer, QStringLiteral("profile"), ns_stream_initiation_file_transfer);
     }
     if (!m_fileInfo.isNull()) {
         m_fileInfo.toXml(writer);

--- a/src/base/QXmppUserTuneItem.cpp
+++ b/src/base/QXmppUserTuneItem.cpp
@@ -5,11 +5,13 @@
 #include "QXmppUserTuneItem.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QUrl>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 /// \cond
 class QXmppTuneItemPrivate : public QSharedData
@@ -262,17 +264,17 @@ void QXmppTuneItem::serializePayload(QXmlStreamWriter *writer) const
     writer->writeStartElement(QStringLiteral("tune"));
     writer->writeDefaultNamespace(ns_tune);
 
-    helperToXmlAddTextElement(writer, QStringLiteral("artist"), d->artist);
+    writeXmlTextElement(writer, QStringLiteral("artist"), d->artist);
     if (d->length) {
         writer->writeTextElement(QStringLiteral("length"), QString::number(*d->length));
     }
     if (d->rating) {
         writer->writeTextElement(QStringLiteral("rating"), QString::number(*d->rating));
     }
-    helperToXmlAddTextElement(writer, QStringLiteral("source"), d->source);
-    helperToXmlAddTextElement(writer, QStringLiteral("title"), d->title);
-    helperToXmlAddTextElement(writer, QStringLiteral("track"), d->track);
-    helperToXmlAddTextElement(writer, QStringLiteral("uri"), d->uri.toString(QUrl::FullyEncoded));
+    writeXmlTextElement(writer, QStringLiteral("source"), d->source);
+    writeXmlTextElement(writer, QStringLiteral("title"), d->title);
+    writeXmlTextElement(writer, QStringLiteral("track"), d->track);
+    writeXmlTextElement(writer, QStringLiteral("uri"), d->uri.toString(QUrl::FullyEncoded));
 
     writer->writeEndElement();
 }

--- a/src/base/QXmppUtils.cpp
+++ b/src/base/QXmppUtils.cpp
@@ -5,7 +5,6 @@
 
 #include "QXmppUtils.h"
 
-#include "QXmppLogger.h"
 #include "QXmppUtils_p.h"
 
 #include <QBuffer>
@@ -310,16 +309,17 @@ QString QXmppUtils::generateStanzaHash(int length)
     return hashResult;
 }
 
-void helperToXmlAddAttribute(QXmlStreamWriter *stream, const QString &name,
-                             const QString &value)
+/// \cond
+void QXmpp::Private::writeOptionalXmlAttribute(QXmlStreamWriter *stream, const QString &name,
+                                               const QString &value)
 {
     if (!value.isEmpty()) {
         stream->writeAttribute(name, value);
     }
 }
 
-void helperToXmlAddTextElement(QXmlStreamWriter *stream, const QString &name,
-                               const QString &value)
+void QXmpp::Private::writeXmlTextElement(QXmlStreamWriter *stream, const QString &name,
+                                         const QString &value)
 {
     if (!value.isEmpty()) {
         stream->writeTextElement(name, value);
@@ -327,8 +327,6 @@ void helperToXmlAddTextElement(QXmlStreamWriter *stream, const QString &name,
         stream->writeEmptyElement(name);
     }
 }
-
-/// \cond
 
 //
 // Generates a random count of random bytes.

--- a/src/base/QXmppUtils.h
+++ b/src/base/QXmppUtils.h
@@ -44,9 +44,4 @@ public:
     static QString generateStanzaHash(int length = 36);
 };
 
-void helperToXmlAddAttribute(QXmlStreamWriter *stream, const QString &name,
-                             const QString &value);
-void helperToXmlAddTextElement(QXmlStreamWriter *stream, const QString &name,
-                               const QString &value);
-
 #endif  // QXMPPUTILS_H

--- a/src/base/QXmppUtils_p.h
+++ b/src/base/QXmppUtils_p.h
@@ -12,7 +12,12 @@
 
 #include <QByteArray>
 
+class QXmlStreamWriter;
+
 namespace QXmpp::Private {
+
+void writeOptionalXmlAttribute(QXmlStreamWriter *stream, const QString &name, const QString &value);
+void writeXmlTextElement(QXmlStreamWriter *stream, const QString &name, const QString &value);
 
 QXMPP_EXPORT QByteArray generateRandomBytes(uint32_t minimumByteCount, uint32_t maximumByteCount);
 QXMPP_EXPORT void generateRandomBytes(uint8_t *bytes, uint32_t byteCount);

--- a/src/base/QXmppVCardIq.cpp
+++ b/src/base/QXmppVCardIq.cpp
@@ -5,10 +5,12 @@
 #include "QXmppVCardIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QBuffer>
 #include <QXmlStreamWriter>
+
+using namespace QXmpp::Private;
 
 static QString getImageType(const QByteArray &contents)
 {
@@ -638,8 +640,8 @@ void QXmppVCardOrganization::toXml(QXmlStreamWriter *stream) const
         stream->writeEndElement();
     }
 
-    helperToXmlAddTextElement(stream, QStringLiteral("TITLE"), d->title);
-    helperToXmlAddTextElement(stream, QStringLiteral("ROLE"), d->role);
+    writeXmlTextElement(stream, QStringLiteral("TITLE"), d->title);
+    writeXmlTextElement(stream, QStringLiteral("ROLE"), d->role);
 }
 /// \endcond
 
@@ -1036,32 +1038,32 @@ void QXmppVCardIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
         address.toXml(writer);
     }
     if (d->birthday.isValid()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("BDAY"), d->birthday.toString(QStringLiteral("yyyy-MM-dd")));
+        writeXmlTextElement(writer, QStringLiteral("BDAY"), d->birthday.toString(QStringLiteral("yyyy-MM-dd")));
     }
     if (!d->description.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("DESC"), d->description);
+        writeXmlTextElement(writer, QStringLiteral("DESC"), d->description);
     }
     for (const QXmppVCardEmail &email : d->emails) {
         email.toXml(writer);
     }
     if (!d->fullName.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("FN"), d->fullName);
+        writeXmlTextElement(writer, QStringLiteral("FN"), d->fullName);
     }
     if (!d->nickName.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("NICKNAME"), d->nickName);
+        writeXmlTextElement(writer, QStringLiteral("NICKNAME"), d->nickName);
     }
     if (!d->firstName.isEmpty() ||
         !d->lastName.isEmpty() ||
         !d->middleName.isEmpty()) {
         writer->writeStartElement("N");
         if (!d->firstName.isEmpty()) {
-            helperToXmlAddTextElement(writer, QStringLiteral("GIVEN"), d->firstName);
+            writeXmlTextElement(writer, QStringLiteral("GIVEN"), d->firstName);
         }
         if (!d->lastName.isEmpty()) {
-            helperToXmlAddTextElement(writer, QStringLiteral("FAMILY"), d->lastName);
+            writeXmlTextElement(writer, QStringLiteral("FAMILY"), d->lastName);
         }
         if (!d->middleName.isEmpty()) {
-            helperToXmlAddTextElement(writer, QStringLiteral("MIDDLE"), d->middleName);
+            writeXmlTextElement(writer, QStringLiteral("MIDDLE"), d->middleName);
         }
         writer->writeEndElement();
     }
@@ -1075,12 +1077,12 @@ void QXmppVCardIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
         if (photoType.isEmpty()) {
             photoType = getImageType(d->photo);
         }
-        helperToXmlAddTextElement(writer, QStringLiteral("TYPE"), photoType);
-        helperToXmlAddTextElement(writer, QStringLiteral("BINVAL"), d->photo.toBase64());
+        writeXmlTextElement(writer, QStringLiteral("TYPE"), photoType);
+        writeXmlTextElement(writer, QStringLiteral("BINVAL"), d->photo.toBase64());
         writer->writeEndElement();
     }
     if (!d->url.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("URL"), d->url);
+        writeXmlTextElement(writer, QStringLiteral("URL"), d->url);
     }
 
     d->organization.toXml(writer);

--- a/src/base/QXmppVersionIq.cpp
+++ b/src/base/QXmppVersionIq.cpp
@@ -5,9 +5,11 @@
 #include "QXmppVersionIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 /// Returns the name of the software.
 ///
@@ -86,15 +88,15 @@ void QXmppVersionIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
     writer->writeDefaultNamespace(ns_version);
 
     if (!m_name.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("name"), m_name);
+        writeXmlTextElement(writer, QStringLiteral("name"), m_name);
     }
 
     if (!m_os.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("os"), m_os);
+        writeXmlTextElement(writer, QStringLiteral("os"), m_os);
     }
 
     if (!m_version.isEmpty()) {
-        helperToXmlAddTextElement(writer, QStringLiteral("version"), m_version);
+        writeXmlTextElement(writer, QStringLiteral("version"), m_version);
     }
 
     writer->writeEndElement();

--- a/src/base/compat/QXmppPubSubIq.cpp
+++ b/src/base/compat/QXmppPubSubIq.cpp
@@ -5,10 +5,12 @@
 #include "QXmppPubSubIq.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
 #include <QSharedData>
+
+using namespace QXmpp::Private;
 
 /// \cond
 QT_WARNING_PUSH
@@ -186,8 +188,8 @@ void QXmppPubSubIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
 
     // write query type
     writer->writeStartElement(PUBSUB_QUERIES.at(d->queryType));
-    helperToXmlAddAttribute(writer, QStringLiteral("jid"), d->queryJid);
-    helperToXmlAddAttribute(writer, QStringLiteral("node"), d->queryNode);
+    writeOptionalXmlAttribute(writer, QStringLiteral("jid"), d->queryJid);
+    writeOptionalXmlAttribute(writer, QStringLiteral("node"), d->queryNode);
 
     // write contents
     switch (d->queryType) {
@@ -199,8 +201,8 @@ void QXmppPubSubIq::toXmlElementFromChild(QXmlStreamWriter *writer) const
         }
         break;
     case QXmppPubSubIq::SubscriptionQuery:
-        helperToXmlAddAttribute(writer, QStringLiteral("subid"), d->subscriptionId);
-        helperToXmlAddAttribute(writer, QStringLiteral("subscription"), d->subscriptionType);
+        writeOptionalXmlAttribute(writer, QStringLiteral("subid"), d->subscriptionId);
+        writeOptionalXmlAttribute(writer, QStringLiteral("subscription"), d->subscriptionType);
         break;
     default:
         break;

--- a/src/base/compat/QXmppPubSubItem.cpp
+++ b/src/base/compat/QXmppPubSubItem.cpp
@@ -5,9 +5,11 @@
 #include "QXmppPubSubItem.h"
 
 #include "QXmppElement.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 /// \cond
 class QXmppPubSubItemPrivate : public QSharedData
@@ -69,7 +71,7 @@ void QXmppPubSubItem::parse(const QDomElement &element)
 void QXmppPubSubItem::toXml(QXmlStreamWriter *writer) const
 {
     writer->writeStartElement(QStringLiteral("item"));
-    helperToXmlAddAttribute(writer, QStringLiteral("id"), d->id);
+    writeOptionalXmlAttribute(writer, QStringLiteral("id"), d->id);
     d->contents.toXml(writer);
     writer->writeEndElement();
 }

--- a/src/server/QXmppDialback.cpp
+++ b/src/server/QXmppDialback.cpp
@@ -5,9 +5,11 @@
 #include "QXmppDialback.h"
 
 #include "QXmppConstants_p.h"
-#include "QXmppUtils.h"
+#include "QXmppUtils_p.h"
 
 #include <QDomElement>
+
+using namespace QXmpp::Private;
 
 /// Constructs a QXmppDialback.
 
@@ -91,10 +93,10 @@ void QXmppDialback::toXml(QXmlStreamWriter *xmlWriter) const
     } else {
         xmlWriter->writeStartElement("db:verify");
     }
-    helperToXmlAddAttribute(xmlWriter, "id", id());
-    helperToXmlAddAttribute(xmlWriter, "to", to());
-    helperToXmlAddAttribute(xmlWriter, "from", from());
-    helperToXmlAddAttribute(xmlWriter, "type", m_type);
+    writeOptionalXmlAttribute(xmlWriter, "id", id());
+    writeOptionalXmlAttribute(xmlWriter, "to", to());
+    writeOptionalXmlAttribute(xmlWriter, "from", from());
+    writeOptionalXmlAttribute(xmlWriter, "type", m_type);
     if (!m_key.isEmpty()) {
         xmlWriter->writeCharacters(m_key);
     }


### PR DESCRIPTION
Previously the helperToXml* functions were in the public Utils header
without namespacing. They couldn't be used externally because they were
not exported, though.

This moves them into the Utils_p.h header, renames them and puts them
into the QXmpp::Private namespace.
