### PR TITLE
Fix migration manager

### DIFF
--- a/src/client/QXmppAccountMigrationManager.cpp
+++ b/src/client/QXmppAccountMigrationManager.cpp
@@ -227,6 +227,14 @@ struct QXmppAccountMigrationManagerPrivate {
 ///
 
 ///
+/// \fn QXmppAccountMigrationManager::errorOccurred(const QXmppError &error)
+///
+/// Emitted when an error occured during export or import.
+///
+/// \param error The occured error
+///
+
+///
 /// \fn QXmppAccountMigrationManager::registerExportData(ImportFunc importFunc, ExportFunc exportFunc)
 ///
 /// Registers a data type that can be imported to an account using importFunc and generated using

--- a/src/client/QXmppAccountMigrationManager.h
+++ b/src/client/QXmppAccountMigrationManager.h
@@ -112,6 +112,8 @@ public:
     template<typename DataType>
     void unregisterExportData();
 
+    Q_SIGNAL void errorOccurred(const QXmppError &error);
+
 private:
     void registerMigrationDataInternal(std::type_index dataType, std::function<QXmppTask<Result<>>(std::any)>, std::function<QXmppTask<Result<std::any>>()>);
     void unregisterMigrationDataInternal(std::type_index dataType);

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -148,6 +148,8 @@ private:
     QXmppTask<RosterResult> requestRoster();
 
     const std::unique_ptr<QXmppRosterManagerPrivate> d;
+
+    friend class QXmppMixManager;
 };
 
 #endif  // QXMPPROSTER_H

--- a/tests/TestClient.h
+++ b/tests/TestClient.h
@@ -16,9 +16,10 @@ class TestClient : public QXmppClient
 {
     Q_OBJECT
 public:
-    TestClient(bool enableDebug = false)
+    TestClient(bool enableDebug = false, bool enableAutoReset = true)
         : QXmppClient(),
-          debugEnabled(enableDebug)
+          debugEnabled(enableDebug),
+          autoResetEnabled(enableAutoReset)
     {
         // clear extensions
         qDeleteAll(d->extensions);
@@ -28,6 +29,7 @@ public:
         // setup logging (for expect())
         logger()->setLoggingType(QXmppLogger::SignalLogging);
         connect(logger(), &QXmppLogger::message, this, &TestClient::onLoggerMessage);
+        // In all case, start with a 0 default id
         resetIdCount();
     }
 
@@ -41,7 +43,9 @@ public:
     {
         d->stream->handleIqResponse(xmlToDom(xml));
         QCoreApplication::processEvents();
-        resetIdCount();
+        if (autoResetEnabled) {
+            resetIdCount();
+        }
     }
     void expect(QString &&packet)
     {
@@ -51,7 +55,9 @@ public:
         auto actualXml = rewriteXml(m_sentPackets.takeFirst());
         QCOMPARE(actualXml, expectedXml);
 
-        resetIdCount();
+        if (autoResetEnabled) {
+            resetIdCount();
+        }
     }
     // compares packets, ignoring different IDs and order of sending
     // returns ID of the packet that matched
@@ -104,7 +110,9 @@ public:
     void ignore()
     {
         m_sentPackets.takeFirst();
-        resetIdCount();
+        if (autoResetEnabled) {
+            resetIdCount();
+        }
     }
 
     void resetIdCount()
@@ -145,6 +153,7 @@ private:
     }
 
     bool debugEnabled;
+    bool autoResetEnabled;
     QList<QString> m_sentPackets;
 };
 

--- a/tests/qxmppaccountmigrationmanager/tst_qxmppaccountmigrationmanager.cpp
+++ b/tests/qxmppaccountmigrationmanager/tst_qxmppaccountmigrationmanager.cpp
@@ -297,6 +297,10 @@ void tst_QXmppAccountMigrationManager::serialization()
     QByteArray xml2 =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         "<account-data xmlns=\"org.qxmpp.export\" jid=\"pasnox@xmpp.example\">"
+        "<roster>"
+        "<item xmlns=\"jabber:iq:roster\" jid=\"3@gamer.com\" name=\"3 Gamer\"><group>gamers</group></item>"
+        "<item xmlns=\"jabber:iq:roster\" jid=\"4@gamer.com\" name=\"4 Gamer\"><group>gamers</group></item>"
+        "</roster>"
         "<vcard>"
         "<vCard xmlns=\"vcard-temp\">"
         "<NICKNAME>It is me Bookri</NICKNAME>"
@@ -304,10 +308,6 @@ void tst_QXmppAccountMigrationManager::serialization()
         "<TITLE/><ROLE/>"
         "</vCard>"
         "</vcard>"
-        "<roster>"
-        "<item xmlns=\"jabber:iq:roster\" jid=\"3@gamer.com\" name=\"3 Gamer\"><group>gamers</group></item>"
-        "<item xmlns=\"jabber:iq:roster\" jid=\"4@gamer.com\" name=\"4 Gamer\"><group>gamers</group></item>"
-        "</roster>"
         "</account-data>\n";
 
     if (xml1 != xml2) {

--- a/tests/util.h
+++ b/tests/util.h
@@ -32,15 +32,15 @@ struct QXmppError;
         throw std::runtime_error(description);
 
 template<typename String>
-inline QDomElement xmlToDom(const String &xml)
+inline QDomDocument xmlToDomDoc(const String &xml, bool namespaceProcessing)
 {
     QDomDocument doc;
     QString errorText;
     bool success = false;
     if constexpr (std::is_same_v<String, QString> || std::is_same_v<String, QByteArray>) {
-        success = doc.setContent(xml, true, &errorText);
+        success = doc.setContent(xml, namespaceProcessing, &errorText);
     } else {
-        success = doc.setContent(QString(xml), true, &errorText);
+        success = doc.setContent(QString(xml), namespaceProcessing, &errorText);
     }
     if (!success) {
         qDebug() << "Parsing error:";
@@ -48,7 +48,19 @@ inline QDomElement xmlToDom(const String &xml)
         qDebug().noquote() << "Error:" << errorText;
         QTest::qFail("Invalid XML", __FILE__, __LINE__);
     }
-    return doc.documentElement();
+    return doc;
+}
+
+template<typename String>
+inline QDomElement xmlToDom(const String &xml)
+{
+    return xmlToDomDoc(xml, true).documentElement();
+}
+
+template<typename String>
+inline QByteArray xmlToFormattedByteArray(const String &xml)
+{
+    return xmlToDomDoc(xml, false).toByteArray(4);
 }
 
 template<typename String>


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

Fixed a bunch of issues in the QXmppAccountMigrationManager:

- Stabilized the unit tests moving from unordered to sorted keys nodes
- Handle correctly joining mix channels