### PR TITLE
RosterManager: Fix notifying on subscription request with valid old JID

### DIFF
--- a/src/client/QXmppMovedManager.cpp
+++ b/src/client/QXmppMovedManager.cpp
@@ -253,41 +253,38 @@ void QXmppMovedManager::onUnregistered(QXmppClient *client)
 /// \endcond
 
 ///
-/// Checks for moved elements in incoming subscription requests and verifies them.
+/// Verifies an old JID in a received presence subscription request and removes it if it is invalid.
 ///
 /// This requires the QXmppRosterManager to be registered with the client.
 ///
-/// \returns a task for the verification result if the subscription request contains a moved
-/// element with an 'old-jid' that is already in the account's roster.
+/// \param presence presence subscription request to be processed containing a non-empty old JID.
 ///
-std::optional<QXmppTask<bool>> QXmppMovedManager::handleSubscriptionRequest(const QXmppPresence &presence)
+/// \returns the processed presence subscription request
+///
+QXmppTask<QXmppPresence> QXmppMovedManager::processSubscriptionRequest(QXmppPresence presence)
 {
-    // check for moved element
-    if (presence.oldJid().isEmpty()) {
-        return {};
-    }
+    Q_ASSERT(!presence.oldJid().isEmpty());
 
-    // find roster manager
     auto *rosterManager = client()->findExtension<QXmppRosterManager>();
     Q_ASSERT(rosterManager);
 
-    // check subscription state of old-jid
     const auto entry = rosterManager->getRosterEntry(presence.oldJid());
 
     switch (entry.subscriptionType()) {
     case QXmppRosterIq::Item::From:
     case QXmppRosterIq::Item::Both:
-        break;
-    default:
-        // The subscription state of the old JID needs to be either from or both, else ignore
-        // the moved element
-        return {};
-    }
+        return chain<QXmppPresence>(verifyStatement(presence.oldJid(), QXmppUtils::jidToBareJid(presence.from())), this, [this, presence = presence](Result &&result) mutable {
+            if (std::holds_alternative<QXmppError>(result)) {
+                warning(presence.from() + u" sent a presence subscription request with the invalid old JID "_s + presence.oldJid());
+                presence.setOldJid({});
+            }
 
-    // return verification result
-    return chain<bool>(verifyStatement(presence.oldJid(), QXmppUtils::jidToBareJid(presence.from())), this, [this](Result &&result) mutable {
-        return std::holds_alternative<Success>(result);
-    });
+            return presence;
+        });
+    default:
+        presence.setOldJid({});
+        return makeReadyTask(std::move(presence));
+    }
 }
 
 ///

--- a/src/client/QXmppMovedManager.h
+++ b/src/client/QXmppMovedManager.h
@@ -41,7 +41,7 @@ protected:
     /// \endcond
 
 private:
-    std::optional<QXmppTask<bool>> handleSubscriptionRequest(const QXmppPresence &presence);
+    QXmppTask<QXmppPresence> processSubscriptionRequest(QXmppPresence presence);
     void handleDiscoInfo(const QXmppDiscoveryIq &iq);
     Result movedJidsMatch(const QString &newBareJid, const QString &pepBareJid) const;
 

--- a/src/client/QXmppRosterManager.cpp
+++ b/src/client/QXmppRosterManager.cpp
@@ -293,7 +293,10 @@ void QXmppRosterManager::handleSubscriptionRequest(const QString &bareJid, const
             notifyOnSubscriptionRequest(presence);
         });
     } else {
-        notifyOnSubscriptionRequest(presence);
+        auto safePresence = presence;
+        safePresence.setOldJid({});
+
+        notifyOnSubscriptionRequest(safePresence);
     }
 }
 

--- a/src/client/QXmppRosterManager.cpp
+++ b/src/client/QXmppRosterManager.cpp
@@ -74,11 +74,16 @@ static void serializeRosterData(const RosterData &d, QXmlStreamWriter &writer)
 /// The user can either accept the request by calling acceptSubscription() or refuse it
 /// by calling refuseSubscription().
 ///
+/// Since *QXmpp 1.10.2* only verified \xep{0283, Moved} old JIDs are passed in \a presence. If
+/// verification fails or the given old JID is not valid, the attribute is cleared in the
+/// QXmppPresence. See \ref rostermanager_moved "above" for more details.
+///
 /// \note If QXmppConfiguration::autoAcceptSubscriptions() is set to true or the subscription
 /// request is automatically accepted by the QXmppMovedManager, this signal will not be emitted.
 ///
 /// \param subscriberBareJid bare JID that wants to subscribe to the user's presence
-/// \param presence presence stanza containing the reason / message (presence.statusText())
+/// \param presence presence stanza, e.g. containing the message (presence.statusText()),
+/// \xep{0283, Moved} old JID or other information
 ///
 /// \since QXmpp 1.5
 ///

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -51,6 +51,33 @@ class QXmppRosterManagerPrivate;
 /// The \c presenceChanged() signal is emitted whenever the presence for a
 /// roster item changes.
 ///
