### PR TITLE
Qt 6: Fix crash when sending encrypted files

### DIFF
--- a/src/client/QXmppFileEncryption.cpp
+++ b/src/client/QXmppFileEncryption.cpp
@@ -152,7 +152,6 @@ EncryptionDevice::EncryptionDevice(std::unique_ptr<QIODevice> input,
     setOpenMode(m_input->openMode() & QIODevice::ReadOnly);
 
     Q_ASSERT(m_cipher->validKeyLength(int(key.length())));
-    Q_ASSERT(m_cipher->ok());
 }
 
 EncryptionDevice::~EncryptionDevice() = default;
@@ -268,7 +267,6 @@ DecryptionDevice::DecryptionDevice(std::unique_ptr<QIODevice> input,
     setOpenMode(m_output->openMode() & QIODevice::WriteOnly);
 
     Q_ASSERT(m_cipher->validKeyLength(int(key.length())));
-    Q_ASSERT(m_cipher->ok());
 }
 
 DecryptionDevice::~DecryptionDevice() = default;


### PR DESCRIPTION
m_cipher->ok() is to be called only after an explicit `update()` or `final()` call.
This changes fix the crash when attempting to upload encrypted files.

PR check list:
- [ ] Document your code
- [ ] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [ ] Update `doc/doap.xml`
- [ ] Add unit tests
- [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
