### PR TITLE
Client: Fix connection if first SRV record fails

### DIFF
--- a/src/client/QXmppOutgoingClient_p.h
+++ b/src/client/QXmppOutgoingClient_p.h
@@ -178,6 +178,10 @@ public:
     // DNS
     QList<QDnsServiceRecord> srvRecords;
     int nextSrvRecordIdx = 0;
+    enum {
+        Current,
+        TryNext,
+    } nextAddressState = Current;
 
     // Stream
     QString streamId;


### PR DESCRIPTION
connectToHost() must be called after the previous connection has been
closed. This happens after the socket error is emitted.