+/// \anchor rostermanager_moved
+/// ## XEP-0283: Moved
+///
+/// \xep{0283, Moved} provides a way to inform other users that an account has moved. This allows a
+/// presence subscription request from a new account to be automatically linked to the old account.
+/// However, this requires verification via a corresponding PubSub node on the old account.
+///
+/// The roster manager automatically checks entries using the QXmppMovedManager. For this to work,
+/// the moved manager must be added to the QXmppClient. If the moved manager is not found or the
+/// specified old JID is incorrect, the entry in the presence subscription request will be removed.
+///
+/// The received and verified presence subscription request is emitted via
+/// subscriptionRequestReceived() and the old JID can be found in QXmppPresence::oldJid().
+/// It is safe to assume that this old JID is valid since QXmpp 1.10.2.
+///
+/// Accepting moved subscription requests automatically is discouraged in
+/// [section 4.3](https://xmpp.org/extensions/xep-0283.html#receive-notification-client) of the
+/// XEP.
+///
+/// ### Behaviour in previous versions
+///
+/// Support in the roster manager and in QXmppPresence was initially added in 1.9.0.
+///
+/// In QXmpp 1.9.0 until 1.9.4 and 1.10.0 until 1.10.1 subscription requests with a Moved element
+/// are verified and automatically accepted without emitting subscriptionRequestReceived(). If
+/// verification fails, the **invalid** old JID is passed in subscriptionRequestReceived()!
+///
 /// \ingroup Managers
 ///
 class QXMPP_EXPORT QXmppRosterManager : public QXmppClientExtension

--- a/src/client/QXmppRosterManager.h
+++ b/src/client/QXmppRosterManager.h
@@ -144,7 +144,7 @@ private Q_SLOTS:
 private:
     using RosterResult = std::variant<QXmppRosterIq, QXmppError>;
 
-    void handleSubscriptionRequest(const QString &bareJid, const QXmppPresence &presence, bool accept);
+    void handleSubscriptionRequest(const QString &bareJid, const QXmppPresence &presence);
     QXmppTask<RosterResult> requestRoster();
 
     const std::unique_ptr<QXmppRosterManagerPrivate> d;

--- a/tests/qxmpprostermanager/tst_qxmpprostermanager.cpp
+++ b/tests/qxmpprostermanager/tst_qxmpprostermanager.cpp
@@ -121,9 +121,14 @@ void tst_QXmppRosterManager::testMovedSubscriptionRequestReceived_data()
     QTest::addColumn<QString>("oldJidResponse");
     QTest::addColumn<bool>("valid");
 
-    QTest::newRow("noMovedManager")
+    QTest::newRow("noMovedManagerNoJid")
         << false
         << QString()
+        << QString()
+        << false;
+    QTest::newRow("noMovedManagerJid")
+        << false
+        << u"old@example.org"_s
         << QString()
         << false;
     QTest::newRow("oldJidEmpty")
@@ -164,7 +169,7 @@ void tst_QXmppRosterManager::testMovedSubscriptionRequestReceived_data()
 
 void tst_QXmppRosterManager::testMovedSubscriptionRequestReceived()
 {
-    TestClient client(true);
+    TestClient client;
     client.configuration().setJid(u"alice@example.org"_s);
     auto *rosterManager = client.addNewExtension<QXmppRosterManager>(&client);
 
@@ -196,10 +201,10 @@ void tst_QXmppRosterManager::testMovedSubscriptionRequestReceived()
     bool subscriptionRequestReceived = false;
     client.resetIdCount();
 
-    connect(rosterManager, &QXmppRosterManager::subscriptionRequestReceived, this, [&subscriptionRequestReceived, &oldJid, &valid](const QString &subscriberBareJid, const QXmppPresence &presence) {
+    connect(rosterManager, &QXmppRosterManager::subscriptionRequestReceived, this, [&](const QString &subscriberBareJid, const QXmppPresence &presence) {
         subscriptionRequestReceived = true;
         QCOMPARE(subscriberBareJid, u"new@example.org"_s);
-        if (valid) {
+        if (valid && movedManagerAdded) {
             QCOMPARE(oldJid, presence.oldJid());
         } else {
             QVERIFY(presence.oldJid().isEmpty());


### PR DESCRIPTION
PR check list:
- [x] Document your code
- [x] Add `\since QXmpp 1.X`, `QXMPP_EXPORT`
- [x] Update `doc/doap.xml`
- [x] Add unit tests
- [x] Format the code: Run `clang-format -i src/<edited-file(s)> tests/<edited-file(s)>`

<!--
Points should be checked when they're done. They should also be checked when no
changes were required.
-->
