### PR TITLE
Update XEP-0428: Fallback Indication to v0.2

### DIFF
--- a/doc/doap.xml
+++ b/doc/doap.xml
@@ -608,7 +608,7 @@ SPDX-License-Identifier: CC0-1.0
       <xmpp:SupportedXep>
         <xmpp:xep rdf:resource='https://xmpp.org/extensions/xep-0428.html'/>
         <xmpp:status>complete</xmpp:status>
-        <xmpp:version>0.1</xmpp:version>
+        <xmpp:version>0.2.0</xmpp:version>
         <xmpp:since>1.3</xmpp:since>
       </xmpp:SupportedXep>
     </implements>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(INSTALL_HEADER_FILES
     base/QXmppExtension.h
     base/QXmppExternalService.h
     base/QXmppExternalServiceDiscoveryIq.h
+    base/QXmppFallback.h
     base/QXmppFileMetadata.h
     base/QXmppFileShare.h
     base/QXmppFutureUtils_p.h

--- a/src/base/QXmppFallback.h
+++ b/src/base/QXmppFallback.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2024 Linus Jahn <lnj@kaidan.im>
+//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef QXMPPFALLBACK_H
+#define QXMPPFALLBACK_H
+
+#include "QXmppGlobal.h"
+
+#include <optional>
+
+#include <QSharedDataPointer>
+
+class QDomElement;
+class QXmlStreamWriter;
+
+struct QXmppFallbackPrivate;
+
+class QXMPP_EXPORT QXmppFallback
+{
+public:
+    enum Element {
+        Body,
+        Subject,
+    };
+
+    struct Range {
+        /// Start index of the range
+        uint32_t start;
+        /// End index of the range
+        uint32_t end;
+    };
+
+    struct Reference {
+        /// Element of the message stanza this refers to
+        Element element;
+        /// Optional character range in the text
+        std::optional<Range> range;
+    };
+
+    QXmppFallback(const QString &forNamespace, const QVector<Reference> &references);
+    QXMPP_PRIVATE_DECLARE_RULE_OF_SIX(QXmppFallback)
+
+    const QString &forNamespace() const;
+    void setForNamespace(const QString &);
+
+    const QVector<Reference> &references() const;
+    void setReferences(const QVector<Reference> &);
+
+    static std::optional<QXmppFallback> fromDom(const QDomElement &);
+    void toXml(QXmlStreamWriter *) const;
+
+private:
+    QSharedDataPointer<QXmppFallbackPrivate> d;
+};
+
+#endif  // QXMPPFALLBACK_H

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -19,6 +19,7 @@
 
 class QXmppMessagePrivate;
 class QXmppBitsOfBinaryDataList;
+class QXmppFallback;
 class QXmppJingleMessageInitiationElement;
 class QXmppMessageReaction;
 class QXmppMixInvitation;
@@ -254,8 +255,12 @@ public:
     void setMixInvitation(const std::optional<QXmppMixInvitation> &mixInvitation);
 
     // XEP-0428: Fallback Indication
-    bool isFallback() const;
-    void setIsFallback(bool isFallback);
+#if QXMPP_DEPRECATED_SINCE(1, 7)
+    [[deprecated("Use fallbackMarkers()")]] bool isFallback() const;
+    [[deprecated("Use setFallbackMarkers()")]] void setIsFallback(bool isFallback);
+#endif
+    const QVector<QXmppFallback> &fallbackMarkers() const;
+    void setFallbackMarkers(const QVector<QXmppFallback> &);
 
     // XEP-0434: Trust Messages (TM)
     std::optional<QXmppTrustMessageElement> trustMessageElement() const;

--- a/src/base/QXmppUtils.cpp
+++ b/src/base/QXmppUtils.cpp
@@ -358,6 +358,57 @@ std::optional<QByteArray> QXmpp::Private::parseBase64(const QString &text)
     return {};
 }
 
+template<typename Int>
+Int stringToInt(QStringView str, bool *ok)
+{
+    if constexpr (std::is_same_v<Int, int8_t>) {
+        auto result = str.toShort(ok);
+        if (ok && result <= std::numeric_limits<int8_t>().max() && result >= std::numeric_limits<int8_t>().min()) {
+            return int8_t(result);
+        }
+        *ok = false;
+        return 0;
+    } else if constexpr (std::is_same_v<Int, uint8_t>) {
+        auto result = str.toUShort(ok);
+        if (ok && result <= std::numeric_limits<int8_t>().max() && result >= std::numeric_limits<int8_t>().min()) {
+            return int8_t(result);
+        }
+        *ok = false;
+        return 0;
+    } else if constexpr (std::is_same_v<Int, int16_t>) {
+        return str.toShort(ok);
+    } else if constexpr (std::is_same_v<Int, uint16_t>) {
+        return str.toUShort(ok);
+    } else if constexpr (std::is_same_v<Int, int32_t>) {
+        return str.toInt(ok);
+    } else if constexpr (std::is_same_v<Int, uint32_t>) {
+        return str.toUInt(ok);
+    } else if constexpr (std::is_same_v<Int, int64_t>) {
+        return str.toLongLong(ok);
+    } else if constexpr (std::is_same_v<Int, uint64_t>) {
+        return str.toULongLong(ok);
+    }
+}
+
+template<typename Int>
+std::optional<Int> QXmpp::Private::parseInt(QStringView str)
+{
+    bool ok = false;
+    if (auto result = stringToInt<Int>(str, &ok); ok) {
+        return result;
+    }
+    return {};
+}
+
+template std::optional<int8_t> QXmpp::Private::parseInt<int8_t>(QStringView);
+template std::optional<uint8_t> QXmpp::Private::parseInt<uint8_t>(QStringView);
+template std::optional<int16_t> QXmpp::Private::parseInt<int16_t>(QStringView);
+template std::optional<uint16_t> QXmpp::Private::parseInt<uint16_t>(QStringView);
+template std::optional<int32_t> QXmpp::Private::parseInt<int32_t>(QStringView);
+template std::optional<uint32_t> QXmpp::Private::parseInt<uint32_t>(QStringView);
+template std::optional<int64_t> QXmpp::Private::parseInt<int64_t>(QStringView);
+template std::optional<uint64_t> QXmpp::Private::parseInt<uint64_t>(QStringView);
+
 bool QXmpp::Private::isIqType(const QDomElement &element, QStringView tagName, QStringView xmlns)
 {
     // IQs must have only one child element, so we do not need to iterate over the child elements.

--- a/src/base/QXmppUtils_p.h
+++ b/src/base/QXmppUtils_p.h
@@ -85,6 +85,12 @@ void writeEmptyElement(QXmlStreamWriter *writer, QStringView name, QStringView x
 std::optional<QByteArray> parseBase64(const QString &);
 inline QString serializeBase64(const QByteArray &data) { return QString::fromUtf8(data.toBase64()); }
 
+// Integer parsing
+template<typename Int>
+std::optional<Int> parseInt(QStringView str);
+template<typename Int>
+inline QString serializeInt(Int value) { return QString::number(value); }
+
 //
 // DOM
 //


### PR DESCRIPTION
- **Utils: Add parseInt() allowing parsing of all common int types**
- **Update XEP-0428: Fallback Indication to v0.2**

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
orig version, with extra QXmppFallbackReference: f439cd227db94b391b5172dc179bbcc0ede724e8
-->
