### PR TITLE
QXmppAccountMigrationManager: Make public the extensions getter/setter

### DIFF
--- a/src/client/QXmppAccountMigrationManager.cpp
+++ b/src/client/QXmppAccountMigrationManager.cpp
@@ -206,6 +206,9 @@ struct QXmppAccountMigrationManagerPrivate {
 ///
 /// Constructs an account migration manager.
 ///
+/// \note You would need the `QXmppClient(QXmppClient::NoExtensions, this)` approach to use this manager
+/// because it needs to be instantiated before others using it.
+///
 QXmppAccountMigrationManager::QXmppAccountMigrationManager()
     : d(std::make_unique<QXmppAccountMigrationManagerPrivate>())
 {

--- a/src/client/QXmppAccountMigrationManager.cpp
+++ b/src/client/QXmppAccountMigrationManager.cpp
@@ -147,6 +147,11 @@ void QXmppExportData::registerExtensionInternal(std::type_index type, ExtensionP
     accountDataSerializers().emplace(type, serialize);
 }
 
+bool QXmppExportData::isExtensionRegistered(std::type_index type)
+{
+    return accountDataSerializers().contains(type);
+}
+
 struct QXmppAccountMigrationManagerPrivate {
     template<typename T = Success>
     using Result = std::variant<T, QXmppError>;

--- a/src/client/QXmppAccountMigrationManager.h
+++ b/src/client/QXmppAccountMigrationManager.h
@@ -31,6 +31,19 @@ public:
     void setAccountJid(const QString &jid);
 
     template<typename T>
+    std::optional<T> extension() const
+    {
+        const auto it = extensions().find(std::type_index(typeid(T)));
+        return it != extensions().cend() ? std::any_cast<T>(it->second) : std::optional<T>();
+    }
+
+    template<typename T>
+    void setExtension(T &&value)
+    {
+        setExtension(std::any(std::move(value)));
+    }
+
+    template<typename T>
     using ExtensionParser = Result<T> (*)(const QDomElement &);
     template<typename T>
     using ExtensionSerializer = void (*)(const T &, QXmlStreamWriter &);

--- a/src/client/QXmppAccountMigrationManager.h
+++ b/src/client/QXmppAccountMigrationManager.h
@@ -40,6 +40,7 @@ public:
     template<typename T>
     void setExtension(T &&value)
     {
+        Q_ASSERT(isExtensionRegistered<T>());
         setExtension(std::any(std::move(value)));
     }
 
@@ -70,6 +71,9 @@ public:
         registerExtensionInternal(std::type_index(typeid(T)), parseAny, serializeAny, tagName, xmlns);
     }
 
+    template<typename T>
+    static bool isExtensionRegistered() { return isExtensionRegistered(std::type_index(typeid(T))); }
+
 private:
     friend class QXmppAccountMigrationManager;
     friend class tst_QXmppAccountMigrationManager;
@@ -78,6 +82,7 @@ private:
     void setExtension(std::any value);
 
     static void registerExtensionInternal(std::type_index, ExtensionParser<std::any>, ExtensionSerializer<std::any>, QStringView tagName, QStringView xmlns);
+    static bool isExtensionRegistered(std::type_index);
 
     QSharedDataPointer<QXmppExportDataPrivate> d;
 };


### PR DESCRIPTION
This is needed because without that change applications can not store and use app specific data. By example Kaidan export and import its roster settings which requires that all migration tasks finished before importing roster related data.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
