### PR TITLE
MixManager: Fix behavior for updating node subscriptions

### DIFF
--- a/src/client/QXmppMixManager.h
+++ b/src/client/QXmppMixManager.h
@@ -98,7 +98,7 @@ public:
     QXmppTask<JoiningResult> joinChannel(const QXmppMixInvitation &invitation, const QString &nickname = {}, QXmppMixConfigItem::Nodes nodes = ~QXmppMixConfigItem::Nodes());
 
     QXmppTask<NicknameResult> updateNickname(const QString &channelJid, const QString &nickname);
-    QXmppTask<SubscriptionResult> updateSubscriptions(const QString &channelJid, QXmppMixConfigItem::Nodes subscriptionAdditions = ~QXmppMixConfigItem::Nodes(), QXmppMixConfigItem::Nodes subscriptionRemovals = ~QXmppMixConfigItem::Nodes());
+    QXmppTask<SubscriptionResult> updateSubscriptions(const QString &channelJid, QXmppMixConfigItem::Nodes subscriptionAdditions = ~QXmppMixConfigItem::Nodes(), QXmppMixConfigItem::Nodes subscriptionRemovals = {});
 
     QXmppTask<InvitationResult> requestInvitation(const QString &channelJid, const QString &inviteeJid);
 


### PR DESCRIPTION
If no nodes were specified to be unsubscribed from for updateSubscriptions(), all enums were added to be unsubscribed from. That resulted in the same nodes being specified to be subcribed to and to be unsubscribed from.

PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
