### PR TITLE
Fix Qt 6.9 deprecations

### DIFF
--- a/src/base/QXmppDataFormBase.h
+++ b/src/base/QXmppDataFormBase.h
@@ -43,7 +43,11 @@ protected:
 
     std::optional<bool> parseBool(const QVariant &variant)
     {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        if (variant.typeId() == QMetaType::Type::Bool) {
+#else
         if (variant.type() == QVariant::Bool) {
+#endif
             return variant.toBool();
         }
         return std::nullopt;

--- a/src/base/QXmppFutureUtils_p.h
+++ b/src/base/QXmppFutureUtils_p.h
@@ -65,7 +65,10 @@ struct first_argument {
 template<typename F>
 using first_argument_t = typename first_argument<F>::type;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+template<typename T>
+QFuture<T> makeReadyFuture(T &&value) { return QtFuture::makeReadyValueFuture(std::move(value)); }
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
 using QtFuture::makeReadyFuture;
 #else
 template<typename T>

--- a/src/base/QXmppMessage.cpp
+++ b/src/base/QXmppMessage.cpp
@@ -33,6 +33,7 @@
 #include <QDateTime>
 #include <QDomElement>
 #include <QTextStream>
+#include <QTimeZone>
 #include <QXmlStreamWriter>
 
 using namespace QXmpp;
@@ -1722,7 +1723,11 @@ bool QXmppMessage::parseExtension(const QDomElement &element, QXmpp::SceMode sce
                     d->stamp = QDateTime::fromString(
                         element.attribute(u"stamp"_s),
                         u"yyyyMMddThh:mm:ss"_s);
-                    d->stamp.setTimeSpec(Qt::UTC);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+                    d->stamp.setTimeZone(QTimeZone::Initialization::UTC);
+#else
+                    d->stamp.setTimeZone(QTimeZone(0));
+#endif
                     d->stampType = LegacyDelayedDelivery;
                 }
                 return true;

--- a/src/base/QXmppPubSubEvent.h
+++ b/src/base/QXmppPubSubEvent.h
@@ -139,7 +139,7 @@ void QXmppPubSubEvent<T>::parseItems(const QDomElement &parent)
 template<typename T>
 void QXmppPubSubEvent<T>::serializeItems(QXmlStreamWriter *writer) const
 {
-    for (const auto &item : qAsConst(m_items)) {
+    for (const auto &item : std::as_const(m_items)) {
         item.toXml(writer);
     }
 }

--- a/src/base/QXmppPubSubNodeConfig.cpp
+++ b/src/base/QXmppPubSubNodeConfig.cpp
@@ -678,7 +678,11 @@ bool QXmppPubSubNodeConfig::parseField(const QXmppDataForm::Field &field)
         bool ok = false;
         if (const auto maxItems = value.toULongLong(&ok); ok) {
             d->maxItems = maxItems;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        } else if (value.typeId() == QMetaType::Type::QString && value.toString() == u"max") {
+#else
         } else if (value.type() == QVariant::String && value.toString() == u"max") {
+#endif
             d->maxItems = Max();
         } else {
             d->maxItems = Unset();

--- a/src/base/QXmppRpcIq.cpp
+++ b/src/base/QXmppRpcIq.cpp
@@ -22,30 +22,63 @@ using namespace QXmpp::Private;
 void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &value)
 {
     writer->writeStartElement(QSL65("value"));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    switch (value.typeId()) {
+    case QMetaType::Type::Int:
+    case QMetaType::Type::UInt:
+    case QMetaType::Type::LongLong:
+    case QMetaType::Type::ULongLong:
+#else
     switch (value.type()) {
     case QVariant::Int:
     case QVariant::UInt:
     case QVariant::LongLong:
     case QVariant::ULongLong:
+#endif
         writer->writeTextElement(QSL65("i4"), value.toString());
         break;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::Double:
+#else
     case QVariant::Double:
+#endif
         writer->writeTextElement(QSL65("double"), value.toString());
         break;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::Bool:
+#else
     case QVariant::Bool:
+#endif
         writer->writeTextElement(QSL65("boolean"), value.toBool() ? u"1"_s : u"0"_s);
         break;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::QDate:
+#else
     case QVariant::Date:
+#endif
         writer->writeTextElement(QSL65("dateTime.iso8601"), value.toDate().toString(Qt::ISODate));
         break;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::QDateTime:
+#else
     case QVariant::DateTime:
+#endif
         writer->writeTextElement(QSL65("dateTime.iso8601"), value.toDateTime().toString(Qt::ISODate));
         break;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::QTime:
+#else
     case QVariant::Time:
+#endif
         writer->writeTextElement(QSL65("dateTime.iso8601"), value.toTime().toString(Qt::ISODate));
         break;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::QStringList:
+    case QMetaType::Type::QVariantList: {
+#else
     case QVariant::StringList:
     case QVariant::List: {
+#endif
         writer->writeStartElement(QSL65("array"));
         writer->writeStartElement(QSL65("data"));
         const auto list = value.toList();
@@ -56,7 +89,11 @@ void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &valu
         writer->writeEndElement();
         break;
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::QVariantMap: {
+#else
     case QVariant::Map: {
+#endif
         writer->writeStartElement(QSL65("struct"));
         const QMap<QString, QVariant> map = value.toMap();
         QMap<QString, QVariant>::ConstIterator index = map.begin();
@@ -70,7 +107,11 @@ void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &valu
         writer->writeEndElement();
         break;
     }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    case QMetaType::Type::QByteArray: {
+#else
     case QVariant::ByteArray: {
+#endif
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
         writer->writeTextElement("base64", value.toByteArray().toBase64());
 #else
@@ -81,7 +122,11 @@ void QXmppRpcMarshaller::marshall(QXmlStreamWriter *writer, const QVariant &valu
     default: {
         if (value.isNull()) {
             writer->writeEmptyElement(u"nil"_s);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        } else if (value.canConvert(QMetaType(QMetaType::Type::QString))) {
+#else
         } else if (value.canConvert(QVariant::String)) {
+#endif
             writer->writeTextElement(QSL65("string"), value.toString());
         }
         break;

--- a/src/client/QXmppEntityTimeManager.cpp
+++ b/src/client/QXmppEntityTimeManager.cpp
@@ -15,6 +15,7 @@
 
 #include <QDateTime>
 #include <QDomElement>
+#include <QTimeZone>
 
 using namespace QXmpp::Private;
 
@@ -100,7 +101,11 @@ std::variant<QXmppEntityTimeIq, QXmppStanza::Error> QXmppEntityTimeManager::hand
     QDateTime utc = currentTime.toUTC();
     responseIq.setUtc(utc);
 
-    currentTime.setTimeSpec(Qt::UTC);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    currentTime.setTimeZone(QTimeZone::Initialization::UTC);
+#else
+    currentTime.setTimeZone(QTimeZone(0));
+#endif
     responseIq.setTzo(utc.secsTo(currentTime));
     return responseIq;
 }

--- a/tests/qxmpppresence/tst_qxmpppresence.cpp
+++ b/tests/qxmpppresence/tst_qxmpppresence.cpp
@@ -304,10 +304,10 @@ void tst_QXmppPresence::testPresenceWithLastUserInteraction()
     parsePacket(presence, xml);
     QVERIFY(!presence.lastUserInteraction().isNull());
     QVERIFY(presence.lastUserInteraction().isValid());
-    QCOMPARE(presence.lastUserInteraction(), QDateTime(QDate(1969, 7, 21), QTime(2, 56, 15), Qt::UTC));
+    QCOMPARE(presence.lastUserInteraction(), QDateTime(QDate(1969, 7, 21), QTime(2, 56, 15), TimeZoneUTC));
     serializePacket(presence, xml);
 
-    QDateTime another(QDate(2025, 2, 5), QTime(15, 32, 8), Qt::UTC);
+    QDateTime another(QDate(2025, 2, 5), QTime(15, 32, 8), TimeZoneUTC);
     presence.setLastUserInteraction(another);
     QCOMPARE(presence.lastUserInteraction(), another);
 }

--- a/tests/qxmpppubsubevent/tst_qxmpppubsubevent.cpp
+++ b/tests/qxmpppubsubevent/tst_qxmpppubsubevent.cpp
@@ -180,7 +180,7 @@ void tst_QXmppPubSubEvent::testBasic_data()
                                 "ba49252aaa4f5d320c24d3766f0bdcade78c78d3",
                                 QXmppPubSubSubscription::Subscribed,
                                 QXmppPubSubSubscription::Unavailable,
-                                QDateTime({ 2006, 02, 28 }, { 23, 59, 59 }, Qt::UTC)),
+                                QDateTime({ 2006, 02, 28 }, { 23, 59, 59 }, TimeZoneUTC)),
         QVector<QXmppPubSubBaseItem>(),
         std::nullopt);
 

--- a/tests/qxmppsceenvelope/tst_qxmppsceenvelope.cpp
+++ b/tests/qxmppsceenvelope/tst_qxmppsceenvelope.cpp
@@ -31,7 +31,7 @@ void tst_QXmppSceEnvelope::testReader()
     QXmppSceEnvelopeReader reader(xmlToDom(xml));
     QCOMPARE(reader.from(), u"opportunity@mars.planet"_s);
     QCOMPARE(reader.to(), u"missioncontrol@houston.nasa.gov"_s);
-    QCOMPARE(reader.timestamp(), QDateTime({ 2004, 01, 25 }, { 05, 05, 00 }, Qt::UTC));
+    QCOMPARE(reader.timestamp(), QDateTime({ 2004, 01, 25 }, { 05, 05, 00 }, TimeZoneUTC));
     QCOMPARE(reader.contentElement().firstChildElement().tagName(), u"body"_s);
 }
 
@@ -60,7 +60,7 @@ void tst_QXmppSceEnvelope::testWriter()
         writer.writeTextElement("url", "https://en.wikipedia.org/wiki/Fight_Club#Plot");
         writer.writeEndElement();
     });
-    envelope.writeTimestamp(QDateTime({ 2004, 01, 25 }, { 05, 05, 00 }, Qt::UTC));
+    envelope.writeTimestamp(QDateTime({ 2004, 01, 25 }, { 05, 05, 00 }, TimeZoneUTC));
     envelope.writeTo("missioncontrol@houston.nasa.gov");
     envelope.writeFrom("opportunity@mars.planet");
     envelope.writeRpad("C1DHN9HK-9A25tSmwK4hU!Jji9%GKYK^syIlHJT9TnI4");

--- a/tests/qxmppstanza/tst_qxmppstanza.cpp
+++ b/tests/qxmppstanza/tst_qxmppstanza.cpp
@@ -379,7 +379,7 @@ void tst_QXmppStanza::testErrorRetry()
     QCOMPARE(error.text(), QStringLiteral("Quota reached. You can only upload 5 "
                                           "files in 5 minutes"));
     QCOMPARE(error.condition(), QXmppStanza::Error::ResourceConstraint);
-    QCOMPARE(error.retryDate(), QDateTime(QDate(2017, 12, 03), QTime(23, 42, 05), Qt::UTC));
+    QCOMPARE(error.retryDate(), QDateTime(QDate(2017, 12, 03), QTime(23, 42, 05), TimeZoneUTC));
     serializePacket(error, xml);
 
     // test setter

--- a/tests/util.h
+++ b/tests/util.h
@@ -31,6 +31,12 @@ struct QXmppError;
     if (!QTest::qVerify(bool(statement), #statement, static_cast<const char *>(description), __FILE__, __LINE__)) \
         throw std::runtime_error(description);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+constexpr auto TimeZoneUTC = QTimeZone::Initialization::UTC;
+#else
+constexpr auto TimeZoneUTC = Qt::UTC;
+#endif
+
 template<typename String>
 inline QDomDocument xmlToDomDoc(const String &xml, bool namespaceProcessing)
 {


### PR DESCRIPTION

- **Fix deprecations: Use QMetaType::Type instead of QVariant::Type**
- **Fix deprecations: Use std::as_const instead of qAsConst**
- **Fix deprecations: Use QTimeZone instead of Qt::TimeZone**
