### PR TITLE
Fix deprecated QDomDocument::setContent, QMetaType

### DIFF
--- a/src/base/QXmppElement.cpp
+++ b/src/base/QXmppElement.cpp
@@ -147,7 +147,11 @@ QDomElement QXmppElement::sourceDomElement() const
     }
 
     QDomDocument doc;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    if (!doc.setContent(d->serializedSource, QDomDocument::ParseOption::UseNamespaceProcessing)) {
+#else
     if (!doc.setContent(d->serializedSource, true)) {
+#endif
         qWarning("[QXmpp] QXmppElement::sourceDomElement(): cannot parse source element");
         return QDomElement();
     }

--- a/src/base/Stream.cpp
+++ b/src/base/Stream.cpp
@@ -297,7 +297,11 @@ void XmppSocket::processData(const QString &data)
     // Try to parse the wrapped XML
     //
     QDomDocument doc;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    if (!doc.setContent(wrappedStanzas, QDomDocument::ParseOption::UseNamespaceProcessing)) {
+#else
     if (!doc.setContent(wrappedStanzas, true)) {
+#endif
         return;
     }
 

--- a/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
+++ b/tests/qxmppstreamfeatures/tst_qxmppstreamfeatures.cpp
@@ -17,12 +17,19 @@ static void parsePacketWithStream(T &packet, const QByteArray &xml)
         QByteArrayLiteral("<stream:stream xmlns:stream='http://etherx.jabber.org/streams'>") +
         xml + QByteArrayLiteral("</stream:stream>");
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    if (auto result = doc.setContent(wrappedXml, QDomDocument::ParseOption::UseNamespaceProcessing); !result) {
+        qDebug() << result.errorMessage;
+        QFAIL("Could not parse XML.");
+    }
+#else
     QString err;
     bool parsingSuccess = doc.setContent(wrappedXml, true, &err);
     if (!err.isNull()) {
         qDebug() << err;
     }
     QVERIFY(parsingSuccess);
+#endif
 
     packet.parse(doc.documentElement().firstChildElement());
 }


### PR DESCRIPTION

- **Fix deprecations: QDomDocument::setContent(): Use new ParseOptions**
- **Fix deprecations: QMetaType::create/destroy()**
