### PR TITLE
Message: Allow multiple stanza IDs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,6 +10,7 @@ BraceWrapping:
   AfterFunction: true
   AfterStruct: false
   SplitEmptyRecord: false
+BreakAfterAttributes: Always
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true

--- a/src/base/QXmppMessage.h
+++ b/src/base/QXmppMessage.h
@@ -30,6 +30,13 @@ class QXmppTrustMessageElement;
 class QXmppOutOfBandUrl;
 class QXmppCallInviteElement;
 
+struct QXmppStanzaId {
+    /// Identifier of the stanza element
+    QString id;
+    /// JID of the generating entity
+    QString by;
+};
+
 ///
 /// \brief The QXmppMessage class represents an XMPP message.
 ///
@@ -214,11 +221,20 @@ public:
     void setJingleMessageInitiationElement(const std::optional<QXmppJingleMessageInitiationElement> &jingleMessageInitiationElement);
 
     // XEP-0359: Unique and Stable Stanza IDs
+#if QXMPP_DEPRECATED_SINCE(1, 8)
+    [[deprecated("Use stanzaIds() instead.")]]
     QString stanzaId() const;
+    [[deprecated("Use setStanzaIds() instead.")]]
     void setStanzaId(const QString &id);
 
+    [[deprecated("Use stanzaIds() instead.")]]
     QString stanzaIdBy() const;
+    [[deprecated("Use setStanzaIds() instead.")]]
     void setStanzaIdBy(const QString &id);
+#endif
+
+    QVector<QXmppStanzaId> stanzaIds() const;
+    void setStanzaIds(const QVector<QXmppStanzaId> &);
 
     QString originId() const;
     void setOriginId(const QString &id);

--- a/src/client/QXmppHttpUploadManager.cpp
+++ b/src/client/QXmppHttpUploadManager.cpp
@@ -65,7 +65,8 @@ struct QXmppHttpUploadPrivate {
             Q_EMIT q->progressChanged();
         }
     }
-    [[nodiscard]] QXmppHttpUpload::Result result() const
+    [[nodiscard]]
+    QXmppHttpUpload::Result result() const
     {
         // assumes finished = true
         if (error) {

--- a/tests/qxmppaccountmigrationmanager/tst_qxmppaccountmigrationmanager.cpp
+++ b/tests/qxmppaccountmigrationmanager/tst_qxmppaccountmigrationmanager.cpp
@@ -52,16 +52,20 @@ static QXmppRosterIq newRoster(TestClient *client, int version, const std::optio
     if (roster.type() == QXmppIq::Result || roster.type() == QXmppIq::Set) {
         switch (version) {
         case 0:
-            if (index == -1 || index == 0)
+            if (index == -1 || index == 0) {
                 roster.addItem(newRosterItem(u"1@bare.com"_s, u"1 Bare"_s, { u"all"_s }));
-            if (index == -1 || index == 1)
+            }
+            if (index == -1 || index == 1) {
                 roster.addItem(newRosterItem(u"2@bare.com"_s, u"2 Bare"_s, { u"all"_s }));
+            }
             break;
         case 1:
-            if (index == -1 || index == 0)
+            if (index == -1 || index == 0) {
                 roster.addItem(newRosterItem(u"3@gamer.com"_s, u"3 Gamer"_s, { u"gamers"_s }));
-            if (index == -1 || index == 1)
+            }
+            if (index == -1 || index == 1) {
                 roster.addItem(newRosterItem(u"4@gamer.com"_s, u"4 Gamer"_s, { u"gamers"_s }));
+            }
             break;
         default:
             Q_UNREACHABLE();

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -151,8 +151,12 @@ void tst_QXmppMessage::testBasic()
     QVERIFY(!message.hasHint(QXmppMessage::NoCopy));
     QVERIFY(!message.hasHint(QXmppMessage::Store));
     QCOMPARE(message.bitsOfBinaryData(), QXmppBitsOfBinaryDataList());
+    QT_WARNING_PUSH
+    QT_WARNING_DISABLE_DEPRECATED
     QVERIFY(message.stanzaId().isNull());
     QVERIFY(message.stanzaIdBy().isNull());
+    QT_WARNING_POP
+    QVERIFY(message.stanzaIds().isEmpty());
     QVERIFY(message.originId().isNull());
     QT_WARNING_PUSH
     QT_WARNING_DISABLE_DEPRECATED
@@ -1084,20 +1088,36 @@ void tst_QXmppMessage::testStanzaIds()
 {
     const QByteArray xml = QByteArrayLiteral(
         "<message type=\"chat\">"
+        "<stanza-id xmlns=\"urn:xmpp:sid:0\" id=\"123\" by=\"room@mix.qxmpp.org\"/>"
         "<stanza-id xmlns=\"urn:xmpp:sid:0\" id=\"1236\" by=\"server.tld\"/>"
         "<origin-id xmlns=\"urn:xmpp:sid:0\" id=\"5678\"/>"
         "</message>");
 
+    QT_WARNING_PUSH
+    QT_WARNING_DISABLE_DEPRECATED
     QXmppMessage msg;
     parsePacket(msg, xml);
+    QT_WARNING_PUSH
+    QT_WARNING_DISABLE_DEPRECATED
     QCOMPARE(msg.stanzaId(), u"1236"_s);
     QCOMPARE(msg.stanzaIdBy(), u"server.tld"_s);
+    QT_WARNING_POP
+    QCOMPARE(msg.stanzaIds().size(), 2);
     QCOMPARE(msg.originId(), u"5678"_s);
     serializePacket(msg, xml);
 
     QXmppMessage msg2;
+
+    // test both setters (single id / multiple ids)
+    QT_WARNING_PUSH
+    QT_WARNING_DISABLE_DEPRECATED
     msg2.setStanzaId(u"1236"_s);
     msg2.setStanzaIdBy(u"server.tld"_s);
+    QT_WARNING_POP
+
+    auto ids = msg2.stanzaIds();
+    ids.prepend(QXmppStanzaId { "123", "room@mix.qxmpp.org" });
+    msg2.setStanzaIds(ids);
     msg2.setOriginId(u"5678"_s);
     serializePacket(msg2, xml);
 }


### PR DESCRIPTION
- **clang-format: Break before C++11 attributes**
- **Message: Allow multiple stanza IDs (XEP-0359)**

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
