### PR TITLE
Message: Serialize fallback markers in both public and private modes

### DIFF
--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -1953,11 +1953,6 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
             d->omemoElement->toXml(writer);
         }
 #endif
-
-        // XEP-0428: Fallback Indication
-        for (const auto &fallback : d->fallbackMarkers) {
-            fallback.toXml(writer);
-        }
     }
 
     if (sceMode & QXmpp::SceSensitive) {
@@ -2150,6 +2145,15 @@ void QXmppMessage::serializeExtensions(QXmlStreamWriter *writer, QXmpp::SceMode 
         if (d->callInviteElement) {
             d->callInviteElement->toXml(writer);
         }
+    }
+
+    // serialize in private and in public part
+
+    // XEP-0428: Fallback Indication
+    // fallback markers may be used in the private part (e.g. message replies) but also in the
+    // public part (e.g. the fallback body for e2ee messages)
+    for (const auto &fallback : d->fallbackMarkers) {
+        fallback.toXml(writer);
     }
 }
 

--- a/src/omemo/QXmppOmemoManager_p.cpp
+++ b/src/omemo/QXmppOmemoManager_p.cpp
@@ -992,6 +992,11 @@ QXmppTask<QXmppE2eeExtension::MessageEncryptResult> ManagerPrivate::encryptMessa
                 // Whether to advise the server to store other kinds of messages is up to the
                 // client.
                 // That facilitates a consistent handling of message processing hints.
+
+                // reset fallback markers: they are serialized in both public and private modes,
+                // so this is needed to avoid leaking sensitive content
+                message.setFallbackMarkers({});
+
                 if (!message.body().isEmpty() || message.trustMessageElement()) {
                     QXmppFallback fallback { ns_omemo_2.toString(), { { QXmppFallback::Body, {} } } };
 

--- a/tests/qxmppmessage/tst_qxmppmessage.cpp
+++ b/tests/qxmppmessage/tst_qxmppmessage.cpp
@@ -1342,13 +1342,13 @@ void tst_QXmppMessage::testFileSharing()
     serializePacket(message, xml);
 
     xml = "<message id='adding-photo1' to='juliet@shakespeare.lit' from='romeo@montague.lit/resource' type='normal'>"
-          "<fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:sfs:0'><body/></fallback>"
           "<body>https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/photo1.jpg</body>"
           "<x xmlns='jabber:x:oob'><url>https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/photo1.jpg</url></x>"
           "<attach-to xmlns='urn:xmpp:message-attaching:1' id='sharing-files'/>"
           "<sources xmlns='urn:xmpp:sfs:0' id='photo1.jpg'>"
           "<url-data xmlns='http://jabber.org/protocol/url-data' target='https://download.montague.lit/4a771ac1-f0b2-4a4a-9700-f2a26fa2bb67/photo1.jpg'/>"
           "</sources>"
+          "<fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:sfs:0'><body/></fallback>"
           "</message>";
     message = {};
 


### PR DESCRIPTION
- **Message: Serialize fallback markers in both public/private SCE mode**
- **OmemoManager: Remove private fallback markers before serializing**

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
**Funded by [NLnet](https://nlnet.nl/foundation/) via [NGI Assure](https://nlnet.nl/assure/).**
