### PR TITLE
Fix QXmppMixManager not finishing task when nothing to export

### DIFF
--- a/src/client/QXmppMixManager.cpp
+++ b/src/client/QXmppMixManager.cpp
@@ -1126,6 +1126,10 @@ void QXmppMixManager::onRegistered(QXmppClient *client)
 
                 result->items.reserve(*counter);
 
+                if (iqItems.empty()) {
+                    return promise.finish(*result.get());
+                }
+
                 for (const auto &item : std::as_const(iqItems)) {
                     requestParticipants(item.bareJid()).then(this, [manager, result, promise, counter, channelId = item.bareJid(), participantId = item.mixParticipantId()](auto &&participantsResult) mutable {
                         if (promise.task().isFinished()) {


### PR DESCRIPTION
PR check list:
- [ ] Document your code
- [ ] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [ ] Update `doc/doap.xml`
- [ ] Add unit tests
- [ ] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
