### PR TITLE
Fix moved doxygen warnings, windows ci

### DIFF
--- a/src/client/QXmppMovedItem_p.h
+++ b/src/client/QXmppMovedItem_p.h
@@ -18,10 +18,8 @@ public:
     static bool isItem(const QDomElement &itemElement);
 
 protected:
-    /// \cond
     void parsePayload(const QDomElement &payloadElement) override;
     void serializePayload(QXmlStreamWriter *writer) const override;
-    /// \endcond
 
 private:
     QString m_newJid;

--- a/src/client/QXmppMovedManager.cpp
+++ b/src/client/QXmppMovedManager.cpp
@@ -28,9 +28,7 @@ QXmppMovedItem::QXmppMovedItem(const QString &newJid)
     setId(QXmppPubSubManager::standardItemIdToString(QXmppPubSubManager::Current));
 }
 
-///
-/// Returns true if the given DOM element is a valid \xep{0283, Moved} item.
-///
+// Returns true if the given DOM element is a valid \xep{0283, Moved} item.
 bool QXmppMovedItem::isItem(const QDomElement &itemElement)
 {
     return QXmppPubSubBaseItem::isItem(itemElement, [](const QDomElement &payload) {
@@ -101,6 +99,12 @@ public:
 /// \ingroup Managers
 ///
 /// \since QXmpp 1.9
+///
+
+///
+/// \typedef QXmppMovedManager::Result
+///
+/// Contains QXmpp::Success or an error.
 ///
 
 ///

--- a/src/client/QXmppMovedManager.h
+++ b/src/client/QXmppMovedManager.h
@@ -5,9 +5,12 @@
 #ifndef QXMPPMOVEDMANAGER_H
 #define QXMPPMOVEDMANAGER_H
 
-#include "QXmppClient.h"
 #include "QXmppClientExtension.h"
+#include "QXmppSendResult.h"
+#include "QXmppTask.h"
 
+class QXmppPresence;
+class QXmppError;
 class QXmppMovedManagerPrivate;
 
 class QXMPP_EXPORT QXmppMovedManager : public QXmppClientExtension
@@ -40,7 +43,7 @@ protected:
 private:
     std::optional<QXmppTask<bool>> handleSubscriptionRequest(const QXmppPresence &presence);
     void handleDiscoInfo(const QXmppDiscoveryIq &iq);
-    QXmppClient::EmptyResult movedJidsMatch(const QString &newBareJid, const QString &pepBareJid) const;
+    Result movedJidsMatch(const QString &newBareJid, const QString &pepBareJid) const;
 
     void setSupportedByServer(bool supportedByServer);
     void resetCachedData();

--- a/tests/qxmppmovedmanager/tst_qxmppmovedmanager.cpp
+++ b/tests/qxmppmovedmanager/tst_qxmppmovedmanager.cpp
@@ -294,10 +294,10 @@ void tst_QXmppMovedManager::testError(QXmppTask<T> &task, TestClient &client, co
 {
     client.ignore();
     client.inject(u"<iq id='%1' from='%2' type='error'>"
-                                 "<error type='cancel'>"
-                                 "<not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>"
-                                 "</error>"
-                                 "</iq>"_s
+                  u"<error type='cancel'>"
+                  u"<not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>"
+                  u"</error>"
+                  u"</iq>"_s
                       .arg(id, from));
 
     expectFutureVariant<QXmppError>(task);


### PR DESCRIPTION
- **MovedManager: Fix doxygen warnings**
- **MovedManager.h: Remove Client.h include**
- **tests: MovedManager: Fix ""_s literals with MSVC**
